### PR TITLE
Speed up Info validation, picking, and copying

### DIFF
--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1153,10 +1153,7 @@ class MNEBadsList(list):
 
     def __init__(self, *, bads, info):
         _check_bads_info_compat(bads, info)
-        # Weak ref to avoid an info <-> bads reference cycle. A strong ref made
-        # copying the (usually tiny) bads list drag the whole Info along -- e.g.
-        # in Info.__deepcopy__, dominating info.copy() -- and kept the cycle alive
-        # for the garbage collector.
+        # avoid an info <-> bads reference cycle
         self._mne_info = weakref.ref(info)
         super().__init__(bads)
 
@@ -1178,9 +1175,8 @@ class MNEBadsList(list):
         return self
 
     def __reduce__(self):
-        # The weakref is not picklable, and we don't want to drag the whole Info
-        # into pickles/copies, so serialize as a plain list. The parent Info
-        # re-wraps it as an MNEBadsList (via __setitem__) on load.
+        # The weakref is not picklable, and the parent Info re-wraps it as an
+        # MNEBadsList (via __setitem__) on load.
         return (list, (list(self),))
 
 
@@ -1828,16 +1824,10 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
 
     @contextlib.contextmanager
     def _skip_checks(self):
-        """Skip ``_check_consistency()`` on this instance within the block.
-
-        Consistency checking is ``O(n_channels)`` and dominates hot paths that
-        pick/copy an already-consistent info repeatedly (see ``pick_info``). Wrap
-        such work in this context manager when the info is known to be consistent.
-        The flag is transient: it is not pickled (see ``__getstate__``) and not
-        propagated to copies (``__deepcopy__`` builds a fresh instance), so any
-        info produced *inside* the block (e.g. the copy returned by ``pick_info``)
-        is still validated normally.
-        """
+        """Skip ``_check_consistency()`` on this instance within the block."""
+        # dominates frequently used pick/copy operations an already-consistent info
+        # flag is transient: not pickled (see ``__getstate__``) and ``__deepcopy__``
+        # builds a fresh instance
         prev = getattr(self, "_no_check", False)
         self._no_check = True
         try:
@@ -1973,9 +1963,16 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
                 result[k] = v.copy()
             elif k == "dig":
                 # DigPoint has a fast __deepcopy__ (only copies its "r" array);
-                # calling it directly avoids the generic list-deepcopy dispatch
-                # overhead (~2x faster when there are many points).
-                result[k] = None if v is None else [d.__deepcopy__(memodict) for d in v]
+                # calling it directly avoids the generic list-deepcopy dispatch.
+                # dig is almost always DigPoints, but can hold plain dicts (e.g.
+                # appended directly), which lack __deepcopy__; fall back for those.
+                if v is None:
+                    result[k] = None
+                else:
+                    try:
+                        result[k] = [d.__deepcopy__(memodict) for d in v]
+                    except AttributeError:
+                        result[k] = deepcopy(v, memodict)
             elif k == "hpi_meas":
                 hms = list()
                 for hm in v:

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -7,6 +7,7 @@ import datetime
 import operator
 import re
 import string
+import weakref
 from collections import Counter, OrderedDict
 from collections.abc import Mapping
 from copy import deepcopy
@@ -1152,18 +1153,20 @@ class MNEBadsList(list):
 
     def __init__(self, *, bads, info):
         _check_bads_info_compat(bads, info)
-        self._mne_info = info
+        # Weak ref to avoid an info <-> bads reference cycle. A strong ref made
+        # copying the (usually tiny) bads list drag the whole Info along -- e.g.
+        # in Info.__deepcopy__, dominating info.copy() -- and kept the cycle alive
+        # for the garbage collector.
+        self._mne_info = weakref.ref(info)
         super().__init__(bads)
 
     def extend(self, iterable):
         if not isinstance(iterable, list):
             iterable = list(iterable)
-        # can happen during pickling
-        try:
-            info = self._mne_info
-        except AttributeError:
-            pass  # can happen during pickling
-        else:
+        # info may be absent (during unpickling) or already gone (dead weakref)
+        info_ref = getattr(self, "_mne_info", None)
+        info = info_ref() if info_ref is not None else None
+        if info is not None:
             _check_bads_info_compat(iterable, info)
         return super().extend(iterable)
 
