### PR TITLE
Various testing speedups and tweaks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
           - bash: |
               set -xeo pipefail
               python -m pip install --progress-bar off --upgrade pip
-              python -m pip install --progress-bar off --upgrade --only-binary=":all:" -e . --group=test "mne-qt-browser @ https://github.com/mne-tools/mne-qt-browser/archive/refs/heads/main.zip" pyvista scikit-learn python-picard qtpy nibabel sphinx-gallery "PySide6!=6.8.0,!=6.8.0.1,!=6.8.1.1,!=6.9.1" pandas neo pymatreader antio defusedxml curryreader pymef
+              python -m pip install --progress-bar off --upgrade --only-binary=":all:" -e . --group=test "mne-qt-browser @ https://github.com/mne-tools/mne-qt-browser/archive/refs/heads/main.zip" pyvista scikit-learn python-picard qtpy nibabel sphinx-gallery "PySide6!=6.8.0,!=6.8.0.1,!=6.8.1.1,!=6.9.1" pandas neo pymatreader antio defusedxml curryreader pymef openmeeg
             displayName: Install dependencies with pip
           - bash: ./tools/check_qt_import.sh PySide6
             displayName: Check Qt import

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -373,27 +373,38 @@ def azure_windows():
     )
 
 
-@pytest.fixture(scope="function")
-def raw_orig():
-    """Get raw data without any change to it from mne.io.tests.data."""
-    raw = read_raw_fif(fname_raw_io, preload=True)
-    return raw
+# Read the raw file only once per session; the ``raw_orig``/``raw`` fixtures hand
+# out independent ``.copy()``s (much faster than re-reading, esp. after picking).
+@pytest.fixture(scope="session")
+def _raw_orig_session():
+    return read_raw_fif(fname_raw_io, preload=True)
 
 
-@pytest.fixture(scope="function")
-def raw():
-    """
-    Get raw data and pick channels to reduce load for testing.
-
-    (from mne.io.tests.data)
-    """
-    raw = read_raw_fif(fname_raw_io, preload=True)
+@pytest.fixture(scope="session")
+def _raw_session(_raw_orig_session):
+    raw = _raw_orig_session.copy()
     # Throws a warning about a changed unit.
     with pytest.warns(RuntimeWarning, match="unit"):
         raw.set_channel_types({raw.ch_names[0]: "ias"})
     raw.pick(raw.ch_names[:9])
     raw.info.normalize_proj()  # Fix projectors after subselection
     return raw
+
+
+@pytest.fixture(scope="function")
+def raw_orig(_raw_orig_session):
+    """Get raw data without any change to it from mne.io.tests.data."""
+    return _raw_orig_session.copy()
+
+
+@pytest.fixture(scope="function")
+def raw(_raw_session):
+    """
+    Get raw data and pick channels to reduce load for testing.
+
+    (from mne.io.tests.data)
+    """
+    return _raw_session.copy()
 
 
 @pytest.fixture(scope="function")
@@ -679,6 +690,14 @@ def pg_backend(request, garbage_collect):
 
     with use_browser_backend("qt") as backend:
         backend._close_all()
+        # Snapshot rather than assert_no_instances: when a test fails, pytest
+        # keeps its traceback (for reporting), which keeps that test's frame
+        # and hence its browser alive. Requiring *zero* browsers would then
+        # blame the next test that uses this fixture for a browser it never
+        # created, turning one real failure into a cascade of errors. Only
+        # report browsers this test itself leaked. Snapshot stores only ids,
+        # so it pins nothing alive.
+        snap = Snapshot(MNEQtBrowser, collect=False)
         yield backend
         backend._close_all()
         # This shouldn't be necessary, but let's make sure nothing is stale
@@ -687,9 +706,7 @@ def pg_backend(request, garbage_collect):
         mne_qt_browser._browser_instances.clear()
         if not _test_passed(request):
             return
