### PR TITLE
MRG, ENH: Add forward sensitivity maps to reports

### DIFF
--- a/doc/changes/dev/14107.newfeature.rst
+++ b/doc/changes/dev/14107.newfeature.rst
@@ -1,0 +1,1 @@
+Added the ``sensitivity`` parameter to :meth:`mne.Report.add_forward` to include forward sensitivity maps in reports, by :newcontrib:`Mariam Husain`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -267,8 +267,8 @@
 .. _Manorama Kadwani: https://github.com/synapse-stream
 .. _Manu Sutela: https://github.com/MJAS1
 .. _Marcin Koculak: https://github.com/mkoculak
-.. _Marian Dovgialo: https://github.com/mdovgialo
 .. _Mariam Husain: https://github.com/mariam-hedgie
+.. _Marian Dovgialo: https://github.com/mdovgialo
 .. _Marijn van Vliet: https://github.com/wmvanvliet
 .. _Mark Alexander Henney: https://github.com/henneysq
 .. _Mark Wronkiewicz: https://github.com/wronk

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -213,8 +213,8 @@
 .. _Mainak Jas: https://jasmainak.github.io
 .. _Maksym Balatsko: https://github.com/mbalatsko
 .. _Marcin Koculak: https://github.com/mkoculak
-.. _Marian Dovgialo: https://github.com/mdovgialo
 .. _Mariam Husain: https://github.com/mariam-hedgie
+.. _Marian Dovgialo: https://github.com/mdovgialo
 .. _Marijn van Vliet: https://github.com/wmvanvliet
 .. _Mark Alexander Henney: https://github.com/henneysq
 .. _Mark Wronkiewicz: https://github.com/wronk

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -268,6 +268,7 @@
 .. _Manu Sutela: https://github.com/MJAS1
 .. _Marcin Koculak: https://github.com/mkoculak
 .. _Marian Dovgialo: https://github.com/mdovgialo
+.. _Mariam Husain: https://github.com/mariam-hedgie
 .. _Marijn van Vliet: https://github.com/wmvanvliet
 .. _Mark Alexander Henney: https://github.com/henneysq
 .. _Mark Wronkiewicz: https://github.com/wronk

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -214,6 +214,7 @@
 .. _Maksym Balatsko: https://github.com/mbalatsko
 .. _Marcin Koculak: https://github.com/mkoculak
 .. _Marian Dovgialo: https://github.com/mdovgialo
+.. _Mariam Husain: https://github.com/mariam-hedgie
 .. _Marijn van Vliet: https://github.com/wmvanvliet
 .. _Mark Alexander Henney: https://github.com/henneysq
 .. _Mark Wronkiewicz: https://github.com/wronk

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -4632,8 +4632,8 @@ class Report:
                     brain.set_time(t)
                     figs.append(brain.screenshot(time_viewer=True, mode="rgb"))
                 else:
-                    fig_lh = plt.figure(layout="constrained")
-                    fig_rh = plt.figure(layout="constrained")
+                    fig_lh = plt.figure()
+                    fig_rh = plt.figure()
 
                     brain_lh = stc.plot(
                         views="lat",
@@ -4670,9 +4670,6 @@ class Report:
 
         if backend_is_3d:
             brain.close()
-        else:
-            brain_lh.close()
-            brain_rh.close()
 
         captions = [f"Time point: {round(t, 3):0.3f} s" for t in times]
         if not backend_is_3d:

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -4600,81 +4600,29 @@ class Report:
             )
         t_zero_idx = np.abs(times).argmin()  # index of time closest to zero
 
-        # Plot using 3d backend if available, and use Matplotlib
-        # otherwise.
-        import matplotlib.pyplot as plt
+        if get_3d_backend() is None:
+            raise RuntimeError(
+                "A 3D backend is required to render source estimates in a report."
+            )
 
         stc_plot_kwargs = _handle_default("report_stc_plot_kwargs", stc_plot_kwargs)
         stc_plot_kwargs.update(subject=subject, subjects_dir=subjects_dir)
-        # we need to set the size based on the min (img_max_width can be None)
         if self.img_max_width is not None:
             stc_plot_kwargs["size"] = (
                 stc_plot_kwargs["size"][0],
                 min(stc_plot_kwargs["size"][1], self.img_max_width),
             )
