### PR TITLE
Fix: Handle inline backends in plt_show

### DIFF
--- a/doc/changes/dev/14076.bugfix.rst
+++ b/doc/changes/dev/14076.bugfix.rst
@@ -1,0 +1,1 @@
+Fix figures not being displayed in notebook-style frontends when using a Matplotlib inline backend, by `Mingjian He`_.

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -30,6 +30,7 @@ from mne.viz.utils import (
     centers_to_edges,
     compare_fiff,
     concatenate_images,
+    plt_show,
 )
 
 base_dir = Path(__file__).parents[2] / "io" / "tests" / "data"
@@ -44,6 +45,24 @@ def test_setup_vmin_vmax_warns():
     expected_msg = r"\(min=0.0, max=1\) range.*minimum of data is -1"
     with pytest.warns(UserWarning, match=expected_msg):
         _setup_vmin_vmax(data=[-1, 0], vmin=None, vmax=None, norm=True)
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    (("module://Matplotlib_Inline.backend_inline", "pyplot"), ("QtAgg", "figure")),
+)
+def test_plt_show_backend(monkeypatch, backend, expected):
+    """Test backend-specific show paths."""
+    calls = []
+
+    class Figure:
+        def show(self, **kwargs):
+            calls.append(("figure", kwargs))
+
+    monkeypatch.setattr("matplotlib.get_backend", lambda: backend)
+    monkeypatch.setattr(plt, "show", lambda **kwargs: calls.append(("pyplot", kwargs)))
+    plt_show(fig=Figure(), block=True)
+    assert calls == [(expected, {"block": True})]
 
 
 def test_get_color_list():

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -157,7 +157,10 @@ def plt_show(show=True, fig=None, **kwargs):
         backend = get_backend()
     if show and backend != "agg":
         logger.debug(f"Showing plot for backend {repr(backend)}")
-        (fig or plt).show(**kwargs)
+        if "inline" in str(backend).lower():
+            plt.show(**kwargs)
+        else:
+            (fig or plt).show(**kwargs)
 
 
 def _show_browser(show=True, block=True, fig=None, **kwargs):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -157,6 +157,7 @@ def plt_show(show=True, fig=None, **kwargs):
         backend = get_backend()
     if show and backend != "agg":
         logger.debug(f"Showing plot for backend {repr(backend)}")
+        # if backend is inline and therefore non-interactive, fig.show() fails. See PR gh-14076
         if "inline" in str(backend).lower():
             plt.show(**kwargs)
         else:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -157,7 +157,8 @@ def plt_show(show=True, fig=None, **kwargs):
         backend = get_backend()
     if show and backend != "agg":
         logger.debug(f"Showing plot for backend {repr(backend)}")
-        # if backend is inline and therefore non-interactive, fig.show() fails. See PR gh-14076
+        # if backend is inline and therefore non-interactive,
+        # fig.show() fails with UserWarning. See gh-14076
         if "inline" in str(backend).lower():
             plt.show(**kwargs)
         else:


### PR DESCRIPTION
#### Reference issue (if any)

None


#### What does this implement/fix?

`mne.viz.utils.plt_show()` currently calls `Figure.show()` when it receives a figure. With a Matplotlib inline backend, that call does not reliably trigger display in notebook-style frontends. This includes the VS Code Interactive Window that some people use. `matplotlib.pyplot.show()` does.

This change detects inline backend identifiers case-insensitively and routes them through `plt.show(**kwargs)`. Other GUI backends continue to use `(fig or plt).show(**kwargs)`, while the existing no-show behavior for Agg and `show=False` remains unchanged.


#### Additional information

I manually identified the issue and implemented the fix, but Codex added the test case to mne/viz/tests/test_utils.py
