### PR TITLE
Fix backwards-incompatible changes to Brain.add_annotation

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -2124,6 +2124,87 @@ def _read_annot_cands(dir_name, raise_error=True):
     return cands
 
 
+def _read_annot(fname):
+    """Read a Freesurfer annotation from a .annot file.
+
+    Note : Copied from PySurfer
+
+    Parameters
+    ----------
+    fname : str
+        Path to annotation file
+
+    Returns
+    -------
+    annot : numpy array, shape=(n_verts)
+        Annotation id at each vertex
+    ctab : numpy array, shape=(n_entries, 5)
+        RGBA + label id colortable array
+    names : list of str
+        List of region names as stored in the annot file
+
+    """
+    if not op.isfile(fname):
+        dir_name = op.split(fname)[0]
+        cands = _read_annot_cands(dir_name)
+        if len(cands) == 0:
+            raise OSError(
+                f"No such file {fname}, no candidate parcellations found in directory"
+            )
+        else:
+            raise OSError(
+                f"No such file {fname}, candidate parcellations in "
+                "that directory:\n" + "\n".join(cands)
+            )
+    with open(fname, "rb") as fid:
+        n_verts = np.fromfile(fid, ">i4", 1)[0]
+        data = np.fromfile(fid, ">i4", n_verts * 2).reshape(n_verts, 2)
+        annot = data[data[:, 0], 1]
+        ctab_exists = np.fromfile(fid, ">i4", 1)[0]
+        if not ctab_exists:
+            raise Exception("Color table not found in annotation file")
+        n_entries = np.fromfile(fid, ">i4", 1)[0]
+        if n_entries > 0:
+            length = np.fromfile(fid, ">i4", 1)[0]
+            np.fromfile(fid, ">c", length)  # discard orig_tab
+
+            names = list()
+            ctab = np.zeros((n_entries, 5), np.int64)
+            for i in range(n_entries):
+                name_length = np.fromfile(fid, ">i4", 1)[0]
+                name = np.fromfile(fid, f"|S{name_length}", 1)[0]
+                names.append(name)
+                ctab[i, :4] = np.fromfile(fid, ">i4", 4)
+                ctab[i, 4] = (
+                    ctab[i, 0]
+                    + ctab[i, 1] * (2**8)
+                    + ctab[i, 2] * (2**16)
+                    + ctab[i, 3] * (2**24)
+                )
+        else:
+            ctab_version = -n_entries
+            if ctab_version != 2:
+                raise Exception("Color table version not supported")
+            n_entries = np.fromfile(fid, ">i4", 1)[0]
+            ctab = np.zeros((n_entries, 5), np.int64)
+            length = np.fromfile(fid, ">i4", 1)[0]
+            np.fromfile(fid, f"|S{length}", 1)  # Orig table path
+            entries_to_read = np.fromfile(fid, ">i4", 1)[0]
+            names = list()
+            for i in range(entries_to_read):
+                np.fromfile(fid, ">i4", 1)  # Structure
+                name_length = np.fromfile(fid, ">i4", 1)[0]
+                name = np.fromfile(fid, f"|S{name_length}", 1)[0]
+                names.append(name)
+                ctab[i, :4] = np.fromfile(fid, ">i4", 4)
+                ctab[i, 4] = ctab[i, 0] + ctab[i, 1] * (2**8) + ctab[i, 2] * (2**16)
+
+        # convert to more common alpha value
+        ctab[:, 3] = 255 - ctab[:, 3]
+
+    return annot, ctab, names
+
+
 def _get_annot_fname(annot_fname, subject, hemi, parc, subjects_dir):
     """Get the .annot filenames and hemispheres."""
     if annot_fname is not None:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -46,6 +46,7 @@ from ...transforms import (
 from ...utils import (
     Bunch,
     _auto_weakref,
+    _check_fname,
     _check_option,
     _ensure_int,
     _path_like,
@@ -3110,7 +3111,12 @@ class Brain:
 
             .. versionadded:: 1.13
         """
-        if not _path_like(annot) and len(annot) == len(hemi) and len(annot[0]) == 2:
+
+        from ...label import read_labels_from_annot
+
+        if (isinstance(annot, tuple) and isinstance(annot[0], np.ndarray)) or (
+            isinstance(annot, (tuple, list)) and isinstance(annot[0], tuple)
+        ):
             # Deprecated old style of passing a (labels, cmap) pair per hemisphere.
             # Shortcut to old code that can be removed in version 1.14.
             warn(
@@ -3126,8 +3132,6 @@ class Brain:
                 remove_existing=remove_existing,
                 color=color,
             )
-
-        from ...label import read_labels_from_annot
 
         _validate_type(annot, ("path-like", str, list), "annot")
 
@@ -3209,7 +3213,8 @@ class Brain:
                     )
         self._renderer._update()
 
-    # DEPRECATED: Can be removed in version 1.14
+    # DEPRECATED: Can be removed in version 1.14. Also remove _read_annot from
+    # mne/labels.py.
     def _old_add_annotation(
         self, annot, borders=True, alpha=1, hemi=None, remove_existing=True, color=None
     ):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3290,7 +3290,7 @@ class Brain:
 
             ctable = cmap.astype(np.float64)
             for _ in self._iter_views(hemi):
-                mesh = self._layered_meshes[hemi]
+                mesh = self.layered_meshes[hemi]
                 mesh.add_overlay(
                     scalars=ids,
                     colormap=ctable,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3079,27 +3079,27 @@ class Brain:
         color=None,
         hover=True,
     ):
-        """Add an annotation file.
+        """Add an annotation (i.e. an atlas of many labels) to the brain figure.
 
         Parameters
         ----------
-        annot : str | list of Label | tuple
-            Either path to annotation file or annotation name. Alternatively,
-            a list of :class:`mne.Label` objects. Deprecated alternative: the annotation
-            can be specified as a ``(labels, ctab)`` tuple per hemisphere, i.e.
-            ``annot=(labels, ctab)`` for a single hemisphere or ``annot=((lh_labels,
-            lh_ctab), (rh_labels, rh_ctab))`` for both hemispheres. ``labels`` and
-            ``ctab`` should be arrays as returned by
-            :func:`nibabel.freesurfer.io.read_annot`.
+        annot : path-like | str | list of Label
+            Either path to annotation file, an annotation name, or a list of
+            :class:`mne.Label` objects.
+
+            DEPRECATED: The annotation can be specified as a ``(labels, ctab)`` tuple
+            per hemisphere, i.e. `annot=(labels, ctab)`` for a single hemisphere or
+            ``annot=((lh_labels, lh_ctab), (rh_labels, rh_ctab))`` for both hemispheres.
+
+            .. versionadded:: 1.13
+               The ability to supply a list of :class:`~mne.Label` objects.
         borders : bool | int
             Show only label borders. If int, specify the number of steps
             (away from the true border) along the cortical mesh to include
             as part of the border definition.
         %(alpha)s Default is 1.
         hemi : str | None
-            If None, it is assumed to belong to the hemisphere being
-            shown. If two hemispheres are being shown, data must exist
-            for both hemispheres.
+            Optionally restrict the annotation to the given hemisphere.
         remove_existing : bool
             If True (default), remove old annotations.
         color : matplotlib-style color code
@@ -3110,73 +3110,64 @@ class Brain:
 
             .. versionadded:: 1.13
         """
-        from ...label import Label, read_labels_from_annot
+        if not _path_like(annot) and len(annot) == len(hemi) and len(annot[0]) == 2:
+            # Deprecated old style of passing a (labels, cmap) pair per hemisphere.
+            # Shortcut to old code that can be removed in version 1.14.
+            warn(
+                "Passing the annotation as a `(label, cmap)` tuple is deprecated and "
+                "will be removed in MNE-Python version 1.14.",
+                FutureWarning,
+            )
+            return self._old_add_annotation(
+                annot,
+                borders=borders,
+                alpha=alpha,
+                hemi=hemi,
+                remove_existing=remove_existing,
+                color=color,
+            )
+
+        from ...label import read_labels_from_annot
+
+        _validate_type(annot, ("path-like", str, list), "annot")
 
         hemis = self._check_hemis(hemi)
         kwargs = dict()
 
         for hemi_idx, hemi in enumerate(hemis):
-            if not _path_like(annot) and len(annot[hemi_idx]) == 2:
-                # Old-style labels + cmap combination (deprecated)
-                ids, cmap = annot[hemi_idx]
-
-                # Set label ids sensibly
-                order = np.argsort(cmap[:, -1])
-                cmap = cmap[order]
-                cmap = np.insert(cmap, 0, np.zeros(5), axis=0)
-                ids = np.searchsorted(cmap[:, -1], ids) - 1
-                cmap = cmap[:, :4] / 255
-
-                n_labels = len(cmap)
-                name = "annotation"
-                self._annots[hemi].append(
-                    dict(name=name, labels=None, ids=ids, centroids=None)
-                )
-                hover = False  # hover behavior not supported in this case
-                warn(
-                    "Passing a tuple as the `annot` parameter is deprecated and will "
-                    "be removed in version 1.14. Instead, use a list of mne.Label "
-                    "objects as returned by mne.read_labels_from_annot.",
-                    FutureWarning,
-                )
-            else:
-                if _path_like(annot):
-                    if os.path.isfile(annot):
-                        kwargs["annot_fname"] = annot
-                    else:
-                        kwargs["parc"] = annot
-                    labels = read_labels_from_annot(
-                        self._subject,
-                        hemi=hemi,
-                        subjects_dir=self._subjects_dir,
-                        **kwargs,
-                    )
-                    name = annot
-                elif isinstance(annot[0], Label):
-                    labels = [label for label in annot if label.hemi == hemi]
-                    name = "annotation"  # placeholder name for the annotation
+            if _path_like(annot):
+                if os.path.isfile(annot):
+                    kwargs["annot_fname"] = annot
                 else:
-                    raise TypeError(
-                        f"Invalid type for `annot` parameter: {type(annot)}"
-                    )
-                n_labels = len(labels)
-                ids = -1 * np.ones(self.geo[hemi].coords.shape[0], dtype=int)
-                cmap = np.zeros((len(labels) + 1, 4))
-                cmap[:, 3] = 1
-                cmap[0] = np.array(self._brain_color)
-                cmap[0, 3] = 0.0
-                centroids = np.zeros((len(labels) + 1, 3))
-                for li, label in enumerate(labels):
-                    ids[label.vertices] = li  # will have one added later
-                    cmap[li + 1] = label.color
-                    label.values[:] = 1
-                    centroids[li] = self.geo[hemi].coords[
-                        label.center_of_mass(subjects_dir=self._subjects_dir)
-                    ]
-                self._annots[hemi].append(
-                    dict(name=name, labels=labels, ids=ids, centroids=centroids)
+                    kwargs["parc"] = annot
+                labels = read_labels_from_annot(
+                    self._subject,
+                    hemi=hemi,
+                    subjects_dir=self._subjects_dir,
+                    **kwargs,
                 )
-                del labels
+                name = annot
+            else:
+                labels = [label for label in annot if label.hemi == hemi]
+                name = "annotation"  # placeholder name for the annotation
+            n_labels = len(labels)
+            ids = -1 * np.ones(self.geo[hemi].coords.shape[0], dtype=int)
+            cmap = np.zeros((len(labels) + 1, 4))
+            cmap[:, 3] = 1
+            cmap[0] = np.array(self._brain_color)
+            cmap[0, 3] = 0.0
+            centroids = np.zeros((len(labels) + 1, 3))
+            for li, label in enumerate(labels):
+                ids[label.vertices] = li  # will have one added later
+                cmap[li + 1] = label.color
+                label.values[:] = 1
+                centroids[li] = self.geo[hemi].coords[
+                    label.center_of_mass(subjects_dir=self._subjects_dir)
+                ]
+            self._annots[hemi].append(
+                dict(name=name, labels=labels, ids=ids, centroids=centroids)
+            )
+            del labels
 
             # Maybe zero-out the non-border vertices
             scalars = ids + 1  # make a copy and reindex
@@ -3216,6 +3207,98 @@ class Brain:
                         reset_camera=False,
                         render=False,
                     )
+        self._renderer._update()
+
+    # DEPRECATED: Can be removed in version 1.14
+    def _old_add_annotation(
+        self, annot, borders=True, alpha=1, hemi=None, remove_existing=True, color=None
+    ):
+        from ...label import _read_annot
+
+        hemis = self._check_hemis(hemi)
+
+        # Figure out where the data is coming from
+        if _path_like(annot):
+            if os.path.isfile(annot):
+                filepath = _check_fname(annot, overwrite="read")
+                file_hemi, annot = filepath.name.split(".", 1)
+                if len(hemis) > 1:
+                    if file_hemi == "lh":
+                        filepaths = [filepath, filepath.parent / ("rh." + annot)]
+                    elif file_hemi == "rh":
+                        filepaths = [filepath.parent / ("lh." + annot), filepath]
+                    else:
+                        raise RuntimeError(
+                            "To add both hemispheres simultaneously, filename must "
+                            'begin with "lh." or "rh."'
+                        )
+                else:
+                    filepaths = [filepath]
+            else:
+                filepaths = []
+                for hemi in hemis:
+                    filepath = op.join(
+                        self._subjects_dir,
+                        self._subject,
+                        "label",
+                        ".".join([hemi, annot, "annot"]),
+                    )
+                    if not os.path.exists(filepath):
+                        raise ValueError(f"Annotation file {filepath} does not exist")
+                    filepaths += [filepath]
+            annots = []
+            for hemi, filepath in zip(hemis, filepaths):
+                # Read in the data
+                labels, cmap, _ = _read_annot(filepath)
+                annots.append((labels, cmap))
+        else:
+            annots = [annot] if len(hemis) == 1 else annot
+            annot = "annotation"
+
+        for hemi, (labels, cmap) in zip(hemis, annots):
+            # Maybe zero-out the non-border vertices
+            self._to_borders(labels, hemi, borders)
+
+            # Handle null labels properly
+            cmap[:, 3] = 255
+            bgcolor = np.round(np.array(self._brain_color) * 255).astype(int)
+            bgcolor[-1] = 0
+            cmap[cmap[:, 4] < 0, 4] += 2**24  # wrap to positive
+            cmap[cmap[:, 4] <= 0, :4] = bgcolor
+            if np.any(labels == 0) and not np.any(cmap[:, -1] <= 0):
+                cmap = np.vstack((cmap, np.concatenate([bgcolor, [0]])))
+
+            # Set label ids sensibly
+            order = np.argsort(cmap[:, -1])
+            cmap = cmap[order]
+            ids = np.searchsorted(cmap[:, -1], labels)
+            cmap = cmap[:, :4]
+
+            #  Set the alpha level
+            alpha_vec = cmap[:, 3]
+            alpha_vec[alpha_vec > 0] = alpha * 255
+
+            # Override the cmap when a single color is used
+            if color is not None:
+                rgb = np.round(np.multiply(_to_rgb(color), 255))
+                cmap[:, :3] = rgb.astype(cmap.dtype)
+
+            ctable = cmap.astype(np.float64)
+            for _ in self._iter_views(hemi):
+                mesh = self._layered_meshes[hemi]
+                mesh.add_overlay(
+                    scalars=ids,
+                    colormap=ctable,
+                    rng=[np.min(ids), np.max(ids)],
+                    opacity=alpha,
+                    name=annot,
+                )
+                self._annots[hemi].append(annot)
+                if not self.time_viewer or self.traces_mode == "vertex":
+                    self._renderer._set_colormap_range(
+                        mesh._actor, cmap.astype(np.uint8), None
+                    )
+
         self._renderer._update()
 
     def _create_caption(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -48,6 +48,7 @@ from ...utils import (
     _auto_weakref,
     _check_option,
     _ensure_int,
+    _path_like,
     _ReuseCycle,
     _to_rgb,
     _validate_type,
@@ -3082,8 +3083,14 @@ class Brain:
 
         Parameters
         ----------
-        annot : str
-            Either path to annotation file or annotation name.
+        annot : str | list of Label | tuple
+            Either path to annotation file or annotation name. Alternatively,
+            a list of :class:`mne.Label` objects. Deprecated alternative: the annotation
+            can be specified as a ``(labels, ctab)`` tuple per hemisphere, i.e.
+            ``annot=(labels, ctab)`` for a single hemisphere or ``annot=((lh_labels,
+            lh_ctab), (rh_labels, rh_ctab))`` for both hemispheres. ``labels`` and
+            ``ctab`` should be arrays as returned by
+            :func:`nibabel.freesurfer.io.read_annot`.
         borders : bool | int
             Show only label borders. If int, specify the number of steps
             (away from the true border) along the cortical mesh to include
@@ -3103,37 +3110,73 @@ class Brain:
 
             .. versionadded:: 1.13
         """
-        from ...label import read_labels_from_annot
+        from ...label import Label, read_labels_from_annot
 
         hemis = self._check_hemis(hemi)
         kwargs = dict()
-        if os.path.isfile(annot):
-            kwargs["annot_fname"] = annot
-        else:
-            kwargs["parc"] = annot
 
-        for hemi in hemis:
-            labels = read_labels_from_annot(
-                self._subject, hemi=hemi, subjects_dir=self._subjects_dir, **kwargs
-            )
-            n_labels = len(labels)
-            ids = np.zeros(self.geo[hemi].coords.shape[0], dtype=int)
-            cmap = np.zeros((len(labels) + 1, 4))
-            cmap[:, 3] = 1
-            cmap[0] = np.array(self._brain_color)
-            cmap[0, 3] = 0.0
-            centroids = np.zeros((len(labels) + 1, 3))
-            for li, label in enumerate(labels):
-                ids[label.vertices] = li  # will have one added later
-                cmap[li + 1] = label.color
-                label.values[:] = 1
-                centroids[li] = self.geo[hemi].coords[
-                    label.center_of_mass(subjects_dir=self._subjects_dir)
-                ]
-            self._annots[hemi].append(
-                dict(name=annot, labels=labels, ids=ids, centroids=centroids)
-            )
-            del labels
+        for hemi_idx, hemi in enumerate(hemis):
+            if not _path_like(annot) and len(annot[hemi_idx]) == 2:
+                # Old-style labels + cmap combination (deprecated)
+                ids, cmap = annot[hemi_idx]
+
+                # Set label ids sensibly
+                order = np.argsort(cmap[:, -1])
+                cmap = cmap[order]
+                cmap = np.insert(cmap, 0, np.zeros(5), axis=0)
+                ids = np.searchsorted(cmap[:, -1], ids) - 1
+                cmap = cmap[:, :4] / 255
+
+                n_labels = len(cmap)
+                name = "annotation"
+                self._annots[hemi].append(
+                    dict(name=name, labels=None, ids=ids, centroids=None)
+                )
+                hover = False  # hover behavior not supported in this case
+                warn(
+                    "Passing a tuple as the `annot` parameter is deprecated and will "
+                    "be removed in version 1.14. Instead, use a list of mne.Label "
+                    "objects as returned by mne.read_annotations.",
+                    FutureWarning,
+                )
+            else:
+                if _path_like(annot):
+                    if os.path.isfile(annot):
+                        kwargs["annot_fname"] = annot
+                    else:
+                        kwargs["parc"] = annot
+                    labels = read_labels_from_annot(
+                        self._subject,
+                        hemi=hemi,
+                        subjects_dir=self._subjects_dir,
+                        **kwargs,
+                    )
+                    name = annot
+                elif isinstance(annot[0], Label):
+                    labels = [label for label in annot if label.hemi == hemi]
+                    name = "annotation"  # placeholder name for the annotation
+                else:
+                    raise TypeError(
+                        f"Invalid type for `annot` parameter: {type(annot)}"
+                    )
+                n_labels = len(labels)
+                ids = -1 * np.ones(self.geo[hemi].coords.shape[0], dtype=int)
+                cmap = np.zeros((len(labels) + 1, 4))
+                cmap[:, 3] = 1
+                cmap[0] = np.array(self._brain_color)
+                cmap[0, 3] = 0.0
+                centroids = np.zeros((len(labels) + 1, 3))
+                for li, label in enumerate(labels):
+                    ids[label.vertices] = li  # will have one added later
+                    cmap[li + 1] = label.color
+                    label.values[:] = 1
+                    centroids[li] = self.geo[hemi].coords[
+                        label.center_of_mass(subjects_dir=self._subjects_dir)
+                    ]
+                self._annots[hemi].append(
+                    dict(name=name, labels=labels, ids=ids, centroids=centroids)
+                )
+                del labels
 
             # Maybe zero-out the non-border vertices
             scalars = ids + 1  # make a copy and reindex
@@ -3151,7 +3194,7 @@ class Brain:
                     colormap=ctable * 255,
                     rng=[0, n_labels],
                     opacity=alpha,
-                    name=annot,
+                    name=name,
                 )
 
         if hover:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3136,7 +3136,7 @@ class Brain:
                 warn(
                     "Passing a tuple as the `annot` parameter is deprecated and will "
                     "be removed in version 1.14. Instead, use a list of mne.Label "
-                    "objects as returned by mne.read_annotations.",
+                    "objects as returned by mne.read_labels_from_annot.",
                     FutureWarning,
                 )
             else:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3089,7 +3089,7 @@ class Brain:
             :class:`mne.Label` objects.
 
             DEPRECATED: The annotation can be specified as a ``(labels, ctab)`` tuple
-            per hemisphere, i.e. `annot=(labels, ctab)`` for a single hemisphere or
+            per hemisphere, i.e. ``annot=(labels, ctab)`` for a single hemisphere or
             ``annot=((lh_labels, lh_ctab), (rh_labels, rh_ctab))`` for both hemispheres.
 
             .. versionadded:: 1.13
@@ -3123,7 +3123,7 @@ class Brain:
                 "will be removed in MNE-Python version 1.14.",
                 FutureWarning,
             )
-            return self._old_add_annotation(
+            self._old_add_annotation(
                 annot,
                 borders=borders,
                 alpha=alpha,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3111,7 +3111,6 @@ class Brain:
 
             .. versionadded:: 1.13
         """
-
         from ...label import read_labels_from_annot
 
         if (isinstance(annot, tuple) and isinstance(annot[0], np.ndarray)) or (

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3131,6 +3131,7 @@ class Brain:
                 remove_existing=remove_existing,
                 color=color,
             )
+            return
 
         _validate_type(annot, ("path-like", str, list), "annot")
 
@@ -3154,7 +3155,7 @@ class Brain:
                 labels = [label for label in annot if label.hemi == hemi]
                 name = "annotation"  # placeholder name for the annotation
             n_labels = len(labels)
-            ids = -1 * np.ones(self.geo[hemi].coords.shape[0], dtype=int)
+            ids = np.full(self.geo[hemi].coords.shape[0], -1, dtype=int)
             cmap = np.zeros((len(labels) + 1, 4))
             cmap[:, 3] = 1
             cmap[0] = np.array(self._brain_color)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -52,6 +52,7 @@ fname_raw_testing = sample_dir / "sample_audvis_trunc_raw.fif"
 fname_trans = sample_dir / "sample_audvis_trunc-trans.fif"
 fname_stc = sample_dir / "sample_audvis_trunc-meg"
 fname_label = sample_dir / "labels" / "Vis-lh.label"
+fname_label_rh = sample_dir / "labels" / "Vis-rh.label"
 fname_cov = sample_dir / "sample_audvis_trunc-cov.fif"
 fname_evoked = sample_dir / "sample_audvis_trunc-ave.fif"
 fname_fwd = sample_dir / "sample_audvis_trunc-meg-eeg-oct-4-fwd.fif"
@@ -590,10 +591,11 @@ def test_add_annotation(renderer_interactive_pyvistaqt, brain_gc):
     annots = [
         "aparc",
         subjects_dir / "fsaverage" / "label" / "lh.PALS_B12_Lobes.annot",
+        [read_label(fname_label, "fsaverage"), read_label(fname_label_rh, "fsaverage")],
     ]
-    borders = [True, 2]
-    alphas = [1, 0.5]
-    colors = [None, "r"]
+    borders = [True, 1, 2]
+    alphas = [1, 0.5, 0]
+    colors = [None, "r", "b"]
     size = (100, 100)
     brain = Brain(
         subject="fsaverage",
@@ -655,7 +657,7 @@ def test_add_annotation(renderer_interactive_pyvistaqt, brain_gc):
         subjects_dir=subjects_dir,
     )
     for a, b, p, color in zip(annots, borders, alphas, colors):
-        brain.add_annotation(str(a), b, p, color=color)
+        brain.add_annotation(a, b, p, color=color)
     brain.close()
 
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -52,7 +52,7 @@ fname_raw_testing = sample_dir / "sample_audvis_trunc_raw.fif"
 fname_trans = sample_dir / "sample_audvis_trunc-trans.fif"
 fname_stc = sample_dir / "sample_audvis_trunc-meg"
 fname_label = sample_dir / "labels" / "Vis-lh.label"
-fname_label_rh = sample_dir / "labels" / "Vis-rh.label"
+fname_label2 = sample_dir / "labels" / "Vis-rh.label"
 fname_cov = sample_dir / "sample_audvis_trunc-cov.fif"
 fname_evoked = sample_dir / "sample_audvis_trunc-ave.fif"
 fname_fwd = sample_dir / "sample_audvis_trunc-meg-eeg-oct-4-fwd.fif"
@@ -591,7 +591,7 @@ def test_add_annotation(renderer_interactive_pyvistaqt, brain_gc):
     annots = [
         "aparc",
         subjects_dir / "fsaverage" / "label" / "lh.PALS_B12_Lobes.annot",
-        [read_label(fname_label, "fsaverage"), read_label(fname_label_rh, "fsaverage")],
+        [read_label(fname_label, "fsaverage"), read_label(fname_label2, "fsaverage")],
     ]
     borders = [True, 1, 2]
     alphas = [1, 0.5, 0]


### PR DESCRIPTION
Pr #13931 dropped support for providing custom parcellations to `Brain.add_annotation`. Users may rely on this and so does MNE-RSA. We cannot do this without at least a deprecation cycle. 

This PR puts back the awkward option of providing a tuple `(labels, cmap)`. I understand this was probably dropped because no labels nor centroids are available when using this method, so hover behavior cannot work. Hence I added a deprecation warning to it. We can remove this option in due time.

Since it would be nice to be able to draw annotations not read from a file, but generated by some code, I added the ability to pass a list of `Label` objects. This does support centroids and labels and hence hover behavior.

No AI was used in the creation of this PR.