-        if get_3d_backend() is not None:
-            brain = stc.plot(**stc_plot_kwargs)
-            brain._renderer.plotter.subplot(0, 0)
-            backend_is_3d = True
-        else:
-            backend_is_3d = False
+
+        brain = stc.plot(**stc_plot_kwargs)
+        brain._renderer.plotter.subplot(0, 0)
 
         figs = []
         for t in times:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    action="ignore",
-                    message="More than 20 figures have been opened",
-                    category=RuntimeWarning,
-                )
-
-                if backend_is_3d:
-                    brain.set_time(t)
-                    figs.append(brain.screenshot(time_viewer=True, mode="rgb"))
-                else:
-                    fig_lh = plt.figure()
-                    fig_rh = plt.figure()
-
-                    brain_lh = stc.plot(
-                        views="lat",
-                        hemi="lh",
-                        initial_time=t,
-                        backend="matplotlib",
-                        subject=subject,
-                        subjects_dir=subjects_dir,
-                        figure=fig_lh,
-                    )
-                    brain_rh = stc.plot(
-                        views="lat",
-                        hemi="rh",
-                        initial_time=t,
-                        subject=subject,
-                        subjects_dir=subjects_dir,
-                        backend="matplotlib",
-                        figure=fig_rh,
-                    )
-                    _constrain_fig_resolution(
-                        fig_lh,
-                        max_width=stc_plot_kwargs["size"][0],
-                        max_res=self.img_max_res,
-                    )
-                    _constrain_fig_resolution(
-                        fig_rh,
-                        max_width=stc_plot_kwargs["size"][0],
-                        max_res=self.img_max_res,
-                    )
-                    figs.append(brain_lh)
-                    figs.append(brain_rh)
-                    plt.close(fig_lh)
-                    plt.close(fig_rh)
-
-        if backend_is_3d:
-            brain.close()
+            brain.set_time(t)
+            figs.append(brain.screenshot(time_viewer=True, mode="rgb"))
+        brain.close()
 
         captions = [f"Time point: {round(t, 3):0.3f} s" for t in times]
-        if not backend_is_3d:
-            captions = [caption for caption in captions for _ in range(2)]
-            t_zero_idx *= 2
         return self._render_slider(
             figs=figs,
             imgs=None,
@@ -4684,7 +4632,7 @@ class Report:
             start_idx=t_zero_idx,
             tags=tags,
             klass="stc",
-            own_figure=False,  # prevent rescaling
+            own_figure=False,
         )
 
     @_use_agg

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -89,6 +89,13 @@ from ..viz.utils import _ndarray_to_fig
 
 _BEM_VIEWS = ("axial", "sagittal", "coronal")
 
+# constant for mapping of internal channel type keys to better labels
+# used in figures
+_SENSITIVITY_MAP_CH_LABELS = (
+    ("grad", "Gradiometers"),
+    ("mag", "Magnetometers"),
+    ("eeg", "EEG"),
+)
 
 # For raw files, we want to support different suffixes + extensions for all
 # supported file formats
@@ -3729,26 +3736,15 @@ class Report:
 
         sensitivity_maps_html = ""
         if sensitivity:
-            ch_types = forward["info"].get_channel_types(unique=True)
-            for ch_type in ("grad", "mag", "eeg"):
-                if ch_type not in ch_types:
-                    continue
-                stc = sensitivity_map(forward, ch_type=ch_type)
-                html_partial = self._render_stc(
-                    stc=stc,
-                    title=f"{ch_type.upper()} sensitivity",
-                    subject=subject,
-                    subjects_dir=subjects_dir,
-                    n_time_points=1,
-                    image_format=image_format,
-                    tags=tags,
-                    stc_plot_kwargs=None,
-                )
-                sensitivity_maps_html += html_partial(
-                    id_=self._get_dom_id(
-                        section=section, title=f"{title}-{ch_type}-sensitivity"
-                    )
-                )
+            sensitivity_maps_html = self._render_forward_sensitivity_maps(
+                forward=forward,
+                subject=subject,
+                subjects_dir=subjects_dir,
+                image_format=image_format,
+                section=section,
+                title=title,
+                tags=tags,
+            )
         source_space_html = ""
         if plot:
             source_space_html = self._src_html(
@@ -3773,6 +3769,62 @@ class Report:
             tags=tags,
             html_partial=html_partial,
             replace=replace,
+        )
+
+    def _render_forward_sensitivity_maps(
+        self, *, forward, subject, subjects_dir, image_format, section, title, tags
+    ):
+        # render sensitivity maps for all available sensors as one slider
+        subjects_dir = self.subjects_dir if subjects_dir is None else subjects_dir
+
+        if get_3d_backend() is None:
+            raise RuntimeError(
+                "A 3D backend is needed to render source estimates in a report."
+            )
+        stc_plot_kwargs = _handle_default("report_stc_plot_kwargs", None)
+        stc_plot_kwargs.update(
+            subject=subject,
+            subjects_dir=subjects_dir,
+            clim=dict(kind="value", lims=(0, 0.5, 1.0)),
+        )
+        if self.img_max_width is not None:
+            stc_plot_kwargs["size"] = (
+                stc_plot_kwargs["size"][0],
+                min(stc_plot_kwargs["size"][1], self.img_max_width),
+            )
+        ch_types = forward["info"].get_channel_types(unique=True)
+        figs = []
+        captions = []
+        # compute each sensitivity map and plot it
+        for ch_type, label in _SENSITIVITY_MAP_CH_LABELS:
+            if ch_type not in ch_types:
+                continue
+            stc = sensitivity_map(forward, ch_type=ch_type)
+            brain = stc.plot(**stc_plot_kwargs)
+            brain._renderer.plotter.subplot(0, 0)
+            brain.add_text(
+                x=0.5,
+                y=0.8,
+                text=label,
+                justification="center",
+            )
+            figs.append(brain.screenshot(time_viewer=True, mode="rgb"))
+            brain.close()
+            captions.append(label)
+            # make one working slider
+        html_partial = self._render_slider(
+            figs=figs,
+            imgs=None,
+            captions=captions,
+            title="Sensitivity maps",
+            start_idx=0,
+            image_format=image_format,
+            tags=tags,
+            klass="stc",
+            own_figure=False,
+        )
+        return html_partial(
+            id_=self._get_dom_id(section=section, title=f"{title}-sensitivity")
         )
 
     def _src_html(

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3806,6 +3806,7 @@ class Report:
                 x=0.5,
                 y=0.8,
                 text=label,
+                font_size=8,
                 justification="center",
             )
             figs.append(brain.screenshot(time_viewer=True, mode="rgb"))

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -41,7 +41,7 @@ from ..io._read_raw import _get_supported as _get_extension_reader_map
 from ..minimum_norm import InverseOperator, read_inverse_operator
 from ..parallel import parallel_func
 from ..preprocessing.ica import read_ica
-from ..proj import read_proj
+from ..proj import read_proj, sensitivity_map
 from ..source_estimate import SourceEstimate, read_source_estimate
 from ..source_space._source_space import _ensure_src
 from ..surface import dig_mri_distances
@@ -1583,6 +1583,7 @@ class Report:
         subject=None,
         subjects_dir=None,
         plot=False,
+        sensitivity=False,
         tags=("forward-solution",),
         section=None,
         replace=False,
@@ -1604,6 +1605,10 @@ class Report:
             If True, plot the source space of the forward solution.
 
             .. versionadded:: 1.10
+        sensitivity : bool
+            If True, render sensitivity maps for all available sensor types.
+
+            .. versionadded:: 1.13
         %(tags_report)s
         %(section_report)s
 
@@ -1626,6 +1631,7 @@ class Report:
             tags=tags,
             replace=replace,
             plot=plot,
+            sensitivity=sensitivity,
         )
 
     @fill_doc
@@ -3709,6 +3715,7 @@ class Report:
         title,
         image_format,
         plot,
+        sensitivity,
         section,
         tags,
         replace,
@@ -3720,9 +3727,28 @@ class Report:
         subject = self.subject if subject is None else subject
         subject = forward["src"][0]["subject_his_id"] if subject is None else subject
 
