### PR TITLE
Speed up 3D window creation and sizing, simplify class inheritance

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -8,6 +8,7 @@ Actual implementation of _Renderer and _Projection classes.
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+import functools
 import os
 import platform
 import re
@@ -1402,6 +1403,9 @@ def _disabled_depth_peeling():
         depth_peeling["enabled"] = depth_peeling_enabled
 
 
+_GPU_REPORT = None
+
+
 def _is_osmesa(plotter):
     # MESA (could use GPUInfo / _get_gpu_info here, but it takes
     # > 700 ms to make a new window + report capabilities!)
@@ -1411,7 +1415,19 @@ def _is_osmesa(plotter):
         return False
     if os.getenv("MNE_IS_OSMESA", "").lower() == "true":
         return True
-    gpu_info_full = plotter.ren_win.ReportCapabilities()
+    global _GPU_REPORT
+    if _GPU_REPORT is None:
+        # Ask at most once per process: the GL driver cannot change while the
+        # process is alive, every report costs ~13 ms (and a GL context
+        # realization the first time), and asking VTK has segfaulted before.
+        # This cannot be a plotter-keyed cache: each figure is a new plotter,
+        # so it would miss every time and keep every plotter alive forever.
+        _GPU_REPORT = plotter.ren_win.ReportCapabilities()
+    return _is_osmesa_from_report(_GPU_REPORT)
+
+
+@functools.cache
+def _is_osmesa_from_report(gpu_info_full):
     gpu_info = re.findall(
         "OpenGL (?:version|renderer) string:(.+)\n",
         gpu_info_full,

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -150,9 +150,14 @@ class _BaseWidget(type(QWidget), type(_AbstractWidget)):
     pass
 
 
-# The inheritance has to be in this order for the _Widget and the opposite for
-# the widgets (e.g. _PushButton) that inherit from it, not sure why
-class _Widget(_AbstractWidget, QWidget, metaclass=_BaseWidget):
+# Every concrete widget below lists its real Qt class LAST in its bases and
+# calls its __init__ first; _Widget itself deliberately does not inherit a Qt
+# class (that would create a diamond). Exception: _Canvas keeps its Qt class
+# first, since unlike _Widget's family, _AbstractCanvas defines real Qt
+# method names (update/show/close) that must not be shadowed. Full writeup of
+# the underlying SIP vs. Shiboken __init__/MRO rules:
+# https://github.com/spyder-ide/spyder/pull/25422
+class _Widget(_AbstractWidget, metaclass=_BaseWidget):
     tooltip = None
     _to_qt = dict(
         escape=Qt.Key_Escape,
@@ -166,8 +171,10 @@ class _Widget(_AbstractWidget, QWidget, metaclass=_BaseWidget):
     _from_qt = {v: k for k, v in _to_qt.items()}
 
     def __init__(self):
+        # Concrete widgets must inherit a real Qt class (QWidget or QLayout)
+        # themselves, see the class comment above.
+        assert isinstance(self, (QWidget, QLayout)), type(self)
         _AbstractWidget.__init__()
-        # QWidget.__init__(self)
 
     def _show(self):
         self.show()
@@ -231,11 +238,11 @@ class _Widget(_AbstractWidget, QWidget, metaclass=_BaseWidget):
             self.setMaximumHeight(height)
 
 
-class _Label(QLabel, _AbstractLabel, _Widget, metaclass=_BaseWidget):
+class _Label(_AbstractLabel, _Widget, QLabel, metaclass=_BaseWidget):
     def __init__(self, value, center=False, selectable=False):
+        QLabel.__init__(self)
         _AbstractLabel.__init__(value, center=center, selectable=selectable)
         _Widget.__init__(self)
-        QLabel.__init__(self)
         self.setText(value)
         if center:
             self.setAlignment(Qt.AlignCenter)
@@ -244,11 +251,11 @@ class _Label(QLabel, _AbstractLabel, _Widget, metaclass=_BaseWidget):
             self.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
 
-class _Text(QLineEdit, _AbstractText, _Widget, metaclass=_BaseWidget):
+class _Text(_AbstractText, _Widget, QLineEdit, metaclass=_BaseWidget):
     def __init__(self, value=None, placeholder=None, callback=None):
+        QLineEdit.__init__(self, value)
         _AbstractText.__init__(value=value, placeholder=placeholder, callback=callback)
         _Widget.__init__(self)
-        QLineEdit.__init__(self, value)
         self.setPlaceholderText(placeholder)
         if callback is not None:
             self.textChanged.connect(callback)
@@ -257,12 +264,11 @@ class _Text(QLineEdit, _AbstractText, _Widget, metaclass=_BaseWidget):
         self.setText(value)
 
 
-class _Button(QPushButton, _AbstractButton, _Widget, metaclass=_BaseWidget):
+class _Button(_AbstractButton, _Widget, QPushButton, metaclass=_BaseWidget):
     def __init__(self, value, callback, icon=None):
+        QPushButton.__init__(self)
         _AbstractButton.__init__(value=value, callback=callback)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractButton):
-            QPushButton.__init__(self)
         self.setText(value)
         self.released.connect(callback)
         if icon:
@@ -272,14 +278,13 @@ class _Button(QPushButton, _AbstractButton, _Widget, metaclass=_BaseWidget):
         self.click()
 
 
-class _Slider(QSlider, _AbstractSlider, _Widget, metaclass=_BaseWidget):
+class _Slider(_AbstractSlider, _Widget, QSlider, metaclass=_BaseWidget):
     def __init__(self, value, rng, callback, horizontal=True):
+        QSlider.__init__(self, Qt.Horizontal if horizontal else Qt.Vertical)
         _AbstractSlider.__init__(
             value=value, rng=rng, callback=callback, horizontal=horizontal
         )
         _Widget.__init__(self)
-        with _disabled_init(_AbstractSlider):
-            QSlider.__init__(self, Qt.Horizontal if horizontal else Qt.Vertical)
         self.setMinimum(rng[0])
         self.setMaximum(rng[1])
         self.setValue(value)
@@ -292,11 +297,11 @@ class _Slider(QSlider, _AbstractSlider, _Widget, metaclass=_BaseWidget):
         return self.value()
 
 
-class _ProgressBar(QProgressBar, _AbstractProgressBar, _Widget, metaclass=_BaseWidget):
+class _ProgressBar(_AbstractProgressBar, _Widget, QProgressBar, metaclass=_BaseWidget):
     def __init__(self, count):
+        QProgressBar.__init__(self)
         _AbstractProgressBar.__init__(count=count)
         _Widget.__init__(self)
-        QProgressBar.__init__(self)
         self.setMaximum(count)
 
     def _increment(self):
@@ -306,12 +311,11 @@ class _ProgressBar(QProgressBar, _AbstractProgressBar, _Widget, metaclass=_BaseW
         return self.value()
 
 
-class _CheckBox(QCheckBox, _AbstractCheckBox, _Widget, metaclass=_BaseWidget):
+class _CheckBox(_AbstractCheckBox, _Widget, QCheckBox, metaclass=_BaseWidget):
     def __init__(self, value, callback):
+        QCheckBox.__init__(self)
         _AbstractCheckBox.__init__(value=value, callback=callback)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractCheckBox):
-            QCheckBox.__init__(self)
         self.setChecked(value)
         self.stateChanged.connect(lambda x: callback(bool(x)))
 
@@ -322,12 +326,11 @@ class _CheckBox(QCheckBox, _AbstractCheckBox, _Widget, metaclass=_BaseWidget):
         return self.checkState() != Qt.Unchecked
 
 
-class _SpinBox(QDoubleSpinBox, _AbstractSpinBox, _Widget, metaclass=_BaseWidget):
+class _SpinBox(_AbstractSpinBox, _Widget, QDoubleSpinBox, metaclass=_BaseWidget):
     def __init__(self, value, rng, callback, step=None):
+        QDoubleSpinBox.__init__(self)
         _AbstractSpinBox.__init__(value=value, rng=rng, callback=callback, step=step)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractSpinBox):
