### PR TITLE
Clean up old version usages and SPEC0 pin a few more deps

### DIFF
--- a/doc/changes/dev/14108.bugfix.rst
+++ b/doc/changes/dev/14108.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed bug in :meth:`mne.io.Raw.plot` where, with the matplotlib backend and
+``group_by="selection"``, the channel-selection radio buttons no longer all appeared
+selected while in butterfly mode, by `Eric Larson`_.

--- a/doc/changes/dev/14108.dependency.rst
+++ b/doc/changes/dev/14108.dependency.rst
@@ -1,0 +1,9 @@
+Raised minimum versions of some optional dependencies to comply with MNE-Python's
+SPEC0-like policy, and added them to the set kept up to date automatically by the
+``spec_zero`` CI job, by `Eric Larson`_:
+
+- Optional dependency ``dipy >= 1.9``
+- Optional dependency ``mne-qt-browser >= 0.6``
+- Optional dependency ``nibabel >= 5.2``
+- Optional dependency ``nilearn >= 0.10``
+- Optional dependency ``numba >= 0.60``

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -2,24 +2,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-import docutils
 from docutils.nodes import reference
-
-# Adapted from sphinx
-if docutils.__version_info__[:2] < (0, 22):
-    from docutils.parsers.rst import roles
-
-    def _normalize_options(options):
-        if options is None:
-            return {}
-        n_options = options.copy()
-        roles.set_classes(n_options)
-        return n_options
-
-else:
-    from docutils.parsers.rst.roles import (
-        normalize_options as _normalize_options,
-    )
+from docutils.parsers.rst.roles import normalize_options as _normalize_options
 
 
 def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):  # noqa: B006

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - darkdetect
   - decorator >=5.1
   - defusedxml
-  - dipy >=0.8
+  - dipy >=1.9
   - edfio >=0.4.10
   - eeglabio
   - ffmpeg =8.1.2
@@ -30,13 +30,13 @@ dependencies:
   - mamba
   - matplotlib >=3.9
   - mffpy >=0.11.0
-  - mne-qt-browser
+  - mne-qt-browser >=0.6
   - nest-asyncio2
-  - nibabel >=2.0
-  - nilearn
+  - nibabel >=5.2
+  - nilearn >=0.10
   - nomkl
   - noqt5
-  - numba >=0.35
+  - numba >=0.60
   - numpy >=2.0,<3
   - openmeeg >=2.5.7
   - packaging

--- a/examples/decoding/decoding_xdawn_eeg.py
+++ b/examples/decoding/decoding_xdawn_eeg.py
@@ -72,7 +72,7 @@ epochs = Epochs(
 
 # Create classification pipeline
 kwargs = dict()
-if check_version("sklearn", "1.8"):
+if check_version("sklearn", "1.8"):  # TODO VERSION remove on sklearn 1.8+
     kwargs["l1_ratio"] = 1
 else:
     kwargs["penalty"] = "l1"

--- a/examples/stats/r_interop.py
+++ b/examples/stats/r_interop.py
@@ -30,6 +30,7 @@ used for anything the R ecosystem has to offer.
 # We use the MNE sample dataset and create epochs for two conditions:
 # auditory/left and auditory/right.
 
+import numpy as np
 import rpy2.robjects as ro
 from rpy2.robjects import default_converter, numpy2ri
 from rpy2.robjects.conversion import localconverter
@@ -142,3 +143,4 @@ print(f"R       →  t = {t_r:.4f},  p = {p_r:.4f}")
 
 print(f"\nt difference: {abs(t_python - t_r):.2e}")
 print(f"p difference: {abs(p_python - p_r):.2e}")
+np.testing.assert_allclose([t_python, p_python], [t_r, p_r], rtol=1e-10)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -33,7 +33,7 @@ from ._fiff.write import (
     write_int_matrix,
     write_string,
 )
-from .fixes import _compare_version, _safe_svd
+from .fixes import _safe_svd
 from .surface import (
     _complete_sphere_surf,
     _compute_nearest,
@@ -356,8 +356,6 @@ def _import_openmeeg(what="compute a BEM solution using OpenMEEG"):
             f"The OpenMEEG module must be installed to {what}, but "
             f'"import openmeeg" resulted in: {exc}'
         ) from None
-    if not _compare_version(om.__version__, ">=", "2.5.6"):
-        raise ImportError(f"OpenMEEG 2.5.6+ is required, got {om.__version__}")
     return om
 
 

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -44,7 +44,6 @@ from mne.utils import (
     _pl,
     _record_warnings,
     _TempDir,
-    check_version,
     numerics,
 )
 from mne.viz._figure import use_browser_backend
@@ -667,11 +666,6 @@ def mpl_backend(garbage_collect):
         backend._close_all()
 
 
-# Skip functions or modules for mne-qt-browser < 0.2.0
-pre_2_0_skip_modules = ["mne.viz.tests.test_epochs", "mne.viz.tests.test_ica"]
-pre_2_0_skip_funcs = ["test_plot_raw_white", "test_plot_raw_selection"]
-
-
 def _check_pyqtgraph(request):
     # Check Qt
     qt_version, api = _check_qt_version(return_api=True)
@@ -681,17 +675,6 @@ def _check_pyqtgraph(request):
         )
     try:
         import mne_qt_browser  # noqa: F401