-        # XXX Todo
-        # Render sensitivity maps
         sensitivity_maps_html = ""
+        if sensitivity:
+            ch_types = forward["info"].get_channel_types(unique=True)
+            for ch_type in ("grad", "mag", "eeg"):
+                if ch_type not in ch_types:
+                    continue
+                stc = sensitivity_map(forward, ch_type=ch_type)
+                html_partial = self._render_stc(
+                    stc=stc,
+                    title=f"{ch_type.upper()} sensitivity",
+                    subject=subject,
+                    subjects_dir=subjects_dir,
+                    n_time_points=1,
+                    image_format=image_format,
+                    tags=tags,
+                    stc_plot_kwargs=None,
+                )
+                sensitivity_maps_html += html_partial(
+                    id_=self._get_dom_id(
+                        section=section, title=f"{title}-{ch_type}-sensitivity"
+                    )
+                )
         source_space_html = ""
         if plot:
             source_space_html = self._src_html(
@@ -4508,6 +4534,37 @@ class Report:
         replace,
     ):
         """Render STC."""
+        html_partial = self._render_stc(
+            stc=stc,
+            title=title,
+            subject=subject,
+            subjects_dir=subjects_dir,
+            n_time_points=n_time_points,
+            image_format=image_format,
+            tags=tags,
+            stc_plot_kwargs=stc_plot_kwargs,
+        )
+        self._add_or_replace(
+            title=title,
+            section=section,
+            tags=tags,
+            html_partial=html_partial,
+            replace=replace,
+        )
+
+    def _render_stc(
+        self,
+        *,
+        stc,
+        title,
+        subject,
+        subjects_dir,
+        n_time_points,
+        image_format,
+        tags,
+        stc_plot_kwargs,
+    ):
+        """Render an STC as embeddable report HTML."""
         if isinstance(stc, SourceEstimate):
             if subject is None:
                 subject = self.subject  # supplied during Report init
@@ -4618,16 +4675,14 @@ class Report:
             brain_rh.close()
 
         captions = [f"Time point: {round(t, 3):0.3f} s" for t in times]
-        self._add_slider(
+        return self._render_slider(
             figs=figs,
             imgs=None,
             captions=captions,
             title=title,
             image_format=image_format,
             start_idx=t_zero_idx,
-            section=section,
             tags=tags,
-            replace=replace,
             own_figure=False,  # prevent rescaling
         )
         for fig in figs:

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -42,7 +42,7 @@ from ..minimum_norm import InverseOperator, read_inverse_operator
 from ..parallel import parallel_func
 from ..preprocessing.ica import read_ica
 from ..proj import read_proj, sensitivity_map
-from ..source_estimate import _BaseSourceEstimate, SourceEstimate, read_source_estimate
+from ..source_estimate import _BaseSourceEstimate, read_source_estimate
 from ..source_space._source_space import _ensure_src
 from ..surface import dig_mri_distances
 from ..transforms import _find_trans

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -4686,9 +4686,6 @@ class Report:
             klass="stc",
             own_figure=False,  # prevent rescaling
         )
-        for fig in figs:
-            if not isinstance(fig, np.ndarray):
-                plt.close(fig)
 
     @_use_agg
     def _add_bem(

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -42,7 +42,7 @@ from ..minimum_norm import InverseOperator, read_inverse_operator
 from ..parallel import parallel_func
 from ..preprocessing.ica import read_ica
 from ..proj import read_proj, sensitivity_map
-from ..source_estimate import SourceEstimate, read_source_estimate
+from ..source_estimate import _BaseSourceEstimate, SourceEstimate, read_source_estimate
 from ..source_space._source_space import _ensure_src
 from ..surface import dig_mri_distances
 from ..transforms import _find_trans
@@ -4565,7 +4565,7 @@ class Report:
         stc_plot_kwargs,
     ):
         """Render an STC as embeddable report HTML."""
-        if isinstance(stc, SourceEstimate):
+        if isinstance(stc, _BaseSourceEstimate):
             if subject is None:
                 subject = self.subject  # supplied during Report init
                 if not subject:
@@ -4675,6 +4675,9 @@ class Report:
             brain_rh.close()
 
         captions = [f"Time point: {round(t, 3):0.3f} s" for t in times]