-            QDoubleSpinBox.__init__(self)
         self.setAlignment(Qt.AlignCenter)
         self.setMinimum(rng[0])
         self.setMaximum(rng[1])
@@ -346,12 +349,11 @@ class _SpinBox(QDoubleSpinBox, _AbstractSpinBox, _Widget, metaclass=_BaseWidget)
         return self.value()
 
 
-class _ComboBox(QComboBox, _AbstractComboBox, _Widget, metaclass=_BaseWidget):
+class _ComboBox(_AbstractComboBox, _Widget, QComboBox, metaclass=_BaseWidget):
     def __init__(self, value, items, callback):
+        QComboBox.__init__(self)
         _AbstractComboBox.__init__(value=value, items=items, callback=callback)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractComboBox):
-            QComboBox.__init__(self)
         self.addItems(items)
         self.setCurrentText(value)
         self.currentTextChanged.connect(callback)
@@ -364,12 +366,11 @@ class _ComboBox(QComboBox, _AbstractComboBox, _Widget, metaclass=_BaseWidget):
         return self.currentText()
 
 
-class _RadioButtons(QVBoxLayout, _AbstractRadioButtons, _Widget, metaclass=_BaseWidget):
+class _RadioButtons(_AbstractRadioButtons, _Widget, QVBoxLayout, metaclass=_BaseWidget):
     def __init__(self, value, items, callback):
