### PR TITLE
Remove dead code from GUI base

### DIFF
--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -739,14 +739,6 @@ class _AbstractWidget(ABC):
         pass
 
     @abstractmethod
-    def _get_tooltip(self):
-        pass
-
-    @abstractmethod
-    def _set_tooltip(self, tooltip: str):
-        pass
-
-    @abstractmethod
     def _add_keypress(self, callback):
         pass
 
@@ -756,10 +748,6 @@ class _AbstractWidget(ABC):
 
     @abstractmethod
     def _set_focus(self):
-        pass
-
-    @abstractmethod
-    def _set_layout(self, layout):
         pass
 
     @abstractmethod
@@ -799,10 +787,6 @@ class _AbstractButton(_AbstractWidget):
     def _click(self):
         pass
 
-    @abstractmethod
-    def _set_icon(self, icon):
-        pass
-
 
 class _AbstractSlider(_AbstractWidget):
     @classmethod
@@ -816,10 +800,6 @@ class _AbstractSlider(_AbstractWidget):
 
     @abstractmethod
     def _get_value(self):
-        pass
-
-    @abstractmethod
-    def _set_range(self, rng):
         pass
 
 
@@ -985,10 +965,6 @@ class _AbstractBoxLayout(ABC):
     def _add_widget(self, widget):
         pass
 
-    @abstractmethod
-    def _add_stretch(self, amount=1):
-        pass
-
 
 class _AbstractHBoxLayout(_AbstractBoxLayout):
     @abstractmethod
@@ -1021,31 +997,7 @@ class _AbstractAppWindow(ABC):
         pass
 
     @abstractmethod
-    def _get_dpi(self):
-        pass
-
-    @abstractmethod
     def _get_size(self):