-        assert_no_instances(
-            MNEQtBrowser, f"Closure of {request.node.name}", request=request
-        )
+        snap.assert_no_new(f"Closure of {request.node.name}", request=request)
 
 
 @pytest.fixture(
@@ -752,16 +769,28 @@ def renderer_interactive(request, options_3d):
 
 @contextmanager
 def _use_backend(backend_name, interactive):
+    import matplotlib
+
     from mne.viz.backends.renderer import _use_test_3d_backend
 
+    # Capture the matplotlib backend up front: for the notebook backend,
+    # _check_skip_backend() imports ipympl, which switches matplotlib to
+    # module://ipympl.backend_nbagg (and does not switch it back). Under that
+    # backend pyplot mis-tracks figures in Gcf, so every later matplotlib
+    # figure-count test (in other modules) fails. Restore it on teardown.
+    mpl_backend = matplotlib.get_backend()
     _check_skip_backend(backend_name)
-    with _use_test_3d_backend(backend_name, interactive=interactive):
-        from mne.viz.backends import renderer
+    try:
+        with _use_test_3d_backend(backend_name, interactive=interactive):
+            from mne.viz.backends import renderer
 
-        try:
-            yield renderer
-        finally:
-            renderer.backend._close_all()
+            try:
+                yield renderer
+            finally:
+                renderer.backend._close_all()
+    finally:
+        if matplotlib.get_backend() != mpl_backend:
+            matplotlib.use(mpl_backend, force=True)
 
 
 def _check_skip_backend(name):
@@ -1079,7 +1108,13 @@ def brain_gc(request):
 
     # Snapshot stores only ids (pins nothing alive) so VTK objects that
     # pre-date the test (e.g. held by module-level state) are never reported.
-    snap = Snapshot(_is_vtk, label="VTK")
+    # collect=False: a gc.collect() here would cost as much as the one that
+    # actually matters at teardown, and we only care about objects going *up*
+    # (new ones surviving), not down. Skipping it just means some snapshotted
+    # objects are already garbage and vanish by teardown, which is fine; the
+    # only cost is a slightly wider id-reuse window (a missed leak at worst,
+    # never a false report).
+    snap = Snapshot(_is_vtk, label="VTK", collect=False)
     yield
     close_func()
     # pyvistaqt >= 0.11.3 schedules the plotter's window for deferred deletion

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -264,6 +264,7 @@ def test_receptive_field_basic(n_jobs):
         ReceptiveField(tmin, tmax, 1.0, scoring="foo").fit(X, y)
 
 
+@pytest.mark.slowtest  # slow on Azure
 @pytest.mark.parametrize("n_jobs", n_jobs_test)
 def test_time_delaying_fast_calc(n_jobs):
     """Test time delaying and fast calculations."""

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -307,7 +307,7 @@ def test_make_forward_solution_bti(fname_src_small):
         pytest.param("MNE-C", marks=requires_mne_mark()),
         pytest.param(
             "openmeeg",
-            marks=[requires_openmeeg_mark(), pytest.mark.slowtest],
+            marks=[requires_openmeeg_mark(), pytest.mark.ultraslowtest],
         ),
     ],
 )
@@ -443,7 +443,7 @@ def test_make_forward_solution_basic():
         make_forward_solution(fname_raw, fname_trans, fname_src, fname_bem_meg)
 
 
