### PR TITLE
Add windowing system to `mne.sys_info`

### DIFF
--- a/doc/changes/dev/14099.newfeature.rst
+++ b/doc/changes/dev/14099.newfeature.rst
@@ -1,0 +1,1 @@
+On Linux, :func:`mne.sys_info` now includes the detected windowing system (Wayland or X11), by `Clemens Brunner`_.

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -699,6 +699,16 @@ def _get_total_memory():
     return total_memory
 
 
+def _get_linux_windowing_system():
+    """Return the windowing system on Linux ("Wayland", "X11", or None)."""
+    session_type = os.getenv("XDG_SESSION_TYPE", "").lower()
+    if session_type == "wayland" or os.getenv("WAYLAND_DISPLAY"):
+        return "Wayland"
+    if session_type == "x11" or os.getenv("DISPLAY"):
+        return "X11"
+    return None
+
+
 def _get_cpu_brand():
     """Return the CPU brand string."""
     if platform.system() == "Windows":
@@ -770,6 +780,10 @@ def sys_info(
             unicode = False
     ljust = 24 if dependencies == "developer" else 21
     platform_str = platform.platform()
+    if platform.system() == "Linux":
+        windowing_system = _get_linux_windowing_system()
+        if windowing_system is not None:
+            platform_str += f" ({windowing_system})"
 
     out = partial(print, end="", file=fid)
     out("Platform".ljust(ljust) + platform_str + "\n")

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -122,6 +122,29 @@ def test_sys_info_basic():
         assert "Platform Linux" in out
 
 
+def test_sys_info_windowing_system(monkeypatch):
+    """Test that sys_info reports the windowing system on Linux."""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    for var in ("XDG_SESSION_TYPE", "WAYLAND_DISPLAY", "DISPLAY"):
+        monkeypatch.delenv(var, raising=False)
+
+    out = ClosingStringIO()
+    sys_info(fid=out, check_version=False)
+    line = out.getvalue().splitlines()[0]
+    assert line.startswith("Platform")
+    assert "(" not in line
+
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    out = ClosingStringIO()
+    sys_info(fid=out, check_version=False)
+    assert "(Wayland)" in out.getvalue().splitlines()[0]
+
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    out = ClosingStringIO()
+    sys_info(fid=out, check_version=False)
+    assert "(X11)" in out.getvalue().splitlines()[0]
+
+
 def test_sys_info_complete():
     """Test that sys_info is sufficiently complete."""
     tomllib = pytest.importorskip("tomllib")  # python 3.11+


### PR DESCRIPTION
Inspired by a [forum discussion](https://mne.discourse.group/t/error-when-using-create-3d-figure/11902/2), this PR adds the windowing system to the output of `mne.sys_info`.