-        pass
-
-    @abstractmethod
-    def _get_cursor(self):
-        pass
-
-    @abstractmethod
-    def _set_cursor(self, cursor):
-        pass
-
-    @abstractmethod
-    def _new_cursor(self, name):
-        pass
-
-    @abstractmethod
-    def _close_connect(self, func, *, after=True):
-        pass
-
-    @abstractmethod
-    def _close_disconnect(self, after=True):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -121,10 +121,17 @@ class _NotebookPlotter(Plotter):
     when the trame Jupyter backend cannot be loaded.
     """
 
-    def show(self, *args, **kwargs):
+    def show(
+        self, *args, jupyter_backend=_JUPYTER_BACKEND, return_viewer=False, **kwargs
+    ):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            viewer = super().show(*args, **kwargs)
+            viewer = super().show(
+                *args,
+                jupyter_backend=jupyter_backend,
+                return_viewer=return_viewer,
+                **kwargs,
+            )
         if not isinstance(viewer, Widget):
             reasons = "\n".join(
                 f"- {w.message}"
@@ -132,7 +139,7 @@ class _NotebookPlotter(Plotter):
                 if any(key in str(w.message) for key in ("backend", "trame", "static"))
             )
             raise RuntimeError(
-                f'The notebook 3D backend is not functional: the "{_JUPYTER_BACKEND}" '
+                f'The notebook 3D backend is not functional: the "{jupyter_backend}" '
                 "PyVista Jupyter backend returned a "
                 f"{type(viewer).__module__}.{type(viewer).__qualname__} instead of an "
                 "interactive widget. This usually means the installed trame packages "
@@ -140,7 +147,7 @@ class _NotebookPlotter(Plotter):
                 "mutually incompatible."
                 + (f"\n\nPyVista reported:\n{reasons}" if reasons else "")
             )
-        if kwargs["return_viewer"]:
+        if return_viewer:
             return viewer
 
 
@@ -166,10 +173,6 @@ class _Widget(Widget, _AbstractWidget, metaclass=_BaseWidget):
         # issue since each subclass __init__s it's own (e.g. Label)
         # Widget.__init__(self)
 
-    def _set_range(self, rng):
-        self.min = rng[0]
-        self.max = rng[1]
-
     def _show(self):
         self.layout.visibility = "visible"
 
@@ -184,12 +187,6 @@ class _Widget(Widget, _AbstractWidget, metaclass=_BaseWidget):
 
     def _update(self, repaint=True):
         pass
-
-    def _get_tooltip(self):
-        return self.tooltip
-
-    def _set_tooltip(self, tooltip):
-        self.tooltip = tooltip
 
     def _set_style(self, style):
         for key, val in style.items():
@@ -210,9 +207,6 @@ class _Widget(Widget, _AbstractWidget, metaclass=_BaseWidget):
     def _set_focus(self):
         if hasattr(self, "focus"):  # added in ipywidgets 8.0
             self.focus()
-
-    def _set_layout(self, layout):
-        self.children = (layout,)
 
     def _set_theme(self, theme):
         pass
@@ -257,9 +251,6 @@ class _Button(_Widget, _AbstractButton, Button, metaclass=_BaseWidget):
 
     def _click(self):
         self.click()
-
-    def _set_icon(self, icon):
-        self.icon = _ICON_LUT[icon]
 
 
 class _Slider(_Widget, _AbstractSlider, IntSlider, metaclass=_BaseWidget):
@@ -680,7 +671,7 @@ class _BoxLayout:
     def _add_widget(self, widget):
         # if pyvista plotter, needs to be shown
         if isinstance(widget, Plotter):
-            widget = widget.show(jupyter_backend=_JUPYTER_BACKEND, return_viewer=True)
+            widget = widget.show(return_viewer=True)
         if hasattr(widget, "layout"):
             widget.layout.width = None  # unlock the fixed layout
             widget.layout.margin = "2px 0px 2px 0px"
@@ -705,12 +696,6 @@ class _HBoxLayout(
             for child in self.children:
                 child.layout.height = f"{int(self._height / len(self.children))}px"
 
-    def _add_stretch(self, amount=1):
-        self.children += (
-            self,
-            _Label(" " * 4),
-        )
-
 
 class _VBoxLayout(
     _AbstractVBoxLayout, _BoxLayout, _Widget, VBox, metaclass=_BaseWidget
@@ -727,12 +712,6 @@ class _VBoxLayout(
         if self._width is not None:
             for child in self.children:
                 child.layout.width = f"{int(self._width / len(self.children))}px"
-
-    def _add_stretch(self, amount=1):
-        self.children += (
-            self,
-            _Label(" " * 4),
-        )
 
 
 class _GridLayout(_AbstractGridLayout, _Widget, GridBox, metaclass=_BaseWidget):
@@ -772,31 +751,13 @@ class _AppWindow(_AbstractAppWindow, _Widget, VBox, metaclass=_BaseWidget):
     def _set_central_layout(self, central_layout):
         self.children = (central_layout,)
 
-    def _close_connect(self, func, *, after=True):
-        pass
-
-    def _close_disconnect(self, after=True):
-        pass
-
     def _clean(self):
         pass
-
-    def _get_dpi(self):
-        return 96
 
     def _get_size(self):
         # CSS objects don't have explicit widths and heights
         # https://github.com/jupyter-widgets/ipywidgets/issues/1639
         return (256, 256)
-
-    def _get_cursor(self):
-        pass
-
-    def _set_cursor(self, cursor):
-        pass
-
-    def _new_cursor(self, name):
-        pass
 
     def _show(self, block=False):
         display(self)
@@ -819,7 +780,7 @@ class _3DRenderer(_PyVistaRenderer):
         yield
 
     def show(self):
-        viewer = self.plotter.show(jupyter_backend=_JUPYTER_BACKEND, return_viewer=True)
+        viewer = self.plotter.show(return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
         display(viewer)
 
@@ -1617,7 +1578,7 @@ class _Renderer(
         else:
             self._display_default_tool_bar()
         # viewer
-        viewer = self.plotter.show(jupyter_backend=_JUPYTER_BACKEND, return_viewer=True)
+        viewer = self.plotter.show(return_viewer=True)
         rendering_row = list()
         if self._docks is not None and "left" in self._docks:
             rendering_row.append(self._docks["left"][0])

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -186,12 +186,6 @@ class _Widget(_AbstractWidget, QWidget, metaclass=_BaseWidget):
         if repaint:
             self.repaint()
 
-    def _get_tooltip(self):
-        return self.toolTip()
-
-    def _set_tooltip(self, tooltip):
-        self.setToolTip(tooltip)
-
     def _set_style(self, style):
         stylesheet = ""
         for key, val in style.items():
@@ -214,9 +208,6 @@ class _Widget(_AbstractWidget, QWidget, metaclass=_BaseWidget):
 
     def _set_focus(self):
         self.setFocus()
-
-    def _set_layout(self, layout):
-        self.setLayout(_get_layout(layout))
 
     def _set_theme(self, theme=None):
         if theme is None:
@@ -280,9 +271,6 @@ class _Button(QPushButton, _AbstractButton, _Widget, metaclass=_BaseWidget):
     def _click(self):
         self.click()
 
-    def _set_icon(self, icon):
-        self.setIcon(_qicon(icon))
-
 
 class _Slider(QSlider, _AbstractSlider, _Widget, metaclass=_BaseWidget):
     def __init__(self, value, rng, callback, horizontal=True):
@@ -302,9 +290,6 @@ class _Slider(QSlider, _AbstractSlider, _Widget, metaclass=_BaseWidget):
 
     def _get_value(self):
         return self.value()
-
-    def _set_range(self, rng):
-        self.setRange(int(rng[0]), int(rng[1]))
 
 
 class _ProgressBar(QProgressBar, _AbstractProgressBar, _Widget, metaclass=_BaseWidget):
@@ -615,9 +600,6 @@ class _HBoxLayout(QHBoxLayout, _AbstractHBoxLayout, _Widget, metaclass=_BaseWidg
                 widget.setMaximumHeight(self._height)
             self.addWidget(widget)
 
-    def _add_stretch(self, amount=1):
-        self.addStretch(amount)
-
 
 class _VBoxLayout(QVBoxLayout, _AbstractVBoxLayout, _Widget, metaclass=_BaseWidget):
     def __init__(self, width=None, scroll=None):
@@ -644,9 +626,6 @@ class _VBoxLayout(QVBoxLayout, _AbstractVBoxLayout, _Widget, metaclass=_BaseWidg
                 widget.setMinimumWidth(self._width)
                 widget.setMaximumWidth(self._width)
             self.addWidget(widget)
-
-    def _add_stretch(self, amount=1):
-        self.addStretch(amount)
 
 
 class _GridLayout(QGridLayout, _AbstractGridLayout, _Widget, metaclass=_BaseWidget):
@@ -740,29 +719,12 @@ class _AppWindow(_AbstractAppWindow, _MNEMainWindow, _Widget, metaclass=_BaseWid
         self._set_theme()
         self.setLocale(QLocale(QLocale.Language.English))
         self.signal_close.connect(self._clean)
-        self._before_close_callbacks = list()
-        self._after_close_callbacks = list()
 
         # patch closeEvent
         def closeEvent(event):
-            # functions to call before closing
-            accept_close_event = True
-            for callback in self._before_close_callbacks:
-                ret = callback()
-                # check if one of the callbacks ignores the close event
-                if isinstance(ret, bool) and not ret:
-                    accept_close_event = False
-
-            if accept_close_event:
-                self.signal_close.emit()
-                self._clean()
-                event.accept()
-            else:
-                event.ignore()
-
-            # functions to call after closing
-            for callback in self._after_close_callbacks:
-                callback()
+            self.signal_close.emit()
+            self._clean()
+            event.accept()
 
         self.closeEvent = closeEvent
 
@@ -771,32 +733,8 @@ class _AppWindow(_AbstractAppWindow, _MNEMainWindow, _Widget, metaclass=_BaseWid
         central_widget.setLayout(_get_layout(central_layout))
         self.setCentralWidget(central_widget)
 
-    def _get_dpi(self):
-        return self.windowHandle().screen().logicalDotsPerInch()
-
     def _get_size(self):
         return (self.width(), self.height())
-
-    def _get_cursor(self):
-        return self.cursor()
-
-    def _set_cursor(self, cursor):
-        self.setCursor(cursor)
-
-    def _new_cursor(self, name):
-        return QCursor(getattr(Qt, name))
-
-    def _close_connect(self, callback, *, after=True):
-        if after:
-            self._after_close_callbacks.append(callback)
-        else:
-            self._before_close_callbacks.append(callback)
-
-    def _close_disconnect(self, after=True):
-        if after:
-            self._after_close_callbacks.clear()
-        else:
-            self._before_close_callbacks.clear()
 
     def _clean(self):
         self._app = None


### PR DESCRIPTION
Working on https://github.com/mne-tools/mne-python/pull/14080 I had a quick look at the notebook code and realized there's stuff in there we probably never use, and thinking back I we added it to be complete and future-compatible... but that's not all that useful if we don't ever actually test and use it (these could be totally broken and have been sitting unused for 3+ years). I went through and found (with the help of Fable 5) the stuff we don't use and removed it, with an eye toward maintainability and maybe someday tackling https://github.com/mne-tools/mne-python/issues/11990 as well and relying on them to have anything we do actually want to use going forward.

@wmvanvliet assuming you don't use this stuff in your Xfit refactor (and based on a quick look I don't think any of it is), this should be good to merge assuming it comes back green!