@@ -1173,6 +1176,12 @@ class MNEBadsList(list):
     def __iadd__(self, x):
         self.extend(x)
         return self
+
+    def __reduce__(self):
+        # The weakref is not picklable, and we don't want to drag the whole Info
+        # into pickles/copies, so serialize as a plain list. The parent Info
+        # re-wraps it as an MNEBadsList (via __setitem__) on load.
+        return (list, (list(self),))
 
 
 # As options are added here, test_meas_info.py:test_info_bad should be updated
@@ -1817,6 +1826,25 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
         finally:
             self._unlocked = state
 
+    @contextlib.contextmanager
+    def _skip_checks(self):
+        """Skip ``_check_consistency()`` on this instance within the block.
+
+        Consistency checking is ``O(n_channels)`` and dominates hot paths that
+        pick/copy an already-consistent info repeatedly (see ``pick_info``). Wrap
+        such work in this context manager when the info is known to be consistent.
+        The flag is transient: it is not pickled (see ``__getstate__``) and not
+        propagated to copies (``__deepcopy__`` builds a fresh instance), so any
+        info produced *inside* the block (e.g. the copy returned by ``pick_info``)
+        is still validated normally.
+        """
+        prev = getattr(self, "_no_check", False)
+        self._no_check = True
+        try:
+            yield
+        finally:
+            self._no_check = prev
+
     def normalize_proj(self):
         """(Re-)Normalize projection vectors after subselection.
 
@@ -1943,6 +1971,11 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
             elif k == "ch_names":
                 # we know it's list of str, shallow okay and saves ~100 µs
                 result[k] = v.copy()
+            elif k == "dig":
+                # DigPoint has a fast __deepcopy__ (only copies its "r" array);
+                # calling it directly avoids the generic list-deepcopy dispatch
+                # overhead (~2x faster when there are many points).
+                result[k] = None if v is None else [d.__deepcopy__(memodict) for d in v]
             elif k == "hpi_meas":
                 hms = list()
                 for hm in v:
@@ -1966,6 +1999,8 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
 
     def _check_consistency(self, prepend_error=""):
         """Do some self-consistency checks and datatype tweaks."""
+        if getattr(self, "_no_check", False):
+            return
         meas_date = self.get("meas_date")
         if meas_date is not None:
             if (

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -457,13 +457,17 @@ def _check_meg_type(meg, allow_auto=False):
 
 
 def _check_info_exclude(info, exclude):
+    # NB: we deliberately do not call info._check_consistency() here. This helper
+    # only computes channel indices (it produces no new Info), and it is called
+    # very frequently via _picks_to_idx/pick_types. The consistency of an Info is
+    # validated where it matters -- at construction/I/O and whenever pick_info
+    # produces a new Info from it.
     _validate_type(info, "info")
-    info._check_consistency()
     if exclude is None:
         raise ValueError('exclude must be a list of strings or "bads"')
     elif exclude == "bads":
         exclude = info.get("bads", [])
-    elif not isinstance(exclude, list | tuple):
+    elif not isinstance(exclude, (list, tuple)):
         raise ValueError(
             'exclude must either be "bads" or a list of strings.'
             " If only one channel is to be excluded, use "
@@ -660,6 +664,10 @@ def pick_info(info, sel=(), copy=True, verbose=None):
     # avoid circular imports
     from .meas_info import _bad_chans_comp
 
+    # Validate the *input* (a user may have corrupted `info` despite our
+    # safeguards). This is a no-op inside an `info._skip_checks()` block, which
+    # internal callers use when they know `info` is already consistent. We do not
+    # re-check the picked result below: picking here is trusted to be correct.
     info._check_consistency()
     info = info.copy() if copy else info
     if sel is None:
@@ -714,7 +722,6 @@ def pick_info(info, sel=(), copy=True, verbose=None):
         if len(projs) != len(info["projs"]):
             with info._unlock():
                 info["projs"] = projs
-    info._check_consistency()
 
     return info
 

--- a/mne/_fiff/tests/test_meas_info.py
+++ b/mne/_fiff/tests/test_meas_info.py
@@ -1427,7 +1427,7 @@ def test_pickle(fname_info, unlocked, protocol):
     assert_object_equal(info, info_un)
     assert info_un._unlocked == unlocked
     assert isinstance(info_un["bads"], MNEBadsList)
-    assert info_un["bads"]._mne_info is info_un
+    assert info_un["bads"]._mne_info() is info_un  # weakref back to its Info
 
 
 def test_info_bad():

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -196,7 +196,8 @@ def make_dics(
 
     _, _, allow_mismatch = _check_one_ch_type("dics", info, forward, csd, noise_csd)
     # remove bads so that equalize_channels only keeps all good
-    info = pick_info(info, pick_channels(info["ch_names"], [], info["bads"]))
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, pick_channels(info["ch_names"], [], info["bads"]))
     info, forward, csd = equalize_channels([info, forward, csd])
 
     csd, noise_csd = _prepare_noise_csd(csd, noise_csd, real_filter)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -170,7 +170,8 @@ def make_lcmv(
     # because there can be a mismatch. Should probably add an extra arg to
     # _prepare_beamformer_input at some point (later)
     picks = _check_info_inv(info, forward, data_cov, noise_cov)
-    info = pick_info(info, picks)
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, picks)
     data_rank = compute_rank(data_cov, rank=rank, info=info)
     noise_rank = compute_rank(noise_cov, rank=rank, info=info)
     for key in data_rank:

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -48,7 +48,8 @@ def _apply_rap_music(
         Data explained by the dipoles using a least square fitting with the
         selected active dipoles and their estimated orientation.
     """