+        if not backend_is_3d:
+            captions = [caption for caption in captions for _ in range(2)]
+            t_zero_idx *= 2
         return self._render_slider(
             figs=figs,
             imgs=None,
@@ -4683,6 +4686,7 @@ class Report:
             image_format=image_format,
             start_idx=t_zero_idx,
             tags=tags,
+            klass="stc",
             own_figure=False,  # prevent rescaling
         )
         for fig in figs:

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -36,6 +36,7 @@ from mne.report.report import (
     _ALLOWED_IMAGE_FORMATS,
     CONTENT_ORDER,
 )
+from mne.source_estimate import SourceEstimate, VolSourceEstimate
 from mne.utils import Bunch, _record_warnings
 from mne.utils._testing import assert_object_equal
 from mne.viz import plot_alignment
@@ -556,6 +557,89 @@ def test_add_forward(renderer_interactive_pyvistaqt):
 def test_add_forward_sensitivity_parameter():
     """Test sensitivity maps can be requested when adding a forward solution."""
     assert "sensitivity" in inspect.signature(Report.add_forward).parameters
+
+
+class _FakeBrain:
+    """Minimal stand-in for a 3D source-estimate plot."""
+
+    def __init__(self):
+        self._renderer = Bunch(plotter=Bunch(subplot=lambda *_: None))
+
+    def close(self):
+        pass
+
+    def screenshot(self, **kwargs):
+        return np.zeros((2, 2, 3), np.uint8)
+
+    def set_time(self, time):
+        pass
+
+
+def _fake_stc_plot(*args, **kwargs):
+    """Return a lightweight source-estimate plot for report rendering tests."""
+    return _FakeBrain()
+
+
+def test_render_volume_stc(monkeypatch):
+    """Test rendering an in-memory volume source estimate."""
+    stc = VolSourceEstimate(
+        data=np.ones((1, 1)),
+        vertices=[np.array([0])],
+        tmin=0,
+        tstep=1,
+        subject="sample",
+    )
+    report = Report()
+    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: "pyvista")
+    monkeypatch.setattr(VolSourceEstimate, "plot", _fake_stc_plot)
+    monkeypatch.setattr(
+        report_mod,
+        "read_source_estimate",
+        lambda **kwargs: pytest.fail("An in-memory STC must not be read from disk"),
+    )
+    html_partial = report._render_stc(
+        stc=stc,
+        title="Volume STC",
+        subject="sample",
+        subjects_dir=None,
+        n_time_points=1,
+        image_format="png",
+        tags=(),
+        stc_plot_kwargs=None,
+    )
+    assert callable(html_partial)
+
+
+def test_render_stc_matplotlib_captions(monkeypatch):
+    """Test Matplotlib source-estimate views have one caption per image."""
+    stc = SourceEstimate(
+        data=np.ones((2, 1)),
+        vertices=[np.array([0]), np.array([0])],
+        tmin=0,
+        tstep=1,
+        subject="sample",
+    )
+    report = Report()
+    slider_kwargs = {}
+
+    def _render_slider(**kwargs):
+        slider_kwargs.update(kwargs)
+        return lambda **kwargs: ""
+
+    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
+    monkeypatch.setattr(SourceEstimate, "plot", _fake_stc_plot)
+    monkeypatch.setattr(report, "_render_slider", _render_slider)
+    report._render_stc(
+        stc=stc,
+        title="Surface STC",
+        subject="sample",
+        subjects_dir=None,
+        n_time_points=1,
+        image_format="png",
+        tags=(),
+        stc_plot_kwargs=None,
+    )
+    assert len(slider_kwargs["figs"]) == len(slider_kwargs["captions"]) == 2
 
 
 @testing.requires_testing_data

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -551,7 +551,18 @@ def test_add_forward(renderer_interactive_pyvistaqt):
         sensitivity=True,
     )
     assert len(report.html) == 1