-
-        # Check mne-qt-browser version
-        lower_2_0 = _compare_version(mne_qt_browser.__version__, "<", "0.2.0")
-        m_name = request.function.__module__
-        f_name = request.function.__name__
-        if lower_2_0 and m_name in pre_2_0_skip_modules:
-            pytest.skip(
-                f'Test-Module "{m_name}" was skipped for mne-qt-browser < 0.2.0'
-            )
-        elif lower_2_0 and f_name in pre_2_0_skip_funcs:
-            pytest.skip(f'Test "{f_name}" was skipped for mne-qt-browser < 0.2.0')
     except Exception:
         pytest.skip("Requires mne_qt_browser")
 
@@ -834,7 +817,7 @@ def _check_skip_backend(name):
 def pixel_ratio(qapp):
     """Get the pixel ratio."""
     # _check_qt_version will init an app for us, so no need for us to do it
-    if not check_version("pyvista", "0.32") or not _check_qt_version():
+    if not _check_qt_version():
         return 1.0
     from qtpy.QtCore import Qt
     from qtpy.QtWidgets import QMainWindow

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -457,7 +457,7 @@ class LinearModel(MetaEstimatorMixin, BaseEstimator):
         "predict",
         "predict_proba",
         "predict_log_proba",
-        "_estimator_type",  # remove after sklearn 1.6
+        "_estimator_type",  # TODO VERSION remove on sklearn 1.6+
         "decision_function",
         "score",
         "classes_",
@@ -505,7 +505,7 @@ class LinearModel(MetaEstimatorMixin, BaseEstimator):
                     "(classifier or regressor)"
                 )
 
-        # For sklearn < 1.6
+        # TODO VERSION remove on sklearn 1.6+
         try:
             self._check_n_features(X, reset=True)
         except AttributeError:

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -289,7 +289,6 @@ class SlidingEstimator(MetaEstimatorMixin, MNETransformerMixin, BaseEstimator):
 
     def _check_Xy(self, X, y=None, fit=False):
         """Aux. function to check input data."""
-        # Once we require sklearn 1.1+ we should do something like:
         X = self._check_data(X, y=y, atleast_3d=False, fit=fit)
         is_nd = X.ndim >= 3
         if not is_nd:

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -121,8 +121,7 @@ def _safe_svd(A, **kwargs):
     """Get around the SVD did not converge error of death."""
     # Intel has a bug with their GESVD driver:
     #     https://software.intel.com/en-us/forums/intel-distribution-for-python/topic/628049  # noqa: E501
-    # For SciPy 0.18 and up, we can work around it by using
-    # lapack_driver='gesvd' instead.
+    # We can work around it by using lapack_driver='gesvd' instead.
     from scipy import linalg
 
     if kwargs.get("overwrite_a", False):
@@ -137,7 +136,7 @@ def _safe_svd(A, **kwargs):
 
 
 ###############################################################################
-# NumPy Generator (NumPy 1.17)
+# NumPy Generator vs. RandomState
 
 
 def rng_uniform(rng):
@@ -634,8 +633,6 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
 try:
     import numba
 
-    if _compare_version(numba.__version__, "<", "0.56.4"):
-        raise ImportError
     prange = numba.prange
 
     def jit(nopython=True, nogil=True, fastmath=True, cache=True, **kwargs):  # noqa

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -3,13 +3,8 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-
-try:
-    from scipy.io.matlab import MatlabFunction, MatlabOpaque
-except ImportError:  # scipy < 1.8
-    from scipy.io.matlab.mio5 import MatlabFunction
-    from scipy.io.matlab.mio5_params import MatlabOpaque
 from scipy.io import loadmat
+from scipy.io.matlab import MatlabFunction, MatlabOpaque
 
 from ...fixes import _whosmat
 from ...utils import _import_pymatreader_funcs, warn

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -101,10 +101,8 @@ def _to_loc(ll):
 
 
 def _eeg_has_montage_information(eeg):
-    try:
-        from scipy.io.matlab import mat_struct
-    except ImportError:  # SciPy < 1.8
-        from scipy.io.matlab.mio5_params import mat_struct
+    from scipy.io.matlab import mat_struct
+
     if not len(eeg.chanlocs):
         has_pos = False
     else:

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -29,8 +29,8 @@ from .utils import (
     _ensure_int,
     _import_h5io_funcs,
     _import_nibabel,
+    _soft_import,
     _validate_type,
-    check_version,
     fill_doc,
     get_subjects_dir,
     logger,
@@ -210,7 +210,7 @@ def compute_source_morph(
     vertices_to_surf, vertices_to_vol = list(), list()
 
     if kind in ("volume", "mixed"):
-        _check_dep(nibabel="2.1.0", dipy="0.10.1")
+        _check_dep()
         nib = _import_nibabel("work with a volume source space")
 
         logger.info("Volume source space(s) present...")
@@ -889,16 +889,12 @@ def read_source_morph(fname):
 
 ###############################################################################
 # Helper functions for SourceMorph methods
-def _check_dep(nibabel="2.1.0", dipy="0.10.1"):
+def _check_dep(nibabel=True, dipy=True):
     """Check dependencies."""
-    for lib, ver in zip(["nibabel", "dipy"], [nibabel, dipy]):
-        passed = True if not ver else check_version(lib, ver)
-
-        if not passed:
-            raise ImportError(
-                f"{lib} {ver} or higher must be correctly "
-                "installed and accessible from Python"
-            )
+    if nibabel:
+        _import_nibabel("morph source estimates")
+    if dipy:
+        _soft_import("dipy", "volumetric source morphing")
 
 
 def _morphed_stc_as_volume(morph, stc, mri_resolution, mri_space, output):
@@ -906,7 +902,7 @@ def _morphed_stc_as_volume(morph, stc, mri_resolution, mri_space, output):
     assert isinstance(stc, _BaseVolSourceEstimate)  # should be guaranteed
     if stc._data_ndim == 3:
         stc = stc.magnitude()
-    _check_dep(nibabel="2.1.0", dipy=False)
+    _check_dep(dipy=False)
 
     NiftiImage, NiftiHeader = _triage_output(output)
 
@@ -1038,7 +1034,7 @@ def _triage_output(output):
 
 def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
     """Interpolate source estimate data to MRI."""
-    _check_dep(nibabel="2.1.0", dipy=False)
+    _check_dep(dipy=False)
     NiftiImage, NiftiHeader = _triage_output(output)
     _validate_type(stc, _BaseVolSourceEstimate, "stc", "volume source estimate")
     assert morph.kind in ("volume", "mixed")
@@ -1050,7 +1046,7 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
         mri_resolution = (float(mri_resolution),) * 3
 
     if isinstance(mri_resolution, tuple):
-        _check_dep(nibabel=False, dipy="0.10.1")  # nibabel was already checked
+        _check_dep(nibabel=False)  # nibabel was already checked
         from dipy.align.reslice import reslice
 
         voxel_size = mri_resolution

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -158,8 +158,8 @@ def get_score_funcs():
             if signature(f).parameters == ["u", "v"]
         }
     )