-    info = pick_info(info, picks)
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, picks)
     del picks
     # things are much simpler if we avoid surface orientation
     align = forward["source_nn"].copy()

--- a/mne/beamformer/resolution_matrix.py
+++ b/mne/beamformer/resolution_matrix.py
@@ -67,7 +67,8 @@ def _get_matrix_from_lcmv(filters, forward, info, verbose=None):
         Inverse matrix associated with LCMV beamformer filters.
     """
     # number of channels for identity matrix
-    info = pick_info(info, pick_channels(info["ch_names"], filters["ch_names"]))
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, pick_channels(info["ch_names"], filters["ch_names"]))
     n_chs = len(info["ch_names"])
 
     # create identity matrix as input for inverse operator

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1148,7 +1148,8 @@ def compute_covariance(
             for n_epoch, mean in zip(n_epochs, data_mean)
         ]
 
-    info = pick_info(info, picks_meeg)
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, picks_meeg)
     tslice = _get_tslice(epochs[0], tmin, tmax)
     epochs = [ee.get_data(picks=picks_meeg)[..., tslice] for ee in epochs]
     picks_meeg = np.arange(len(picks_meeg))
@@ -2146,7 +2147,8 @@ def regularize(
                     )
         else:
             this_picks = pick_channels(info["ch_names"], this_ch_names)
-            this_info = pick_info(info, this_picks)
+            with info._skip_checks():  # info is already consistent
+                this_info = pick_info(info, this_picks)
             # Here we could use proj_subspace=True, but this should not matter
             # since this is already in a loop over channel types
             _, eigvec, mask = _smart_eigh(this_C, this_info, rank)

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -891,7 +891,8 @@ def _check_reference(inst, ch_names=None):
         picks = [
             ci for ci, ch_name in enumerate(info["ch_names"]) if ch_name in ch_names
         ]
-        info = pick_info(info, sel=picks)
+        with info._skip_checks():  # info is already consistent
+            info = pick_info(info, sel=picks)
     if _needs_eeg_average_ref_proj(info):
         raise ValueError(
             "EEG average reference (using a projector) is mandatory for "
@@ -1644,7 +1645,8 @@ def apply_inverse_cov(
     _validate_type(inverse_operator, InverseOperator, "inverse_operator")
     sel = _pick_channels_inverse_operator(cov["names"], inverse_operator)
     use_names = [cov["names"][idx] for idx in sel]
-    info = pick_info(info, pick_channels(info["ch_names"], use_names, ordered=True))
+    with info._skip_checks():  # info is already consistent
+        info = pick_info(info, pick_channels(info["ch_names"], use_names, ordered=True))
     evoked = EvokedArray(np.eye(len(info["ch_names"])), info, nave=nave, comment="cov")
     is_free_ori = inverse_operator["source_ori"] == FIFF.FIFFV_MNE_FREE_ORI
     _check_option("pick_ori", pick_ori, (None, "normal"))

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -4,7 +4,7 @@
 
 import re
 from contextlib import contextmanager
-from functools import partial
+from functools import cache, partial
 from pathlib import Path
 
 import numpy as np
@@ -186,9 +186,19 @@ def _assert_mag_coil_type(info, coil_type):
     assert coil_types == {coil_type}
 
 
+@cache
+def _read_raw_maxshield(fname, _mtime, _size):
+    # Cache the (unloaded) raw so files read many times (e.g. raw_fname, ~14x)
+    # are parsed only once. Keyed on (path, mtime, size) so a rewritten temp file
+    # is not served stale. read_crop() returns an independent copy of this.
+    return read_raw_fif(fname, allow_maxshield="yes")
+
+
 def read_crop(fname, lims=(0, None)):
-    """Read and crop."""
-    return read_raw_fif(fname, allow_maxshield="yes").crop(*lims)
+    """Read (cached) and crop a copy."""
+    st = Path(fname).stat()
+    raw = _read_raw_maxshield(str(fname), st.st_mtime, st.st_size)
+    return raw.copy().crop(*lims)
 
 
 # For backward compat and to be most like MaxFilter, we make "maxwell_filter"

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -582,6 +582,9 @@ _multi = {
     "array-like": (list, tuple, set, np.ndarray),
     "sparse": (_Sparse(),),
 }
+# Precomputed for isinstance() -- `list | tuple` rebuilds a UnionType on every
+# call (~11x slower), which matters in hot validation paths.
+_list_or_tuple = (list, tuple)
 
 
 def _validate_type(item, types=None, item_name=None, type_name=None, *, extra=""):
@@ -610,7 +613,18 @@ def _validate_type(item, types=None, item_name=None, type_name=None, *, extra=""
     elif types == "info":
         from .._fiff.meas_info import Info as types
 
-    if not isinstance(types, list | tuple):
+    # Fast path for the common single-type / single-string-spec calls: avoids
+    # rebuilding `check_types` (and the `list | tuple` union) on every call.
+    # `_validate_type` is one of the hottest functions in MNE (e.g. it runs per
+    # channel inside Info._check_consistency). Only returns early on success;
+    # failures fall through to the general path below to build the error message.
+    if isinstance(types, type):
+        if isinstance(item, types):
+            return
+    elif isinstance(types, str) and isinstance(item, _multi[types]):
+        return
+
+    if not isinstance(types, _list_or_tuple):
         types = [types]
 
     check_types = sum(


### PR DESCRIPTION
1. In profiling, `info._check_consistency` was about 15% of non-viz test runtime (!). This is mostly due to re-validating all of `info` way more than needed. Add `info._skip_checks()` context manager, and continue to have `pick_info` validate its input at the start, but no longer at the end. Highest risk to us is that some user has found a way to mess with something -- assume we've done our implentations correctly, and if we haven't, that it will get noticed on the *next* call that uses info (and it gets validated).
2. Wrap known-consistent internal pick_info calls (`inverse`, `beamformer`, etc.) with the skipper
3. Don't check validation in `_check_info_exclude` -- it's used by things that already validate
4. Speed up `_validate_type` for the common single-type and `str` calls, plus a precomputed (list, tuple) instead of rebuilding `list | tuple` each call (the type unioning is slower :scream: )
4. `MNEBadsList` held a strong back-reference to its `info`, so copying it was very expensive (fix: use `weakref`; this requires setting `__reduce__` on it; cuts down `info.copy()` time in half, and that is used a lot!)

Part of https://github.com/mne-tools/mne-python/pull/14063. Investigated speedups and drafted changes using Claude Fable 5 and Opus 4.8, then I revised (and understand + vouch for all changes).