-    assert report.html[0].count("<img") == 3
+    html = report.html[0]
+
+    assert html.count("<img") == 3
+    assert html.count("slider stc") == 1
+    assert html.count("Sensitivity maps") == 4
+    assert "GRAD sensitivity" not in html
+    assert "MAG sensitivity" not in html
+    assert "EEG sensitivity" not in html
+    grad_idx = html.index("Gradiometers")
+    mag_idx = html.index("Magnetometers", grad_idx)
+    eeg_idx = html.index("EEG", mag_idx)
+    assert grad_idx < mag_idx < eeg_idx
 
 
 def test_add_forward_sensitivity_parameter():
@@ -572,6 +583,9 @@ class _FakeBrain:
         return np.zeros((2, 2, 3), np.uint8)
 
     def set_time(self, time):
+        pass
+
+    def add_text(self, x, y, text, justification=None):
         pass
 
 
@@ -634,6 +648,66 @@ def test_render_stc_requires_3d_backend(monkeypatch):
             image_format="png",
             tags=(),
             stc_plot_kwargs=None,
+        )
+
+
+def test_render_forward_sensitivity_maps(monkeypatch):
+    """Tests that all sensor type maps share a single slider."""
+    calls = []
+
+    def _fake_sensitivity_map(forward, ch_type):
+        calls.append(ch_type)
+        return VolSourceEstimate(
+            data=np.ones((1, 1)),
+            vertices=[np.array([0])],
+            tmin=0,
+            tstep=1,
+            subject="sample",
+        )
+
+    class _FakeInfo:
+        def get_channel_types(self, unique=True):
+            return ["grad", "mag", "eeg"]
+
+    forward = {"info": _FakeInfo()}
+
+    report = Report()
+    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: "pyvista")
+    monkeypatch.setattr(report_mod, "sensitivity_map", _fake_sensitivity_map)
+    monkeypatch.setattr(VolSourceEstimate, "plot", _fake_stc_plot)
+
+    html = report._render_forward_sensitivity_maps(
+        forward=forward,
+        subject="sample",
+        subjects_dir=None,
+        image_format="png",
+        section=None,
+        title="My forward solution",
+        tags=(),
+    )
+    assert calls == ["grad", "mag", "eeg"]
+    assert html.count("<img") == 3
+    assert html.count('slider stc"') == 1
+    grad_idx = html.index("Gradiometers")
+    mag_idx = html.index("Magnetometers", grad_idx)
+    eeg_idx = html.index("EEG", mag_idx)
+    assert grad_idx < mag_idx < eeg_idx
+
+
+def test_render_forward_sensitivity_maps_requires_3d_backend(monkeypatch):
+    """Test that rendering forward sensitivity maps needs a 3D backend."""
+    report = Report()
+    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
+
+    with pytest.raises(RuntimeError, match="3D backend"):
+        report._render_forward_sensitivity_maps(
+            forward={"info": None},
+            subject="sample",
+            subjects_dir=None,
+            image_format="png",
+            section=None,
+            title="My forward solution",
+            tags=(),
         )
 
 

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -613,9 +613,9 @@ def test_render_volume_stc(monkeypatch):
 def test_render_stc_matplotlib_captions(monkeypatch):
     """Test Matplotlib source-estimate views have one caption per image."""
     stc = SourceEstimate(
-        data=np.ones((2, 1)),
+        data=np.ones((2, 3)),
         vertices=[np.array([0]), np.array([0])],
-        tmin=0,
+        tmin=-1,
         tstep=1,
         subject="sample",
     )
@@ -634,12 +634,13 @@ def test_render_stc_matplotlib_captions(monkeypatch):
         title="Surface STC",
         subject="sample",
         subjects_dir=None,
-        n_time_points=1,
+        n_time_points=3,
         image_format="png",
         tags=(),
         stc_plot_kwargs=None,
     )
-    assert len(slider_kwargs["figs"]) == len(slider_kwargs["captions"]) == 2
+    assert len(slider_kwargs["figs"]) == len(slider_kwargs["captions"]) == 6
+    assert slider_kwargs["start_idx"] == 2
 
 
 @testing.requires_testing_data

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -559,22 +559,6 @@ def test_add_forward_sensitivity_parameter():
     assert "sensitivity" in inspect.signature(Report.add_forward).parameters
 
 
