### PR TITLE
Clean up dark/light tests

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -737,6 +737,8 @@ def browser_backend(request, garbage_collect, monkeypatch):
     with use_browser_backend(backend_name) as backend:
         backend._close_all()
         monkeypatch.setenv("MNE_BROWSE_RAW_SIZE", "10,10")
+        # Unify theme across dev setups (regardless of current light/dark mode)
+        monkeypatch.setenv("MNE_BROWSER_THEME", "light")
         yield backend
         backend._close_all()
         if backend_name == "qt":
@@ -1079,6 +1081,7 @@ def options_3d():
             "MNE_3D_OPTION_ANTIALIAS": "false",
             "MNE_3D_OPTION_DEPTH_PEELING": "false",
             "MNE_3D_OPTION_SMOOTH_SHADING": "false",
+            "MNE_3D_OPTION_THEME": "light",  # unify colors across setups
         },
     ):
         yield

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -15,7 +15,9 @@ pytest.importorskip("nibabel")
 def test_gui_api_notebook(renderer_notebook, nbexec, *, backend="qt"):
     """Test GUI API."""
     import contextlib
+    import os
     import warnings
+    from unittest import mock
 
     import mne
 
@@ -31,8 +33,14 @@ def test_gui_api_notebook(renderer_notebook, nbexec, *, backend="qt"):
         mne.viz.set_3d_backend("notebook")
     renderer = mne.viz.backends.renderer._get_renderer(size=(300, 300))
 
-    # theme
-    with warnings.catch_warnings(record=True) as w:
+    # theme -- drop the MNE_3D_OPTION_THEME that the options_3d fixture pins to
+    # "light" (it takes precedence via get_config), so the bad path is actually
+    # used and warns.
+    with (
+        mock.patch.dict(os.environ),
+        warnings.catch_warnings(record=True) as w,
+    ):
+        os.environ.pop("MNE_3D_OPTION_THEME", None)
         warnings.simplefilter("always")
         renderer._window_set_theme("/does/not/exist")
     if backend == "qt":

--- a/mne/viz/backends/tests/test_utils.py
+++ b/mne/viz/backends/tests/test_utils.py
@@ -2,7 +2,6 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-import platform
 from colorsys import rgb_to_hls
 
 import numpy as np
@@ -10,7 +9,6 @@ import pytest
 
 from mne import create_info
 from mne.io import RawArray
-from mne.utils import _check_qt_version
 from mne.viz.backends._utils import (
     _check_color,
     _get_colormap_from_array,
@@ -50,6 +48,17 @@ def test_check_color():
         _check_color(None)
 
 
+def _assert_correct_darkness(widget, want_dark):
+    __tracebackhide__ = True  # noqa
+    # The override propagates to children, so both palette and pixels should match.
+    bgcolor = widget.palette().color(widget.backgroundRole()).getRgbF()[:3]
+    dark = rgb_to_hls(*bgcolor)[1] < 0.5
+    assert dark == want_dark, f"{widget} palette dark={dark} want_dark={want_dark}"
+    colors = _pixmap_to_ndarray(widget.grab())[:, :, :3]
+    dark = colors.mean() < 0.5
+    assert dark == want_dark, f"{widget} pixmap dark={dark} want_dark={want_dark}"
+
+
 @pytest.mark.pgtest
 @pytest.mark.parametrize("theme", ("auto", "light", "dark"))
 def test_theme_colors(pg_backend, theme, monkeypatch, tmp_path):
@@ -57,30 +66,18 @@ def test_theme_colors(pg_backend, theme, monkeypatch, tmp_path):
     darkdetect = pytest.importorskip("darkdetect")
     monkeypatch.setenv("_MNE_FAKE_HOME_DIR", str(tmp_path))
     monkeypatch.delenv("MNE_BROWSER_THEME", raising=False)
-    # make it seem like the system is always in light mode
-    monkeypatch.setattr(darkdetect, "theme", lambda: "light")
+    # A qdarkstyle stylesheet is only applied when the requested theme differs from
+    # the system, so fake the system as the opposite of the request
+    if theme == "auto":
+        want_dark = (darkdetect.theme() or "light").lower() == "dark"
+    else:
+        want_dark = theme == "dark"
+        fake_system = "light" if want_dark else "dark"
+        monkeypatch.setattr(darkdetect, "theme", lambda: fake_system)
     raw = RawArray(np.zeros((1, 1000)), create_info(1, 1000.0, "eeg"))
-    _, api = _check_qt_version(return_api=True)
     fig = raw.plot(theme=theme)
     is_dark = _qt_is_dark(fig)
-    # on Darwin these checks get complicated, so don't bother for now
-    if platform.system() == "Darwin":
-        pytest.skip("Problems on macOS")
-    if theme == "dark":
-        assert is_dark, theme
-    elif theme == "light":
-        assert not is_dark, theme
-
-    def assert_correct_darkness(widget, want_dark):
-        __tracebackhide__ = True  # noqa
-        # This should work, but it just picks up the parent in the errant case!
-        bgcolor = widget.palette().color(widget.backgroundRole()).getRgbF()[:3]
-        dark = rgb_to_hls(*bgcolor)[1] < 0.5
-        assert dark == want_dark, f"{widget} dark={dark} want_dark={want_dark}"
-        # ... so we use a more direct test
-        colors = _pixmap_to_ndarray(widget.grab())[:, :, :3]
-        dark = colors.mean() < 0.5
-        assert dark == want_dark, f"{widget} dark={dark} want_dark={want_dark}"
+    assert is_dark == want_dark, theme
 
     for widget in (fig.mne.toolbar, fig.statusBar()):
-        assert_correct_darkness(widget, is_dark)
+        _assert_correct_darkness(widget, is_dark)


### PR DESCRIPTION
One last part of #14063: make it so that 1) the theme testing works on all OSes (it was actually failing locally for me on Ubuntu 26.04!), and 2) make it so tests consistently use `"light"` theming for consistency across dev setups. Investigated and drafted changes using Claude Fable 5 and Opus 4.8, then I revised (and understand + vouch for all changes).