+        QVBoxLayout.__init__(self)
         _AbstractRadioButtons.__init__(value=value, items=items, callback=callback)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractRadioButtons):
-            QVBoxLayout.__init__(self)
         self._button_group = QButtonGroup()
         self._button_group.setExclusive(True)
         for val in items:
@@ -389,19 +390,18 @@ class _RadioButtons(QVBoxLayout, _AbstractRadioButtons, _Widget, metaclass=_Base
         return self.checkedButton().text()
 
 
-class _GroupBox(QGroupBox, _AbstractGroupBox, _Widget, metaclass=_BaseWidget):
+class _GroupBox(_AbstractGroupBox, _Widget, QGroupBox, metaclass=_BaseWidget):
     def __init__(self, name, items):
+        QGroupBox.__init__(self, name)
         _AbstractGroupBox.__init__(name=name, items=items)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractGroupBox):
-            QGroupBox.__init__(self, name)
         self._layout = _VBoxLayout()
         for item in items:
             self._layout._add_widget(item)
         self.setLayout(self._layout)
 
 
-class _FileButton(_Button, _AbstractFileButton, _Widget, metaclass=_BaseWidget):
+class _FileButton(_AbstractFileButton, _Button, metaclass=_BaseWidget):
     def __init__(
         self,
         callback,
@@ -412,16 +412,6 @@ class _FileButton(_Button, _AbstractFileButton, _Widget, metaclass=_BaseWidget):
         icon="folder",
         window=None,
     ):