-@testing.requires_testing_data
-def test_add_forward_sensitivity_matplotlib(monkeypatch):
-    """Test rendering forward sensitivity maps with the Matplotlib fallback."""
-    pytest.importorskip("nibabel")
-    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
-    report = Report(subjects_dir=subjects_dir, image_format="png")
-    report.add_forward(
-        forward=fwd_fname,
-        subjects_dir=subjects_dir,
-        title="Forward solution",
-        sensitivity=True,
-    )
-    assert len(report.html) == 1
-    assert report.html[0].count("<img") == 6
-
-
 class _FakeBrain:
     """Minimal stand-in for a 3D source-estimate plot."""
 
@@ -626,8 +610,8 @@ def test_render_volume_stc(monkeypatch):
     assert callable(html_partial)
 
 
-def test_render_stc_matplotlib_captions(monkeypatch):
-    """Test Matplotlib source-estimate views have one caption per image."""
+def test_render_stc_requires_3d_backend(monkeypatch):
+    """Test rendering source estimates requires a 3D backend."""
     stc = SourceEstimate(
         data=np.ones((2, 3)),
         vertices=[np.array([0]), np.array([0])],
@@ -636,27 +620,21 @@ def test_render_stc_matplotlib_captions(monkeypatch):
         subject="sample",
     )
     report = Report()
-    slider_kwargs = {}
-
-    def _render_slider(**kwargs):
-        slider_kwargs.update(kwargs)
-        return lambda **kwargs: ""
-
     monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
     monkeypatch.setattr(SourceEstimate, "plot", _fake_stc_plot)
-    monkeypatch.setattr(report, "_render_slider", _render_slider)
-    report._render_stc(
-        stc=stc,
-        title="Surface STC",
-        subject="sample",
-        subjects_dir=None,
-        n_time_points=3,
-        image_format="png",
-        tags=(),
-        stc_plot_kwargs=None,
-    )
-    assert len(slider_kwargs["figs"]) == len(slider_kwargs["captions"]) == 6
-    assert slider_kwargs["start_idx"] == 2
+    monkeypatch.setattr(report, "_render_slider", lambda **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="3D backend"):
+        report._render_stc(
+            stc=stc,
+            title="Surface STC",
+            subject="sample",
+            subjects_dir=None,
+            n_time_points=3,
+            image_format="png",
+            tags=(),
+            stc_plot_kwargs=None,
+        )
 
 
 @testing.requires_testing_data

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -562,6 +562,7 @@ def test_add_forward_sensitivity_parameter():
 @testing.requires_testing_data
 def test_add_forward_sensitivity_matplotlib(monkeypatch):
     """Test rendering forward sensitivity maps with the Matplotlib fallback."""
+    pytest.importorskip("nibabel")
     monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
     report = Report(subjects_dir=subjects_dir, image_format="png")
     report.add_forward(

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -559,6 +559,21 @@ def test_add_forward_sensitivity_parameter():
     assert "sensitivity" in inspect.signature(Report.add_forward).parameters
 
 
+@testing.requires_testing_data
+def test_add_forward_sensitivity_matplotlib(monkeypatch):
+    """Test rendering forward sensitivity maps with the Matplotlib fallback."""
+    monkeypatch.setattr(report_mod, "get_3d_backend", lambda: None)
+    report = Report(subjects_dir=subjects_dir, image_format="png")
+    report.add_forward(
+        forward=fwd_fname,
+        subjects_dir=subjects_dir,
+        title="Forward solution",
+        sensitivity=True,
+    )
+    assert len(report.html) == 1
+    assert report.html[0].count("<img") == 6
+
+
 class _FakeBrain:
     """Minimal stand-in for a 3D source-estimate plot."""
 

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -4,6 +4,7 @@
 
 import base64
 import glob
+import inspect
 import os
 import pickle
 import re
@@ -539,6 +540,22 @@ def test_add_forward(renderer_interactive_pyvistaqt):
     )
     assert len(report.html) == 1
     assert report.html[0].count("<img") == 0