-@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @requires_openmeeg_mark()
 @pytest.mark.parametrize(
     "n_layers",

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -152,7 +152,7 @@ def test_gamma_map_standard():
     _check_stc(stc, evoked, 85739, "lh", fwd=forward, ratio=20.0, res=res)
 
 
-@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @testing.requires_testing_data
 def test_gamma_map_vol_sphere():
     """Gamma MAP with a sphere forward and volumic source space."""

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -48,7 +48,7 @@ def forward():
 
 @testing.requires_testing_data
 @pytest.mark.timeout(150)  # ~30 s on Travis Linux
-@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 def test_mxne_inverse_standard(forward):
     """Test (TF-)MxNE inverse computation."""
     # Read noise covariance matrix

--- a/mne/preprocessing/tests/test_annotate_nan.py
+++ b/mne/preprocessing/tests/test_annotate_nan.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 import mne
 from mne.preprocessing import annotate_nan
@@ -18,9 +18,7 @@ raw_fname = Path(__file__).parents[2] / "io" / "tests" / "data" / "test_raw.fif"
 def test_annotate_nan(meas_date):
     """Tests automatic NaN annotation generation."""
     # Load data
-    raw = mne.io.read_raw_fif(raw_fname)
-    sfreq = 100
-    raw.resample(sfreq)
+    raw = mne.io.read_raw_fif(raw_fname).crop(0, 5).load_data()
     if meas_date is None:
         raw.set_meas_date(None)
 
@@ -34,15 +32,16 @@ def test_annotate_nan(meas_date):
 
     # insert block of NaN from 1s to 3s for one channel
     nan_ch_idx = 0
-    raw._data[nan_ch_idx, 1 * sfreq : 3 * sfreq] = np.nan
+    one_s = int(round(raw.info["sfreq"]))
+    raw._data[nan_ch_idx, one_s : 3 * one_s] = np.nan
 
     # annotate_nan accurately finds this
     annot_nan = annotate_nan(raw)
     onset = np.array([1.0])
     if raw.info["meas_date"]:
         onset += raw.first_time
-    assert_array_equal(annot_nan.onset, onset)
-    assert_array_equal(annot_nan.duration, np.array([2]))
+    assert_allclose(annot_nan.onset, onset, rtol=1e-3)
+    assert_allclose(annot_nan.duration, np.array([2]), rtol=1e-3)
     assert_array_equal(annot_nan.description, np.array(["BAD_NAN"]))
     assert len(annot_nan.ch_names) == 1
     assert annot_nan.ch_names[0] == (raw.ch_names[nan_ch_idx],)

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -240,7 +240,7 @@ def test_compute_fine_cal(kind):
         pytest.param("kit", marks=[pytest.mark.ultraslowtest]),  # ~6s
         pytest.param("ctf", marks=[td_mark, pytest.mark.ultraslowtest]),  # ~13s
         pytest.param("fil", marks=[td_mark]),  # ~3s
-        pytest.param("triux", marks=[td_mark, pytest.mark.slowtest]),  # ~7s
+        pytest.param("triux", marks=[td_mark, pytest.mark.ultraslowtest]),  # ~7s
     ],
 )
 def test_fine_cal_systems(system, tmp_path):

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -4,7 +4,7 @@
 
 import re
 from contextlib import contextmanager
-from functools import partial
+from functools import cache, partial
 from pathlib import Path
 
 import numpy as np
@@ -186,9 +186,19 @@ def _assert_mag_coil_type(info, coil_type):
     assert coil_types == {coil_type}
 
 
+@cache
+def _read_raw_maxshield(fname, _mtime, _size):
+    # Cache the (unloaded) raw so files read many times (e.g. raw_fname, ~14x)
+    # are parsed only once. Keyed on (path, mtime, size) so a rewritten temp file
+    # is not served stale. read_crop() returns an independent copy of this.
+    return read_raw_fif(fname, allow_maxshield="yes")
+
+
 def read_crop(fname, lims=(0, None)):
-    """Read and crop."""
-    return read_raw_fif(fname, allow_maxshield="yes").crop(*lims)
+    """Read (cached) and crop a copy."""
+    st = Path(fname).stat()
+    raw = _read_raw_maxshield(str(fname), st.st_mtime, st.st_size)
+    return raw.copy().crop(*lims)
 
 
 # For backward compat and to be most like MaxFilter, we make "maxwell_filter"

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -451,6 +451,7 @@ def test_warn_maxwell_filtered():
     assert len(amps["times"]) > 0  # but for this file, it does work!
 
 
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_initial_fit_redo():
     """Test that initial fits can be redone based on moments."""