-        _AbstractFileButton.__init__(
-            callback=callback,
-            content_filter=content_filter,
-            initial_directory=initial_directory,
-            save=save,
-            is_directory=is_directory,
-            window=window,
-        )
-        _Widget.__init__(self)
-
         def fp_callback():
             if is_directory:
                 name = QFileDialog.getExistingDirectory(
@@ -442,14 +432,22 @@ class _FileButton(_Button, _AbstractFileButton, _Widget, metaclass=_BaseWidget):
             callback(name)
 
         _Button.__init__(self, "", callback=fp_callback, icon=icon)
+        _AbstractFileButton.__init__(
+            callback=callback,
+            content_filter=content_filter,
+            initial_directory=initial_directory,
+            save=save,
+            is_directory=is_directory,
+            window=window,
+        )
+        _Widget.__init__(self)
 
 
-class _PlayMenu(QVBoxLayout, _AbstractPlayMenu, _Widget, metaclass=_BaseWidget):
+class _PlayMenu(_AbstractPlayMenu, _Widget, QVBoxLayout, metaclass=_BaseWidget):
     def __init__(self, value, rng, callback):
+        QVBoxLayout.__init__(self)
         _AbstractPlayMenu.__init__(value=value, rng=rng, callback=callback)
         _Widget.__init__(self)
-        with _disabled_init(_AbstractPlayMenu):
-            QVBoxLayout.__init__(self)
         self._slider = QSlider(Qt.Horizontal)
         self._slider.setMinimum(rng[0])
         self._slider.setMaximum(rng[1])
@@ -512,7 +510,7 @@ class _PlayMenu(QVBoxLayout, _AbstractPlayMenu, _Widget, metaclass=_BaseWidget):
         self._slider.setValue(value)
 
 
-class _Popup(QMessageBox, _AbstractPopup, _Widget, metaclass=_BaseWidget):
+class _Popup(_AbstractPopup, _Widget, QMessageBox, metaclass=_BaseWidget):
     def __init__(
         self,
         title,
@@ -523,6 +521,7 @@ class _Popup(QMessageBox, _AbstractPopup, _Widget, metaclass=_BaseWidget):
         buttons=None,
         window=None,
     ):
+        QMessageBox.__init__(self, parent=window)
         _AbstractPopup.__init__(
             self,
             title=title,
@@ -534,8 +533,6 @@ class _Popup(QMessageBox, _AbstractPopup, _Widget, metaclass=_BaseWidget):
             window=window,
         )
         _Widget.__init__(self)
-        with _disabled_init(_AbstractPopup):
-            QMessageBox.__init__(self, parent=window)
         self.setWindowTitle(title)
         self.setText(text)
         # icon is one of _Dialog.supported_icon_names
@@ -574,11 +571,11 @@ class _ScrollArea(QScrollArea):
         self.setWidgetResizable(True)
 
 
-class _HBoxLayout(QHBoxLayout, _AbstractHBoxLayout, _Widget, metaclass=_BaseWidget):
+class _HBoxLayout(_AbstractHBoxLayout, _Widget, QHBoxLayout, metaclass=_BaseWidget):
     def __init__(self, height=None, scroll=None):
+        QHBoxLayout.__init__(self)
         _AbstractHBoxLayout.__init__(self, height=height, scroll=scroll)
         _Widget.__init__(self)
-        QHBoxLayout.__init__(self)
 
         if scroll is not None:
             self._scroll_widget = QWidget()
@@ -601,11 +598,11 @@ class _HBoxLayout(QHBoxLayout, _AbstractHBoxLayout, _Widget, metaclass=_BaseWidg
             self.addWidget(widget)
 
 
-class _VBoxLayout(QVBoxLayout, _AbstractVBoxLayout, _Widget, metaclass=_BaseWidget):
+class _VBoxLayout(_AbstractVBoxLayout, _Widget, QVBoxLayout, metaclass=_BaseWidget):
     def __init__(self, width=None, scroll=None):
+        QVBoxLayout.__init__(self)
         _AbstractVBoxLayout.__init__(self, width=width, scroll=scroll)
         _Widget.__init__(self)
-        QVBoxLayout.__init__(self)
 
         if scroll is not None:
             self._scroll_widget = QWidget()
@@ -628,11 +625,11 @@ class _VBoxLayout(QVBoxLayout, _AbstractVBoxLayout, _Widget, metaclass=_BaseWidg
             self.addWidget(widget)
 
 
-class _GridLayout(QGridLayout, _AbstractGridLayout, _Widget, metaclass=_BaseWidget):
+class _GridLayout(_AbstractGridLayout, _Widget, QGridLayout, metaclass=_BaseWidget):
     def __init__(self, height=None, width=None):
+        QGridLayout.__init__(self)
         _AbstractGridLayout.__init__(self)
         _Widget.__init__(self)
-        QGridLayout.__init__(self)
         if height:
             self.setMinimumHeight(height)
             self.setMaximumHeight(height)
@@ -653,6 +650,8 @@ class _BaseCanvas(type(FigureCanvas), type(_AbstractCanvas)):
 
 
 class _Canvas(FigureCanvas, _AbstractCanvas, metaclass=_BaseCanvas):
+    # FigureCanvas must stay first: _AbstractCanvas defines real Qt method
+    # names (update/show/close) that would otherwise shadow the real ones.
     def __init__(self, width, height, dpi):
         _AbstractCanvas.__init__(self, width=width, height=height, dpi=dpi)
         self.fig = Figure(figsize=(width, height), dpi=dpi)
@@ -675,29 +674,16 @@ class _Canvas(FigureCanvas, _AbstractCanvas, metaclass=_BaseCanvas):
 # Windows
 # -------
 
-# In theory we should be able to do this later (e.g., in _pyvista.py when
-# initializing), but at least on Qt6 this has to be done earlier. So let's do
-# it immediately upon instantiation of the QMainWindow class.
+
+# In theory we should be able to set the theme later (e.g., in
+# _window_initialize() below), but at least on Qt6 this has to be done
+# earlier. So let's do it immediately upon instantiation of the QMainWindow
+# class (see _AppWindow.__init__'s self._set_theme() call below).
 # TODO: This should eventually allow us to handle
 # https://github.com/mne-tools/mne-python/issues/9182
-
-
-# This is necessary to make PySide6 happy -- something weird with the
-# __init__ calling causes the _AbstractXYZ class __init__ to be called twice
-@contextmanager
-def _disabled_init(klass):
-    orig = klass.__init__
-    klass.__init__ = lambda *args, **kwargs: None
-    try:
-        yield
-    finally:
-        klass.__init__ = orig
-
-
 class _MNEMainWindow(MainWindow):
     def __init__(self, parent=None, title=None, size=None):
-        with _disabled_init(_Widget):
-            MainWindow.__init__(self, parent=parent, title=title, size=size)
+        MainWindow.__init__(self, parent=parent, title=title, size=size)
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         from . import renderer
@@ -706,11 +692,11 @@ class _MNEMainWindow(MainWindow):
             self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnBottomHint)
 
 
-class _AppWindow(_AbstractAppWindow, _MNEMainWindow, _Widget, metaclass=_BaseWidget):
+class _AppWindow(_AbstractAppWindow, _Widget, _MNEMainWindow, metaclass=_BaseWidget):
     def __init__(self, size=None, fullscreen=False):
         self._app = _init_mne_qtapp()
-        _AbstractAppWindow.__init__(self)
         _MNEMainWindow.__init__(self, size=size)
+        _AbstractAppWindow.__init__(self)
         _Widget.__init__(self)
 
         if fullscreen:
@@ -1454,6 +1440,11 @@ class _QtWindow(_AbstractWindow):
     def _window_initialize(self, *, window=None, central_layout=None, fullscreen=False):
         super()._window_initialize()
         self._interactor = self.figure.plotter.interactor
+        # zero the extra QFrame layout margins around the interactor as they otherwise
+        # make the interactor drift when _window_ensure_minimum_sizes ends
+        frame_layout = self._interactor.parentWidget().layout()
+        if frame_layout is not None:
+            frame_layout.setContentsMargins(0, 0, 0, 0)
         if window is None:
             self._window = self.figure.plotter.app_window
         else:
@@ -1584,9 +1575,6 @@ class _QtWindow(_AbstractWindow):
         # plotter.frame:      QFrame with QVBoxLayout with plotter.interactor as centralWidget  # noqa
         # plotter.ren_win:    vtkXOpenGLRenderWindow
         self._interactor.setMinimumSize(*sz)
-        # Lines like this are useful for debugging these issues:
-        # print('*' * 80)
-        # print(0, self._interactor.app_window.size().height(), self._interactor.size().height(), self._mpl_dock.widget().height(), self._mplcanvas.canvas.size().height())  # noqa
         if adjust_mpl:
             mpl_h = int(
                 round(
@@ -1599,29 +1587,24 @@ class _QtWindow(_AbstractWindow):
         try:
             yield  # show
         finally:
-            # 1. Process events
-            self._process_events()
-            self._process_events()
-            # 2. Get the window and interactor sizes that work
+            # 1. Settle the layout
+            self._window.ensurePolished()
+            _qt_activate_layouts(self._window, self._interactor)
+            # 2. Get the window size that works
             win_sz = self._window.size()
-            ren_sz = self._interactor.size()
-            # 3. Undo the min size setting and process events
+            # 3. Undo the min size setting and re-settle
             self._interactor.setMinimumSize(0, 0)
             if adjust_mpl:
                 self._mplcanvas.canvas.setMinimumSize(0, 0)
                 self._mpl_dock.widget().setMinimumSize(0, 0)
-            self._process_events()
-            self._process_events()
+            _qt_activate_layouts(self._window, self._interactor)
             # 4. Compute the extra height required for dock decorations and add
             win_h = win_sz.height()
             if adjust_mpl:
                 win_h += max(self._mpl_dock.widget().size().height() - mpl_h, 0)
-            # 5. Resize the window and interactor to the correct size
-            #    (not sure why, but this is required on macOS at least)
+            # 5. Resize the window to that size
             self._interactor.window_size = (win_sz.width(), win_h)
-            self._interactor.resize(ren_sz.width(), ren_sz.height())
-            self._process_events()
-            self._process_events()
+            _qt_activate_layouts(self._window, self._interactor)
 
     def _window_set_theme(self, theme=None):
         if theme is None:
@@ -1818,6 +1801,19 @@ class _Renderer(
         # here.
         self._process_events()
         _qt_raise_window(self.plotter.app_window)
+
+
+def _qt_activate_layouts(window, widget):
+    """Recompute the layouts between widget and window (inclusive), in place."""
+    # Qt only settles geometry when the posted LayoutRequest events are delivered,
+    # and every layout in a given chain has to be activated, not just the window's
+    processed = set()
+    while widget is not None and widget not in processed:
+        layout = widget.layout()
+        if layout is not None:
+            layout.activate()
+        processed.add(widget)
+        widget = widget.parentWidget()
 
 
 def _set_widget_tooltip(widget, tooltip):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -1590,8 +1590,9 @@ class _QtWindow(_AbstractWindow):
             # 1. Settle the layout
             self._window.ensurePolished()
             _qt_activate_layouts(self._window, self._interactor)
-            # 2. Get the window size that works
+            # 2. Get the window and interactor sizes that work
             win_sz = self._window.size()
+            ren_sz = self._interactor.size()
             # 3. Undo the min size setting and re-settle
             self._interactor.setMinimumSize(0, 0)
             if adjust_mpl:
@@ -1602,9 +1603,22 @@ class _QtWindow(_AbstractWindow):
             win_h = win_sz.height()
             if adjust_mpl:
                 win_h += max(self._mpl_dock.widget().size().height() - mpl_h, 0)
-            # 5. Resize the window to that size
+            # 5. Resize the window to the size that gave us ren_sz
             self._interactor.window_size = (win_sz.width(), win_h)
             _qt_activate_layouts(self._window, self._interactor)
+            # 6. Zeroing the frame's layout margins above avoids the interactor
+            #    drifting on most platforms, but not always (e.g. CI's macOS
+            #    runners), so nudge the window until the render area is back
+            #    to ren_sz as a safety net (usually converges in one pass).
+            for _ in range(3):
+                err_w = ren_sz.width() - self._interactor.width()
+                err_h = ren_sz.height() - self._interactor.height()
+                if not (err_w or err_h):
+                    break
+                self._window.resize(
+                    self._window.width() + err_w, self._window.height() + err_h
+                )
+                _qt_activate_layouts(self._window, self._interactor)
 
     def _window_set_theme(self, theme=None):
         if theme is None:

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -244,22 +244,35 @@ def test_set_3d_backend_bad(monkeypatch, tmp_path):
 def test_3d_warning(renderer_pyvistaqt, monkeypatch):
     """Test that warnings are emitted for old Mesa."""
     fig = renderer_pyvistaqt.create_3d_figure((800, 600))
-    from mne.viz.backends._pyvista import _is_osmesa
+    from mne.viz.backends import _pyvista
 
     plotter = fig.plotter
     pre = "OpenGL renderer string: "
     good = f"{pre}OpenGL 3.3 (Core Profile) Mesa 20.0.8 via llvmpipe (LLVM 10.0.0, 256 bits)\n"  # noqa
     bad = f"{pre}OpenGL 3.3 (Core Profile) Mesa 18.3.4 via llvmpipe (LLVM 7.0, 256 bits)\n"  # noqa
     monkeypatch.setattr(platform, "system", lambda: "Linux")  # avoid short-circuit
-    monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: good)
     monkeypatch.setenv("MNE_IS_OSMESA", "false")
-    assert _is_osmesa(plotter)
+
+    monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: good)
+    monkeypatch.setattr(_pyvista, "_GPU_REPORT", None)
+    assert _pyvista._is_osmesa(plotter)
     monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: bad)
+    monkeypatch.setattr(_pyvista, "_GPU_REPORT", None)
     with pytest.warns(RuntimeWarning, match=r"18\.3\.4 is too old"):
-        assert _is_osmesa(plotter)
-    non = f"{pre}OpenGL 4.1 Metal - 76.3 via Apple M1 Pro\n"
-    monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: non)
-    assert not _is_osmesa(plotter)
-    non = f"{pre}OpenGL 4.5 (Core Profile) Mesa 24.2.3-1ubuntu1 via NVE6\n"
-    monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: non)
-    assert not _is_osmesa(plotter)
+        assert _pyvista._is_osmesa(plotter)
+    monkeypatch.setattr(plotter.ren_win, "ReportCapabilities", lambda: good)
+    monkeypatch.setattr(_pyvista, "_GPU_REPORT", None)
+    monkeypatch.setattr(
+        plotter.ren_win,
+        "ReportCapabilities",
+        lambda: f"{pre}OpenGL 4.1 Metal - 76.3 via Apple M1 Pro\n",
+    )
+    monkeypatch.setattr(_pyvista, "_GPU_REPORT", None)
+    assert not _pyvista._is_osmesa(plotter)
+    monkeypatch.setattr(
+        plotter.ren_win,
+        "ReportCapabilities",
+        lambda: f"{pre}OpenGL 4.5 (Core Profile) Mesa 24.2.3-1ubuntu1 via NVE6\n",
+    )
+    monkeypatch.setattr(_pyvista, "_GPU_REPORT", None)
+    assert not _pyvista._is_osmesa(plotter)

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -26,7 +26,7 @@ python -m pip install $STD_ARGS pip setuptools packaging \
 	patsy pytz tzdata nibabel tqdm trx-python joblib numexpr \
 	"$MNE_QT_BACKEND!=6.9.1" \
 	py-cpuinfo blosc2 hatchling "formulaic>=1.1.0" \