+
+    report = Report(subjects_dir=subjects_dir, image_format="png")
+    report.add_forward(
+        forward=fwd_fname,
+        subjects_dir=subjects_dir,
+        title="Forward solution",
+        plot=False,
+        sensitivity=True,
+    )
+    assert len(report.html) == 1
+    assert report.html[0].count("<img") == 3
+
+
+def test_add_forward_sensitivity_parameter():
+    """Test sensitivity maps can be requested when adding a forward solution."""
+    assert "sensitivity" in inspect.signature(Report.add_forward).parameters
 
 
 @testing.requires_testing_data

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -575,6 +575,7 @@ class _FakeBrain:
 
     def __init__(self):
         self._renderer = Bunch(plotter=Bunch(subplot=lambda *_: None))
+        self.texts = []
 
     def close(self):
         pass
@@ -585,8 +586,16 @@ class _FakeBrain:
     def set_time(self, time):
         pass
 
-    def add_text(self, x, y, text, justification=None):
-        pass
+    def add_text(self, x, y, text, font_size=None, justification=None):
+        self.texts.append(
+            dict(
+                x=x,
+                y=y,
+                text=text,
+                font_size=font_size,
+                justification=justification,
+            )
+        )
 
 
 def _fake_stc_plot(*args, **kwargs):
@@ -654,6 +663,14 @@ def test_render_stc_requires_3d_backend(monkeypatch):
 def test_render_forward_sensitivity_maps(monkeypatch):
     """Tests that all sensor type maps share a single slider."""
     calls = []
+    plot_kwargs = []
+    brains = []
+
+    def _fake_sensitivity_stc_plot(*args, **kwargs):
+        plot_kwargs.append(kwargs)
+        brain = _FakeBrain()
+        brains.append(brain)
+        return brain
 
     def _fake_sensitivity_map(forward, ch_type):
         calls.append(ch_type)
@@ -674,7 +691,7 @@ def test_render_forward_sensitivity_maps(monkeypatch):
     report = Report()
     monkeypatch.setattr(report_mod, "get_3d_backend", lambda: "pyvista")
     monkeypatch.setattr(report_mod, "sensitivity_map", _fake_sensitivity_map)
-    monkeypatch.setattr(VolSourceEstimate, "plot", _fake_stc_plot)
+    monkeypatch.setattr(VolSourceEstimate, "plot", _fake_sensitivity_stc_plot)
 
     html = report._render_forward_sensitivity_maps(
         forward=forward,
@@ -686,6 +703,16 @@ def test_render_forward_sensitivity_maps(monkeypatch):
         tags=(),
     )
     assert calls == ["grad", "mag", "eeg"]
+    assert all(
+        kwargs["clim"] == dict(kind="value", lims=(0, 0.5, 1.0))
+        for kwargs in plot_kwargs
+    )
+    assert [brain.texts[0]["text"] for brain in brains] == [
+        "Gradiometers",
+        "Magnetometers",
+        "EEG",
+    ]
+    assert all(brain.texts[0]["font_size"] == 8 for brain in brains)
     assert html.count("<img") == 3
     assert html.count('slider stc"') == 1
     grad_idx = html.index("Gradiometers")


### PR DESCRIPTION
Closes #2828 
## the missing feature: 
MNE can already calculate sensitivity maps from a forward model to get information on how strongly each possible brain source would be measured by EEG/MEG sensors. however, the function `Report.add_forward()` did not have an easy way for users to choose to include the sensitivity maps in an HTML report. This PR aims to fix users having to make maps manually and add them separately.
## new behavior:
- added an optional boolean sensitivity parameter to the `Report.add_forward()`
- default is False so the behavior is the same as earlier
- if sensitivity=True then MNE finds the sensor types available in the forward model
- it generates sensitivity maps and embeds them in the forward-solution section of the report
- this also handles report rendering for surface and volume source estimates
- rendering sensitivity maps/source estimates requires a 3D backend and raises a clear error if none is available
- removed matplotlib fallback
## testing:
- a public API test confirms that sensitivity parameter exists in the `Report.add_forward()` function
- a data test loads MNE's testing forward solution, computes the maps, and renders them in a report 
- test that checks that an absent 3d backend raises a clear error
- regression test for in-memory volume source estimates through the 3d path
- these focused tests passed locally
## AI disclosure: 
Codex was used to help inspect the code and issue, implement changes, and run local checks.  I reviewed the final diff, understand the changes and behavior, and reviewed the test results
