### PR TITLE
Pin non-working trame-vuetify version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -65,7 +65,7 @@ dependencies:
   - trame
   - trame-pyvista
   - trame-vtk
-  - trame-vuetify
+  - trame-vuetify !=3.2.3
   - vtk ==9.6.2
   - xlrd
   - pip:

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -6,6 +6,7 @@
 
 import os
 import os.path as op
+import warnings
 from contextlib import contextmanager, nullcontext
 
 from ipyevents import Event
@@ -111,6 +112,37 @@ _BASE_MIN_SIZE = "20px"
 _BASE_KWARGS = dict(layout=Layout(min_width=_BASE_MIN_SIZE, min_height=_BASE_MIN_SIZE))
 
 _JUPYTER_BACKEND = "trame"
+
+
+class _NotebookPlotter(Plotter):
+    """PyVista ``Plotter`` for the notebook backend.
+
+    Validate the object returned by show, as PyVista silently falls back static PIL
+    when the trame Jupyter backend cannot be loaded.
+    """
+
+    def show(self, *args, **kwargs):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            viewer = super().show(*args, **kwargs)
+        if not isinstance(viewer, Widget):
+            reasons = "\n".join(
+                f"- {w.message}"
+                for w in caught
+                if any(key in str(w.message) for key in ("backend", "trame", "static"))
+            )
+            raise RuntimeError(
+                f'The notebook 3D backend is not functional: the "{_JUPYTER_BACKEND}" '
+                "PyVista Jupyter backend returned a "
+                f"{type(viewer).__module__}.{type(viewer).__qualname__} instead of an "
+                "interactive widget. This usually means the installed trame packages "
+                "(trame, trame-vtk, trame-vuetify, trame-pyvista) are missing or "
+                "mutually incompatible."
+                + (f"\n\nPyVista reported:\n{reasons}" if reasons else "")
+            )
+        if kwargs["return_viewer"]:
+            return viewer
+
 
 # %%
 # Widgets

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -17,7 +17,7 @@ from inspect import signature
 
 import numpy as np
 import pyvista
-from pyvista import Line, Plotter, PolyData, close_all
+from pyvista import Line, Plotter, PolyData, close_all  # noqa: F401  # re-exported
 from pyvista.plotting.plotter import _ALL_PLOTTERS
 from pyvistaqt import BackgroundPlotter
 from vtkmodules.util.numpy_support import numpy_to_vtk
@@ -131,7 +131,9 @@ class PyVistaFigure(Figure3D):
 
                 self.store["app_window_class"] = _MNEMainWindow
         else:
-            self._plotter_class = Plotter
+            from ._notebook import _NotebookPlotter
+
+            self._plotter_class = _NotebookPlotter
 
         self._nrows, self._ncols = self.store["shape"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ full-no-qt = [
   "trame",
   "trame-pyvista",
   "trame-vtk",
-  "trame-vuetify",
+  "trame-vuetify != 3.2.3",
   "vtk >= 9.2",
   "xlrd",
 ]

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -67,7 +67,7 @@ python -m pip install $STD_ARGS \
 	git+https://github.com/h5io/h5io \
 	git+https://github.com/BUNPC/pysnirf2 \
 	git+https://github.com/the-siesta-group/edfio \
-	trame trame-vtk trame-vuetify trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
+	trame trame-vtk "trame-vuetify!=3.2.3" trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
 	openmeeg imageio-ffmpeg xlrd mffpy traitlets pybv eeglabio defusedxml antio curryreader \
 	filelock
 echo "::endgroup::"


### PR DESCRIPTION
trame-vuetify accidentally broke some stuff (https://github.com/pyvista/trame-pyvista/pull/80), let's pin not to use it. Also, if we can't use the notebook backend but we're trying to, say why and raise an informative error. Claude Fable 5 drafted changes and I edited them. Marking for merge-when-green since this fixes an active bug that is making all PRs red