-	scikit-learn
+	scikit-learn tables
 python -m pip uninstall -yq numpy
 echo "::endgroup::"
 echo "::group::Scientific Python Nightly Wheels"
@@ -36,13 +36,14 @@ python -m pip install $STD_ARGS --only-binary ":all:" \
 	"scipy>=1.18.0.dev0" \
 	"pandas>=3.1.0.dev0" \
 	"dipy>=1.12.0.dev0" \
-	"tables>=3.10.3.dev0" \
 	"pyarrow>=22.0.0.dev0" \
 	"matplotlib>=3.11.0.dev0" \
 	"statsmodels>=0.15.0.dev0" \
 	"h5py>=3.13.0"
 # https://github.com/scikit-learn/scikit-learn/issues/34458
 #	"scikit-learn>=1.9.dev0" \
+# https://github.com/PyTables/PyTables/issues/1338
+#	"tables>=3.10.3.dev0" \
 echo "::endgroup::"
 # No Numba because it forces an old NumPy version
 


### PR DESCRIPTION
I had to add all sorts of hacks a while ago (multiple `processEvents` calls in different places/stages of window init) to get our `stc.plot(size=(w, h))` to actually set the *render window* to the given `size` without actually setting a fixed size (as this prevents it from interactively resizing, which we *do* want). I knew this had to be more of a hack than necessary, so I asked Opus 4.8 about it and it said:

> Qt defers geometry via posted LayoutRequest events. QLayout.activate() does the same thing synchronously. Every layout between the window and the interactor has to be activated, not just the window's

... and this totally makes sense. It drafted the associated changes and I iterated on them. Saves about 100ms during figure activation, which is nice. While I was at it:

1. cached `_is_osmesa` to cut things down a bit more (this should be stable across a Python session; had to cache using a global var since we need to pass `plotter` to get it to run but this shouldn't be hashed to decide on caching).
2. Cleaned up some crufty comments while I was in there
3. Found a cleaner fix for a MRO issue that I worked out in https://github.com/spyder-ide/spyder/pull/25422/changes#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R252 -- no need to do a monkeypatch of `__init__` if you handle inheritance properly for PySide6 and PyQt6 (which have different but not mutually incompatible approaches), facilitated by *not* using a diamond inheritance (inheriting from QWidget *and* a QWidget subclass simultaneously).

Shouldn't need any test updates since our tests already verify that screenshots are the right size, and that all the Qt stuff still works properly.