-    # In SciPy 1.9+, pearsonr has (x, y, *, alternative='two-sided'), so we
-    # should just look at the positional_only and positional_or_keyword entries
+    # pearsonr has (x, y, *, alternative='two-sided'), so only look at the
+    # positional_only and positional_or_keyword entries
     for n, f in xy_arg_stats_funcs:
         params = [
             name

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -1421,9 +1421,7 @@ def _write_one_source_space(fid, this, verbose=None):
     if this["dist"] is not None:
         # Save only upper triangular portion of the matrix
         dists = this["dist"].copy()
-        # Shouldn't need this cast but on SciPy 1.9.3 at least this returns a csr_matrix
-        # instead of csr_array
-        dists = csr_array(triu(dists, format=dists.format))
+        dists = triu(dists, format=dists.format)
         write_float_sparse_rcs(fid, FIFF.FIFF_MNE_SOURCE_SPACE_DIST, dists)
         write_float_matrix(
             fid,

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -450,7 +450,7 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
         else:
             agg_df = gb.mean()  # excludes missing values itself
     else:
-        gb = gb[df.columns]  # XXX: try removing when minimum pandas >= 2.1 is required
+        gb = gb[df.columns]  # still needed as of pandas 3.0
         agg_df = gb.apply(_agg_helper, spectrum.weights, grouping_cols)
     # even with check_categorical=False, we know that the *data* matches;
     # what may differ is the order of the "levels" in the *metadata* for the

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -52,7 +52,6 @@ from mne.time_frequency.tfr import (
     write_tfrs,
 )
 from mne.utils import _import_h5io_funcs, catch_logging, grand_average
-from mne.utils._testing import _get_suptitle
 from mne.viz.utils import (
     _channel_type_prettyprint,
     _fake_click,
@@ -953,7 +952,7 @@ def test_tfr_plot_joint(
     popup_fig = plt.figure(fignums[-1])
     assert re.match(
         r"-?\d{1,2}\.\d{3} - -?\d{1,2}\.\d{3} s,\n\d{1,2}\.\d{2} - \d{1,2}\.\d{2} Hz",
-        _get_suptitle(popup_fig),
+        popup_fig.get_suptitle(),
     )
 
 
@@ -1794,7 +1793,7 @@ def test_tfr_plot_combine(epochs_tfr, picks, combine):
             want = rf"{'RMS' if combine == 'rms' else 'Mean'} of \d{{1,3}} {ch_type}s"
         else:
             want = epochs_tfr.ch_names[picks[ix]]
-        assert re.search(want, _get_suptitle(_fig))
+        assert re.search(want, _fig.get_suptitle())
 
 
 def test_tfr_plot_extras(epochs_tfr):
@@ -1803,7 +1802,7 @@ def test_tfr_plot_extras(epochs_tfr):
     picks = [1]
     mask = np.ones(epochs_tfr.data.shape[2:], bool)
     fig = epochs_tfr.plot(picks=picks, mask=mask, title="Foo")
-    assert _get_suptitle(fig[0]) == "Foo"
+    assert fig[0].get_suptitle() == "Foo"
     mask = np.ones(epochs_tfr.data.shape[1:], bool)
     with pytest.raises(ValueError, match="mask must have the same shape as the data"):
         epochs_tfr.plot(picks=picks, mask=mask)

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -73,9 +73,7 @@ def requires_openmeeg_mark():
     """Mark pytest tests that require OpenMEEG."""
     import pytest
 
-    return pytest.mark.skipif(
-        not check_version("openmeeg", "2.5.6"), reason="Requires OpenMEEG >= 2.5.6"
-    )
+    return pytest.mark.skipif(not check_version("openmeeg"), reason="Requires OpenMEEG")
 
 
 def requires_freesurfer(arg):
@@ -384,16 +382,6 @@ def _click_ch_name(fig, ch_index=0, button=1):
     x = bbox.intervalx.mean()
     y = bbox.intervaly.mean()
     _fake_click(fig, fig.mne.ax_main, (x, y), xform="pix", button=button)
-
-
-def _get_suptitle(fig):
-    """Get fig suptitle (shim for matplotlib < 3.8.0)."""
-    # TODO: obsolete when minimum MPL version is 3.8
-    if check_version("matplotlib", "3.8"):
-        return fig.get_suptitle()
-    else:
-        # unreliable hack; should work in most tests as we rarely use `sup_{x,y}label`
-        return fig.texts[0].get_text()
 
 
 def assert_trans_allclose(actual, desired, dist_tol=0.0, angle_tol=0.0):

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -4,8 +4,6 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from inspect import signature
-
 import numpy as np
 
 from ..defaults import _handle_default
@@ -58,9 +56,7 @@ def _convert_times(
 
 
 def _inplace(df, method, **kwargs):
-    # TODO VERSION remove on pandas 3.0+
-    # Handle transition: inplace=True (pandas <1.5) → copy=False (>=1.5)
-    # and 3.0 warning:
+    # TODO VERSION remove on pandas 3.0+, which warns:
     #     The copy keyword will be removed in a
     #     future version. Copy-on-Write is active in pandas since 3.0 which utilizes a
     #     lazy copy mechanism that defers copies until necessary. Use .copy() to make
@@ -69,11 +65,7 @@ def _inplace(df, method, **kwargs):
 
     if check_version("pandas", "3.0"):
         return _meth(**kwargs)
-    elif "copy" in signature(_meth).parameters:
-        return _meth(**kwargs, copy=False)
-    else:
-        _meth(**kwargs, inplace=True)
-        return df
+    return _meth(**kwargs, copy=False)
 
 
 @verbose

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -4,6 +4,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from inspect import signature
+
 import numpy as np
 
 from ..defaults import _handle_default
@@ -61,11 +63,16 @@ def _inplace(df, method, **kwargs):
     #     future version. Copy-on-Write is active in pandas since 3.0 which utilizes a
     #     lazy copy mechanism that defers copies until necessary. Use .copy() to make
     #     an eager copy if necessary.
-    _meth = getattr(df, method)  # used for set_index() and rename()
+    _meth = getattr(df, method)  # used for set_index(), rename(), sort_values()
 
     if check_version("pandas", "3.0"):
         return _meth(**kwargs)
-    return _meth(**kwargs, copy=False)
+    # per-method, not per-version: rename() takes copy=, set_index()/sort_values() don't
+    elif "copy" in signature(_meth).parameters:
+        return _meth(**kwargs, copy=False)
+    else:
+        _meth(**kwargs, inplace=True)
+        return df
 
 
 @verbose

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -147,7 +147,7 @@ def test_sys_info_windowing_system(monkeypatch):
 
 def test_sys_info_complete():
     """Test that sys_info is sufficiently complete."""
-    tomllib = pytest.importorskip("tomllib")  # python 3.11+
+    tomllib = pytest.importorskip("tomllib")  # TODO VERSION remove on Python 3.11+
     pyproject = Path(__file__).parents[3] / "pyproject.toml"
     if not pyproject.is_file():
         pytest.skip("Does not appear to be a dev installation")

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -70,9 +70,9 @@ from ..utils import (
     _ensure_int,
     _import_nibabel,
     _pl,
+    _soft_import,
     _to_rgb,
     _validate_type,
-    check_version,
     fill_doc,
     get_config,
     get_subjects_dir,
@@ -3101,8 +3101,7 @@ def plot_volume_source_estimates(
     from ..source_estimate import VolSourceEstimate
     from ..source_space._source_space import _ensure_src
 
-    if not check_version("nilearn", "0.4"):
-        raise RuntimeError("This function requires nilearn >= 0.4")
+    _soft_import("nilearn", "plotting volume source estimates")
 
     from nilearn.image import index_img
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -19,7 +19,6 @@ import numpy as np
 from .._fiff.pick import _DATA_CH_TYPES_SPLIT
 from ..defaults import _handle_default
 from ..filter import _iir_filter, _overlap_add_filter
-from ..fixes import _compare_version
 from ..utils import (
     _check_option,
     _get_stim_channel,
@@ -747,32 +746,7 @@ def _get_browser(show, block, **kwargs):
     if kwargs.get("overview_mode", None) is None:
         kwargs["overview_mode"] = get_config("MNE_BROWSER_OVERVIEW_MODE", "channels")
 
-    # Initialize browser backend
-    backend_name = get_browser_backend()
-    # Check mne-qt-browser compatibility
-    if backend_name == "qt":
-        import mne_qt_browser
-
-        from ..epochs import BaseEpochs
-
-        is_ica = kwargs.get("ica", False)
-        is_epochs = isinstance(kwargs.get("inst", False), BaseEpochs)
-        not_compat = _compare_version(mne_qt_browser.__version__, "<", "0.2.0")
-        inst_str = "ICA" if is_ica else "Epochs"
-        if not_compat and (is_ica or is_epochs):
-            logger.info(
-                f'You set the browser-backend to "qt" but your'
-                f" current version {mne_qt_browser.__version__}"
-                f" of mne-qt-browser is too low for {inst_str}."
-                f"Update with pip or conda."
-                f"Defaults to matplotlib."
-            )
-            with use_browser_backend("matplotlib"):
-                # Initialize Browser
-                fig = backend._init_browser(**kwargs)
-                _show_browser(show=show, block=block, fig=fig)
-                return fig
-
+    get_browser_backend()  # sets the module-level `backend` used just below
     # Initialize Browser
     fig = backend._init_browser(**kwargs)
     _show_browser(show=show, block=block, fig=fig)

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -57,7 +57,7 @@ from .._fiff.pick import (
 )
 from ..defaults import DEFAULTS
 from ..fixes import _close_event
-from ..utils import Bunch, _click_ch_name, check_version, logger
+from ..utils import Bunch, _click_ch_name, logger
 from ._figure import BrowserBase
 from .utils import (
     _BLIT_KWARGS,
@@ -81,7 +81,6 @@ ANNOTATION_FIG_PAD = 0.1
 ANNOTATION_FIG_MIN_H = 2.9  # fixed part, not including radio buttons/labels
 ANNOTATION_FIG_W = 5.0
 ANNOTATION_FIG_CHECKBOX_COLUMN_W = 0.5
-_OLD_BUTTONS = not check_version("matplotlib", "3.7")
 
 # DARK THEME COLORS
 # These colors are duplicated from mne-qt-browser (_dark_dict). If you change one, make
@@ -335,25 +334,6 @@ class MNEAnnotationFigure(MNEFigure):
         if draw:
             self.canvas.draw()
 
-    def _click_override(self, event):
-        """Override MPL radiobutton click detector to use transData."""
-        assert _OLD_BUTTONS
-        ax = self.mne.radio_ax
-        buttons = ax.buttons
-        if buttons.ignore(event) or event.button != 1 or event.inaxes != ax:
-            return
-        pclicked = ax.transData.inverted().transform((event.x, event.y))
-        distances = {}
-        for i, (p, t) in enumerate(zip(buttons.circles, buttons.labels)):
-            if (
-                t.get_window_extent().contains(event.x, event.y)
-                or np.linalg.norm(pclicked - p.center) < p.radius
-            ):
-                distances[i] = np.linalg.norm(pclicked - p.center)
-        if len(distances) > 0:
-            closest = min(distances, key=distances.get)
-            buttons.set_active(closest)
-
     def _set_active_button(self, idx, *, draw=True):
         """Set active button in annotation dialog figure."""
         buttons = self.mne.radio_ax.buttons
@@ -361,15 +341,6 @@ class MNEAnnotationFigure(MNEFigure):
         logger.debug(f"active idx: {idx}")
         with _events_off(buttons):
             buttons.set_active(idx)
-        if _OLD_BUTTONS:
-            logger.debug(f"circles: {buttons.circles}")
-            for circle in buttons.circles:
-                circle.set_facecolor(self.mne.parent_fig.mne.bgcolor)
-            # active circle gets filled in, partially transparent
-            color = list(buttons.circles[idx].get_edgecolor())
-            logger.debug(f"color: {color}")
-            color[-1] = 0.5
-            buttons.circles[idx].set_facecolor(color)
         if draw:
             self.canvas.draw()
 
@@ -425,15 +396,15 @@ class MNESelectionFigure(MNEFigure):
 
     def _style_radio_buttons_butterfly(self):
         """Handle RadioButton state for keyboard interactions."""
-        # Show all radio buttons as selected when in butterfly mode
         parent = self.mne.parent_fig
         buttons = self.mne.radio_ax.buttons
-        color = buttons.activecolor if parent.mne.butterfly else parent.mne.bgcolor
-        if _OLD_BUTTONS:
-            for circle in buttons.circles:
-                circle.set_facecolor(color)
-        # when leaving butterfly mode, make most-recently-used selection active
-        if not parent.mne.butterfly:
+        if parent.mne.butterfly:
+            # Show all radio buttons as selected. RadioButtons keeps its markers in a
+            # single scatter collection, so recolor that; set_active() would undo it.
+            facecolors = [buttons.activecolor] * len(buttons.labels)
+            buttons.ax.collections[0].set_facecolor(facecolors)
+        else:
+            # when leaving butterfly mode, make most-recently-used selection active
             with _events_off(buttons):
                 buttons.set_active(self.mne.old_selection)
         # update the sensors too
@@ -1303,24 +1274,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         aspect = width_ax / fig._inch_to_rel(drag_ax_height)
         drag_ax.set(xlim=(0, aspect), ylim=(0, 1))
         drag_ax.set_axis_off()
-        if _OLD_BUTTONS:
-            rect = checkbox.rectangles[0]
-            _pad, _size = (0.2, 0.6)
-            rect.set_bounds(_pad, _pad, _size, _size)
-            lines = checkbox.lines[0]
-            for line, direction in zip(lines, (1, -1)):
-                line.set_xdata((_pad, _pad + _size)[::direction])
-                line.set_ydata((_pad, _pad + _size))
-            text = checkbox.labels[0]
-            text.set(position=(3 * _pad + _size, 0.45), va="center")
-            for artist in lines + (rect, text):
-                artist.set_transform(drag_ax.transData)
-            rect.set_edgecolor(fig.mne.fgcolor)
-            for line in lines:
-                line.set_color(fig.mne.fgcolor)
-            text.set_color(fig.mne.fgcolor)
-        else:
-            checkbox.labels[0].set_color(fig.mne.fgcolor)
+        checkbox.labels[0].set_color(fig.mne.fgcolor)
         # setup interactivity in plot window
         if fig.mne.radio_ax.buttons is None:
             col = "#ff0000"
@@ -1384,35 +1338,17 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         title = "Existing labels:" if len(labels) else "No existing labels"
         ax.set_title(title, size=None, loc="left").set_color(fig.mne.fgcolor)
         if len(labels):
-            if _OLD_BUTTONS:
-                ax.buttons = RadioButtons(ax, labels, **_BLIT_KWARGS)
-                radius = 0.15
-                circles = ax.buttons.circles
-                for circle, label in zip(circles, ax.buttons.labels):
-                    circle.set_transform(ax.transData)
-                    center = ax.transData.inverted().transform(
-                        ax.transAxes.transform((0.1, 0))
-                    )
-                    circle.set_center((center[0], circle.center[1]))
-                    circle.set_edgecolor(
-                        self.mne.annotation_segment_colors[label.get_text()]
-                    )
-                    circle.set_linewidth(4)
-                    circle.set_radius(radius / len(labels))
-            else:
-                edgecolors = [
-                    self.mne.annotation_segment_colors[label] for label in labels
-                ]
-                facecolors = [to_rgba(col)[:3] + (0.5,) for col in edgecolors]
-                radio_props = dict(
-                    s=144,
-                    linewidth=4,
-                    edgecolor=edgecolors,
-                    facecolor=facecolors,
-                )
-                ax.buttons = RadioButtons(
-                    ax, labels, radio_props=radio_props, **_BLIT_KWARGS
-                )
+            edgecolors = [self.mne.annotation_segment_colors[label] for label in labels]
+            facecolors = [to_rgba(col)[:3] + (0.5,) for col in edgecolors]
+            radio_props = dict(
+                s=144,
+                linewidth=4,
+                edgecolor=edgecolors,
+                facecolor=facecolors,
+            )
+            ax.buttons = RadioButtons(
+                ax, labels, radio_props=radio_props, **_BLIT_KWARGS
+            )
         else:
             ax.buttons = None
         if ax.buttons is not None:
@@ -1428,11 +1364,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             fig._set_active_button(0, draw=False)
         # add event listeners
         if ax.buttons is not None:
-            if _OLD_BUTTONS:
-                ax.buttons.disconnect_events()  # clear MPL default listeners
             ax.buttons.on_clicked(fig._radiopress)
-            if _OLD_BUTTONS:
-                ax.buttons.connect_event("button_press_event", fig._click_override)
         ax.set_axis_off()
 
         # now do the show/hide checkboxes
@@ -1459,25 +1391,6 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         for label in checkboxes.labels:
             label.set_visible(False)
         show_hide_ax.set_axis_off()
-        # fix aspect and right-align
-        if _OLD_BUTTONS:
-            if len(labels) == 1:
-                bounds = (0.05, 0.375, 0.25, 0.25)  # undo MPL special case
-                checkboxes.rectangles[0].set_bounds(bounds)
-                for line, step in zip(checkboxes.lines[0], (1, -1)):
-                    line.set_xdata((bounds[0], bounds[0] + bounds[2]))
-                    line.set_ydata((bounds[1], bounds[1] + bounds[3])[::step])
-            for rect in checkboxes.rectangles:
-                rect.set_transform(show_hide_ax.transData)
-                bbox = rect.get_bbox()
-                bounds = (aspect, bbox.ymin, -bbox.width, bbox.height)
-                rect.set_bounds(bounds)
-                rect.set_clip_on(False)
-                rect.set_edgecolor(fig.mne.fgcolor)
-            for line in np.array(checkboxes.lines).ravel():
-                line.set_transform(show_hide_ax.transData)
-                line.set_xdata(aspect + 0.05 - np.array(line.get_xdata()))
-                line.set_color(fig.mne.fgcolor)
         # store state
         self.mne.visible_annotations = check_values
         self.mne.show_hide_annotation_checkboxes = checkboxes
@@ -1662,7 +1575,6 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
 
     def _create_selection_fig(self):
         """Create channel selection dialog window."""
-        from matplotlib.colors import to_rgb
         from matplotlib.widgets import RadioButtons
 
         # make figure
@@ -1694,17 +1606,12 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         selections_dict = self.mne.ch_selections
         selections_dict.update(Custom=np.array([], dtype=int))  # for lasso
         labels = list(selections_dict)
-        # make & style the radio buttons
-        activecolor = to_rgb(self.mne.fgcolor) + (0.5,)
+        # make & style the radio buttons; this dialog keeps a light background in
+        # both themes, so don't use mne.fgcolor (light gray under the dark theme)
         radio_ax.buttons = RadioButtons(
-            radio_ax, labels, activecolor=activecolor, **_BLIT_KWARGS
+            radio_ax, labels, activecolor="k", **_BLIT_KWARGS
         )
         fig.mne.old_selection = 0
-        if _OLD_BUTTONS:
-            for circle in radio_ax.buttons.circles:
-                circle.set_radius(0.25 / len(labels))
-                circle.set_linewidth(2)
-                circle.set_edgecolor(self.mne.fgcolor)
         fig._style_radio_buttons_butterfly()
         # add instructions at bottom
         instructions = (
@@ -1826,16 +1733,6 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             actives=self.mne.projs_on,
             **_get_check_kwargs(labels=labels, fgcolor=fig.mne.fgcolor),
         )
-        # gray-out already applied projectors
-        if _OLD_BUTTONS:
-            for label, rect, lines in zip(
-                checkboxes.labels, checkboxes.rectangles, checkboxes.lines
-            ):
-                if label.get_text().endswith("(already applied)"):
-                    label.set_color("0.5")
-                    rect.set_edgecolor("0.7")
-                    [x.set_color("0.7") for x in lines]
-                rect.set_linewidth(1)
         # add "toggle all" button
         ax_all = fig.add_axes((0.25, 0.01, 0.5, offset), frame_on=True)
         fig.mne.proj_all = Button(ax_all, "Toggle all")
@@ -2779,28 +2676,26 @@ def _init_browser(**kwargs):
 
 
 def _get_check_kwargs(labels=None, fgcolor=None):
-    check_kwargs = dict()
-    if not _OLD_BUTTONS:
-        check_kwargs.update(
-            check_props=dict(s=144, clip_on=False),
-            frame_props=dict(s=144, clip_on=False),
-        )
-        if fgcolor is not None:
-            # Color check marks (unfilled 'x' marker uses facecolor) and frame borders
-            check_kwargs["check_props"].update(facecolor=fgcolor)
-            check_kwargs["frame_props"].update(edgecolor=fgcolor)
-        if labels is not None:
-            textcolor = list()
-            checkcolor = list()
-            for label in labels:
-                if label.endswith("(already applied)"):
-                    textcolor.append("0.5")
-                    checkcolor.append("0.7")
-                else:
-                    _clr = fgcolor if fgcolor is not None else "k"
-                    textcolor.append(_clr)
-                    checkcolor.append(_clr)
-            check_kwargs["check_props"].update(facecolor=checkcolor, linewidth=1)
-            check_kwargs["frame_props"].update(edgecolor=checkcolor, linewidth=1)
-            check_kwargs["label_props"] = dict(color=textcolor)
+    check_kwargs = dict(
+        check_props=dict(s=144, clip_on=False),
+        frame_props=dict(s=144, clip_on=False),
+    )
+    if fgcolor is not None:
+        # Color check marks (unfilled 'x' marker uses facecolor) and frame borders
+        check_kwargs["check_props"].update(facecolor=fgcolor)
+        check_kwargs["frame_props"].update(edgecolor=fgcolor)
+    if labels is not None:
+        textcolor = list()
+        checkcolor = list()
+        for label in labels:
+            if label.endswith("(already applied)"):
+                textcolor.append("0.5")
+                checkcolor.append("0.7")
+            else:
+                _clr = fgcolor if fgcolor is not None else "k"
+                textcolor.append(_clr)
+                checkcolor.append(_clr)
+        check_kwargs["check_props"].update(facecolor=checkcolor, linewidth=1)
+        check_kwargs["frame_props"].update(edgecolor=checkcolor, linewidth=1)
+        check_kwargs["label_props"] = dict(color=textcolor)
     return check_kwargs

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -298,6 +298,7 @@ def _qt_get_stylesheet(theme):
                 "pip install qdarkstyle\n"
             )
         else:
+            # TODO VERSION remove on qdarkstyle 3.2.3+
             if api in ("PySide6", "PyQt6") and _compare_version(
                 qdarkstyle.__version__, "<", "3.2.3"
             ):

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -37,16 +37,11 @@ raw_fname = base_dir / "test_raw.fif"
 
 
 def _get_button_xy(buttons, idx):
-    from mne.viz._mpl_figure import _OLD_BUTTONS
-
-    if _OLD_BUTTONS:
-        return buttons.circles[idx].center
-    else:
-        # Each transform is to display coords, and our offsets are in Axes
-        # coords. We want data coords, so we go Axes -> display -> data.
-        return buttons.ax.transData.inverted().transform(
-            buttons.ax.transAxes.transform(buttons.ax.collections[0].get_offsets()[idx])
-        )
+    # Each transform is to display coords, and our offsets are in Axes
+    # coords. We want data coords, so we go Axes -> display -> data.
+    return buttons.ax.transData.inverted().transform(
+        buttons.ax.transAxes.transform(buttons.ax.collections[0].get_offsets()[idx])
+    )
 
 
 def _annotation_helper(raw, browse_backend, events=False):
@@ -408,6 +403,11 @@ def test_plot_raw_selection(raw, browser_backend):
     assert fig.mne.butterfly
     # test clicking on radio buttons → should cancel butterfly mode
     if ismpl:
+        # in butterfly mode all radio buttons show as selected
+        buttons = sel_fig.mne.radio_ax.buttons
+        facecolors = buttons.ax.collections[0].get_facecolor()
+        want = mcolors.to_rgba(buttons.activecolor)
+        assert_allclose(facecolors, [want] * len(facecolors))
         print(f"Clicking button: {repr(left_temp)}")
         assert sel_fig.mne.radio_ax.buttons.labels[0].get_text() == left_temp
         xy = _get_button_xy(sel_fig.mne.radio_ax.buttons, 0)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -502,24 +502,14 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
 
     # make edges around checkbox areas and change already-applied projectors
     # to red
-    from ._mpl_figure import _OLD_BUTTONS
-
-    check_kwargs = dict()
-    if not _OLD_BUTTONS:
-        checkcolor = ["#ff0000" if p["active"] else "k" for p in projs]
-        check_kwargs["check_props"] = dict(facecolor=checkcolor)
-        check_kwargs["frame_props"] = dict(edgecolor="0.5", linewidth=1)
+    checkcolor = ["#ff0000" if p["active"] else "k" for p in projs]
     proj_checks = widgets.CheckButtons(
-        ax_temp, labels=labels, actives=actives, **check_kwargs
+        ax_temp,
+        labels=labels,
+        actives=actives,
+        check_props=dict(facecolor=checkcolor),
+        frame_props=dict(edgecolor="0.5", linewidth=1),
     )
-    if _OLD_BUTTONS:
-        for rect in proj_checks.rectangles:
-            rect.set_edgecolor("0.5")
-            rect.set_linewidth(1.0)
-        for ii, p in enumerate(projs):
-            if p["active"]:
-                for x in proj_checks.lines[ii]:
-                    x.set_color("#ff0000")
 
     # make minimal size
     # pass key presses from option dialog over

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires = ["hatch-vcs", "hatchling >= 1.27"]
 dev = ["pip >= 25.1", "pre-commit", "pyside6 >= 6.11.1", "rcssmin >= 1.1", {include-group = "doc"}, {include-group = "test_extra"}]
 # Dependencies for building the documentation
 doc = [
+  # 0.22 moved normalize_options into docutils.parsers.rst.roles
+  "docutils >= 0.22",
   "graphviz",
   "intersphinx_registry >= 0.2405.27",
   "ipython != 8.7.0",  # also in "full-no-qt" and "test"
@@ -19,11 +21,11 @@ doc = [
   "psutil",
   "pydata-sphinx-theme >= 0.15.2",
   "pygments >= 2.13",
-  "pymef",
+  "pymef",  # released 2023-06-30, will become 0.12 on 2028-07-01
   "pyvistaqt >= 0.11",  # released 2023-06-30, will become 0.12 on 2028-07-01
   "pyxdf",
   "pyzmq != 24.0.0",
-  "refleak >= 0.2.1",
+  "refleak >= 0.2.1",  # released 2024-05-21, will become 1.6 on 2026-12-09
   "scikit-learn >= 1.5",  # released 2024-05-21, will become 1.6 on 2026-12-09
   "seaborn >= 0.5, != 0.11.2",
   "selenium >= 4.27.1",
@@ -151,7 +153,7 @@ full-no-qt = [
   "curryreader >= 0.1.2",
   "darkdetect",
   "defusedxml",
-  "dipy >= 0.8",
+  "dipy >= 1.9",  # released 2024-03-08, will become 1.10 on 2026-12-12
   "edfio >= 0.4.10",
   "eeglabio",
   "filelock >= 3.18.0",
@@ -165,13 +167,13 @@ full-no-qt = [
   "joblib >= 0.8",
   "jupyter",
   "mffpy >= 0.11.0",
-  "mne-qt-browser",
+  "mne-qt-browser >= 0.6",  # released 2023-10-11, will become 0.7 on 2027-04-08
   "mne[hdf5]",
   "neo",
   "nest-asyncio2",
-  "nibabel >= 2.0",
-  "nilearn",
-  "numba >= 0.35",
+  "nibabel >= 5.2",  # released 2023-12-11, will become 5.3 on 2026-10-08
+  "nilearn >= 0.10",  # released 2023-01-06, will become 0.11 on 2026-12-02
+  "numba >= 0.60",  # released 2024-06-13, will become 0.61 on 2027-01-20
   "openmeeg >= 2.5.7",
   "pandas >= 2.2, != 3.0.4",  # released 2024-01-20, will become 2.3 on 2027-06-05
   "pillow",  # for `Brain.save_image` and `mne.Report`

--- a/tools/circleci_bash_env.sh
+++ b/tools/circleci_bash_env.sh
@@ -10,9 +10,14 @@ if [[ $(lsb_release -rs) == "26.04" ]]; then
 else
     EXTRA_DEPS=""
 fi
-sudo apt install -qq graphviz optipng python3-venv libxft2 ffmpeg r-base libtirpc-dev $EXTRA_DEPS
+APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+# no -qq: it hides download progress, which trips CircleCI's 10 min no-output timeout (gh-14103)
+sudo apt install -y $APT_OPTS graphviz optipng python3-venv libxft2 ffmpeg libtirpc-dev $EXTRA_DEPS
+# r-base-dev rather than r-base: rpy2-rinterface has no manylinux wheel so it builds against
+# R's headers, but we don't need r-recommended (the r-cran-* set) or the html manuals
+sudo apt install -y $APT_OPTS r-base-dev
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo apt install ./google-chrome-stable_current_amd64.deb
+sudo apt install -y $APT_OPTS ./google-chrome-stable_current_amd64.deb
 python -m venv ~/python_env
 echo "set -e" >> $BASH_ENV
 echo "set -o pipefail" >> $BASH_ENV

--- a/tools/dev/spec_zero_update_versions.py
+++ b/tools/dev/spec_zero_update_versions.py
@@ -53,7 +53,12 @@ from tomlkit.items import Comment, Trivia
 from tomlkit.toml_file import TOMLFile
 
 SORT_PACKAGES = [
+    "dipy",
     "matplotlib",
+    "mne-qt-browser",
+    "nibabel",
+    "nilearn",
+    "numba",
     "numpy",
     "pandas",
     "pyvista",

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -9,13 +9,17 @@ for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do
     sudo rm $apt_file
 done
 
+# Give up on a stalled mirror connection quickly and retry instead of hanging (gh-14103)
+APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+
 # This also includes the libraries necessary for Qt6
-sudo apt update
+sudo apt update $APT_OPTS
 # Need two different libxml2 variants for 24.04 and 26.04
 if [[ $(lsb_release -rs) == "26.04" ]]; then
     XML_DEP=libxml2-16
 else
     XML_DEP=libxml2
 fi
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0 $XML_DEP
+# no -qq: it hides download progress, which trips CircleCI's 10 min no-output timeout
+sudo apt install -y $APT_OPTS xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0 $XML_DEP
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
I used Claude Opus 5 to look for places we had cruft / technical debt from old versions, and places that we should have TODO VERSION and don't. It found a lot, including a bug regarding buttons:
```python
from pathlib import Path

import mne

mne.viz.set_browser_backend("matplotlib")
fname = Path(mne.__file__).parent / "io" / "tests" / "data" / "test_raw.fif"
raw = mne.io.read_raw_fif(fname, verbose="error").crop(0, 5).pick("mag")
fig = raw.plot(group_by="selection", block=True)

buttons = fig.mne.fig_selection.mne.radio_ax.buttons
print(buttons.ax.collections[0].get_facecolor())
```
Click the Channel selection window and press b: on this branch every radio button fills in; on `main` only the active one does.

Also moves a few packages into SPEC0-checking (nilearn, dipy, nibabel, mne-qt-browser, numba) as it allows us to remove some old code / checks. And includes a tiny fix that hopefully helps CircleCI when there are `apt` downloading issues.

Opus drafted the changes but I iterated until I was happy with them.