### PR TITLE
DOC: Clarify plot_topo interactivity

### DIFF
--- a/tutorials/raw/40_visualize_raw.py
+++ b/tutorials/raw/40_visualize_raw.py
@@ -156,7 +156,7 @@ spectrum.plot_topomap()
 spectrum.plot_topo()
 
 # %%
-# This plot is also interactive; hovering over each "thumbnail" plot will
+# This plot is also interactive if an interactive backend is enabled; hovering
 # display the channel name in the bottom left of the plot window, and clicking
 # on a thumbnail plot will create a second figure showing a larger version of
 # the selected channel's spectral density (as if you had called

--- a/tutorials/raw/40_visualize_raw.py
+++ b/tutorials/raw/40_visualize_raw.py
@@ -157,6 +157,7 @@ spectrum.plot_topo()
 
 # %%
 # This plot is also interactive if an interactive backend is enabled; hovering
+# over each "thumbnail" plot will
 # display the channel name in the bottom left of the plot window, and clicking
 # on a thumbnail plot will create a second figure showing a larger version of
 # the selected channel's spectral density (as if you had called


### PR DESCRIPTION
#### Reference issue (if any)

Closes the [`mne-qt-browser` proposal](https://github.com/mne-tools/mne-qt-browser/issues/438)


#### What does this implement/fix?

Update the tutorial doc to mention an interactive backend is needed for `.plot_topo()` to open as an interactive window.