@@ -675,7 +676,7 @@ def _check_dists(info, cHPI_digs, n_bad=0, bad_low=0.02, bad_high=0.04):
         assert_array_less(bads, bad_high)
 
 
-@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @testing.requires_testing_data
 def test_calculate_chpi_coil_locs_artemis():
     """Test computing just cHPI locations."""

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -29,7 +29,6 @@ from ..fixes import (
 )
 from ._logging import logger, verbose, warn
 from .check import (
-    _check_pandas_installed,
     _ensure_int,
     _validate_type,
     check_random_state,
@@ -777,7 +776,6 @@ def object_diff(a, b, pre="", *, allclose=False):
     diffs : str
         A string representation of the differences.
     """
-    pd = _check_pandas_installed(strict=False)
     out = ""
     if type(a) is not type(b):
         # Deal with NamedInt and NamedFloat
@@ -838,7 +836,11 @@ def object_diff(a, b, pre="", *, allclose=False):
             c.eliminate_zeros()
             if c.nnz > 0:
                 out += pre + (f" sparse matrix a and b differ on {c.nnz} elements")
-    elif pd and isinstance(a, pd.DataFrame):
+    elif (pd := sys.modules.get("pandas")) is not None and isinstance(a, pd.DataFrame):
+        # Detect a DataFrame via sys.modules rather than importing pandas: if
+        # ``a`` is a DataFrame then pandas is necessarily already imported. This
+        # avoids a (sometimes very slow) first-time ``import pandas`` on the hot
+        # object_diff path when no DataFrame is present.
         try:
             pd.testing.assert_frame_equal(a, b)
         except AssertionError:

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1790,10 +1790,8 @@ def _sensor_shape(coil):
     else:
         # 3D convex hull (will fail for 2D geometry). This depends on the full
         # (per-channel) integration geometry, so it is not cached.
-        try:
-            from scipy.spatial import QhullError
-        except ImportError:  # scipy < 1.8
-            from scipy.spatial.qhull import QhullError
+        from scipy.spatial import QhullError
+
         rrs = coil["rmag_orig"].copy()
         try:
             tris = _reorder_ccw(rrs, ConvexHull(rrs).simplices)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -10,7 +10,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
-from functools import partial
+from functools import cache, partial
 from itertools import cycle
 from pathlib import Path
 
@@ -1768,13 +1768,55 @@ def _make_tris_fan(n_vert):
 
 def _sensor_shape(coil):
     """Get the sensor shape vertices."""
-    try:
-        from scipy.spatial import QhullError
-    except ImportError:  # scipy < 1.8
-        from scipy.spatial.qhull import QhullError
     id_ = coil["type"] & 0xFFFF
-    add_z_coord = True  # almost all geometry is planar
-    extra_z = 0.0
+    # Offset for visibility (using heuristic for sanely named Neuromag coils).
+    # It depends on the channel name, so keep it out of the cached template.
+    if id_ in (
+        FIFF.FIFFV_COIL_NM_122,
+        FIFF.FIFFV_COIL_VV_PLANAR_W,
+        FIFF.FIFFV_COIL_VV_PLANAR_T1,
+        FIFF.FIFFV_COIL_VV_PLANAR_T2,
+    ):
+        extra_z = 0.001 * (1 + coil["chname"].endswith("2"))
+    else:
+        extra_z = 0.0
+    # The template geometry depends only on the coil id/size/base, so it is
+    # cached: a real system has only a handful of coil types but often hundreds
+    # of channels sharing them.
+    base = coil["base"] if id_ in (5004, 4005) else 0.0
+    out = _sensor_template(id_, float(coil["size"]), float(base))
+    if out is not None:
+        rrs, tris = out
+    else:
+        # 3D convex hull (will fail for 2D geometry). This depends on the full
+        # (per-channel) integration geometry, so it is not cached.
+        try:
+            from scipy.spatial import QhullError
+        except ImportError:  # scipy < 1.8
+            from scipy.spatial.qhull import QhullError
+        rrs = coil["rmag_orig"].copy()
+        try:
+            tris = _reorder_ccw(rrs, ConvexHull(rrs).simplices)
+        except QhullError:  # 2D geometry likely
+            logger.debug("Falling back to planar geometry")
+            u, _, _ = np.linalg.svd(rrs.T, full_matrices=False)
+            u[:, 2] = 0
+            rr_rot = rrs @ u
+            tris = Delaunay(rr_rot[:, :2]).simplices
+            tris = np.concatenate((tris, tris[:, ::-1]))
+    assert rrs.ndim == 2 and rrs.shape[1] == 3
+    return rrs, tris, extra_z
+
+
+@cache
+def _sensor_template(id_, size, base):
+    """Get the local sensor template geometry for a coil type.
+
+    Returns the ``(x, y, z)`` vertices and triangles in the coil's local frame,
+    or ``None`` for coil types without an explicit 2D template (handled by the
+    caller via a convex hull). Pure function of the coil id/size/base, so the
+    result is cached and shared across all channels of the same type.
+    """
     # Square figure eight
     if id_ in (
         FIFF.FIFFV_COIL_NM_122,
@@ -1783,7 +1825,7 @@ def _sensor_shape(coil):
         FIFF.FIFFV_COIL_VV_PLANAR_T2,
     ):
         # wound by right hand rule such that +x side is "up" (+z)
-        long_side = coil["size"]  # length of long side (meters)
+        long_side = size  # length of long side (meters)
         offset = 0.0025  # offset of the center portion of planar grad coil
         rrs = np.array(
             [
@@ -1800,8 +1842,6 @@ def _sensor_shape(coil):
         tris = np.concatenate(
             (_make_tris_fan(4), _make_tris_fan(4)[:, ::-1] + 4), axis=0
         )
-        # Offset for visibility (using heuristic for sanely named Neuromag coils)
-        extra_z = 0.001 * (1 + coil["chname"].endswith("2"))
     # Square
     elif id_ in (
         FIFF.FIFFV_COIL_POINT_MAGNETOMETER,
@@ -1811,8 +1851,8 @@ def _sensor_shape(coil):
         FIFF.FIFFV_COIL_KIT_REF_MAG,
     ):
         # square magnetometer (potentially point-type)
-        size = 0.001 if id_ == 2000 else (coil["size"] / 2.0)
-        rrs = np.array([[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]]) * size
+        half = 0.001 if id_ == 2000 else (size / 2.0)
+        rrs = np.array([[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]]) * half
         tris = _make_tris_fan(4)
     # Circle
     elif id_ in (
@@ -1826,7 +1866,7 @@ def _sensor_shape(coil):
         n_pts = 15  # number of points for circle
         circle = np.exp(2j * np.pi * np.arange(n_pts) / float(n_pts))
         circle = np.concatenate(([0.0], circle))
-        circle *= coil["size"] / 2.0  # radius of coil
+        circle *= size / 2.0  # radius of coil
         rrs = np.array([circle.real, circle.imag]).T
         tris = _make_tris_fan(n_pts + 1)
     # Circle
@@ -1843,12 +1883,12 @@ def _sensor_shape(coil):
         FIFF.FIFFV_COIL_ARTEMIS123_REF_GRAD,
     ):
         # round coil 1st order (off-diagonal) gradiometer
-        baseline = coil["base"] if id_ in (5004, 4005) else 0.0
+        baseline = base if id_ in (5004, 4005) else 0.0
         n_pts = 16  # number of points for circle
         # This time, go all the way around circle to close it fully
         circle = np.exp(2j * np.pi * np.arange(-1, n_pts) / float(n_pts - 1))
         circle[0] = 0  # center pt for triangulation
-        circle *= coil["size"] / 2.0
+        circle *= size / 2.0
         rrs = np.array(
             [  # first, second coil
                 np.concatenate(
@@ -1861,24 +1901,16 @@ def _sensor_shape(coil):
             [_make_tris_fan(n_pts + 1), _make_tris_fan(n_pts + 1) + n_pts + 1]
         )
     else:
-        # 3D convex hull (will fail for 2D geometry)
-        rrs = coil["rmag_orig"].copy()
-        try:
-            tris = _reorder_ccw(rrs, ConvexHull(rrs).simplices)
-        except QhullError:  # 2D geometry likely
-            logger.debug("Falling back to planar geometry")
-            u, _, _ = np.linalg.svd(rrs.T, full_matrices=False)
-            u[:, 2] = 0
-            rr_rot = rrs @ u
-            tris = Delaunay(rr_rot[:, :2]).simplices
-            tris = np.concatenate((tris, tris[:, ::-1]))
-        add_z_coord = False
+        return None
 
     # Go from (x,y) -> (x,y,z)
-    if add_z_coord:
-        rrs = np.pad(rrs, ((0, 0), (0, 1)), mode="constant", constant_values=0.0)
-    assert rrs.ndim == 2 and rrs.shape[1] == 3
-    return rrs, tris, extra_z
+    rrs = np.pad(rrs, ((0, 0), (0, 1)), mode="constant", constant_values=0.0)
+    # The cached arrays are shared across channels, so make them read-only to
+    # guard against accidental in-place mutation by callers.
+    tris = np.ascontiguousarray(tris)
+    rrs.flags.writeable = False
+    tris.flags.writeable = False
+    return rrs, tris
 
 
 def _process_clim(clim, colormap, transparent, data=0.0, allow_pos_lims=True):

--- a/mne/viz/_brain/_linkviewer.py
+++ b/mne/viz/_brain/_linkviewer.py
@@ -2,6 +2,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+import weakref
+
 import numpy as np
 
 from ...utils import warn
@@ -87,9 +89,17 @@ class _LinkViewer:
     def link_cameras(self):
         from ..backends._pyvista import _add_camera_callback
 
+        # Use weak references to the brains: the callback is retained by VTK on
+        # the (shared) camera, so capturing the brains strongly (via ``self``)
+        # would keep the whole scene alive after the brains are closed -- a leak
+        # that Python's gc cannot break through the C++ observer.
+        brain_refs = [weakref.ref(brain) for brain in self.brains]
+
         def _update_camera(vtk_picker, event):
-            for brain in self.brains:
-                brain.plotter.update()
+            for brain_ref in brain_refs:
+                brain = brain_ref()
+                if brain is not None:
+                    brain.plotter.update()
 
         camera = self.leader.plotter.camera
         _add_camera_callback(camera, _update_camera)

--- a/mne/viz/tests/test_3d_mpl.py
+++ b/mne/viz/tests/test_3d_mpl.py
@@ -153,6 +153,7 @@ def test_plot_volume_source_estimates_morph():
         )
 
 
+@pytest.mark.slowtest  # can be slow on Windows
 @testing.requires_testing_data
 def test_plot_volume_source_estimates_on_vol_labels():
     """Test plot of source estimate on srcs setup on 2 labels."""


### PR DESCRIPTION
Speed up tests:

1. Mark a few more tests `ultraslow` to speed up main test runs
2. Use fixtures and caching to avoid re-reading some files over and over (read once and copy instead, similar to how we already do for some evoked/epochs IIRC)
3. Cache 3D sensor geometry so that it doesn't need to be recomputed (we have finite coil geoms)

Part of #14063. Investigated speedups and drafted changes using Claude Fable 5 and Opus 4.8, then I revised (and understand + vouch for all changes).