### PR TITLE
Fix bugs with dark mode panels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,9 @@ changelog entry instead of a plain name link.
 - Prefer the `testing` dataset over `sample`/other large datasets in tests (smaller, faster).
 - Prefer to keep unit tests compact and add to existing tests when possible. The full test suite takes about an hour on CIs, so minimizing test time (for CIs) and test verbosity (for reviewers) is important.
 - When new functionality is added, it is good in general to add it somewhere in an example (`examples/`) or a tutorial (`tutorials/`) to help with discoverability and documentation.
+- Code adapted from an outside source must be under a BSD-compatible license (BSD, MIT, ISC, Apache-2.0, public domain, ...); GPL/LGPL/AGPL and non-commercial or no-derivatives licenses are not acceptable. Attribute it in a comment directly above the adapted code, naming the source (URL and/or author) and its license, e.g.:
+  ```python
+  # Adapted from https://example.com/post by A. Nother, released under the MIT license
+  # (BSD-compatible).
+  ```
+  If the license of a snippet cannot be determined, do not adapt it.

--- a/doc/changes/dev/14109.bugfix.rst
+++ b/doc/changes/dev/14109.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed bug where dialogs of :meth:`mne.io.Raw.plot` did not respect dark mode, by
+`Eric Larson`_.

--- a/doc/changes/dev/14109.bugfix.rst
+++ b/doc/changes/dev/14109.bugfix.rst
@@ -1,2 +1,1 @@
-Fixed bug where dialogs of :meth:`mne.io.Raw.plot` did not respect dark mode, by
-`Eric Larson`_.
+Fixed bug where dialogs of :meth:`mne.io.Raw.plot` did not respect dark mode, by `Eric Larson`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -84,6 +84,7 @@ from ..ui_events import (
 from ..utils import (
     _generate_default_filename,
     _get_color_list,
+    _is_dark,
     _save_ndarray_img,
     concatenate_images,
     safe_event,
@@ -350,7 +351,7 @@ class Brain:
 
         self._bg_color = _to_rgb(background, name="background")
         if foreground is None:
-            foreground = "w" if sum(self._bg_color) < 2 else "k"
+            foreground = "w" if _is_dark(self._bg_color, name="background") else "k"
         self._fg_color = _to_rgb(foreground, name="foreground")
         del background, foreground
         views = _check_views(surf, views, hemi)

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -38,7 +38,6 @@ matplotlib.figure.Figure
 import datetime
 import platform
 from collections import OrderedDict, defaultdict
-from colorsys import rgb_to_hsv
 from contextlib import contextmanager
 from functools import partial
 
@@ -58,7 +57,7 @@ from .._fiff.pick import (
 )
 from ..defaults import DEFAULTS
 from ..fixes import _close_event
-from ..utils import Bunch, _click_ch_name, _to_rgb, logger
+from ..utils import Bunch, _click_ch_name, logger
 from ._figure import BrowserBase
 from .utils import (
     _BLIT_KWARGS,
@@ -67,6 +66,7 @@ from .utils import (
     _fake_click,
     _fake_keypress,
     _fake_scroll,
+    _is_dark,
     _merge_annotations,
     _set_window_title,
     _validate_if_list_of_axes,
@@ -135,13 +135,6 @@ def _resolve_mpl_theme(theme):
 
         return _qt_detect_theme()
     return theme
-
-
-def _is_dark(color):
-    """Check whether a background color calls for light foreground colors."""
-    # mne-qt-browser decides this via oklab lightness; HSV value agrees with it across
-    # the range of backgrounds we care about
-    return rgb_to_hsv(*_to_rgb(color))[2] < 0.5
 
 
 def _apply_mpl_theme_to_kwargs(kwargs):

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -38,6 +38,7 @@ matplotlib.figure.Figure
 import datetime
 import platform
 from collections import OrderedDict, defaultdict
+from colorsys import rgb_to_hsv
 from contextlib import contextmanager
 from functools import partial
 
@@ -57,7 +58,7 @@ from .._fiff.pick import (
 )
 from ..defaults import DEFAULTS
 from ..fixes import _close_event
-from ..utils import Bunch, _click_ch_name, logger
+from ..utils import Bunch, _click_ch_name, _to_rgb, logger
 from ._figure import BrowserBase
 from .utils import (
     _BLIT_KWARGS,
@@ -136,14 +137,25 @@ def _resolve_mpl_theme(theme):
     return theme
 
 
+def _is_dark(color):
+    """Check whether a background color calls for light foreground colors."""
+    # mne-qt-browser decides this via oklab lightness; HSV value agrees with it across
+    # the range of backgrounds we care about
+    return rgb_to_hsv(*_to_rgb(color))[2] < 0.5
+
+
 def _apply_mpl_theme_to_kwargs(kwargs):
     """Apply dark theme colors to browser kwargs in-place."""
     theme = kwargs.get("theme", "auto")
-    if _resolve_mpl_theme(theme) != "dark":
+    if _resolve_mpl_theme(theme) == "dark":
+        # bgcolor: override if absent or still at the light default "w"
+        if kwargs.get("bgcolor", "w") == "w":
+            kwargs["bgcolor"] = _DARK_BGCOLOR
+    # follow the resolved background rather than the theme, so an explicitly light
+    # bgcolor never gets light-on-light styling (mne-qt-browser derives it the same way)
+    kwargs["dark"] = _is_dark(kwargs.get("bgcolor", "w"))
+    if not kwargs["dark"]:
         return
-    # bgcolor: override if absent or still at the light default "w"
-    if kwargs.get("bgcolor", "w") == "w":
-        kwargs["bgcolor"] = _DARK_BGCOLOR
     # fgcolor: inject if not explicitly set by the caller
     kwargs.setdefault("fgcolor", _DARK_FGCOLOR)
     # bad channel colors: override if still at the light default
@@ -179,7 +191,9 @@ class MNEFigure(Figure):
         super().__init__(figsize=figsize)
         # things we'll almost always want
         defaults = dict(
-            fgcolor=rcParams["axes.edgecolor"], bgcolor=rcParams["axes.facecolor"]
+            fgcolor=rcParams["axes.edgecolor"],
+            bgcolor=rcParams["axes.facecolor"],
+            dark=False,
         )
         for key, value in defaults.items():
             if key not in kwargs:
@@ -650,7 +664,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         )
 
         # apply theme colors (dark mode only)
-        if self.mne.bgcolor == _DARK_BGCOLOR:
+        if self.mne.dark:
             self.patch.set_facecolor(self.mne.bgcolor)
             for _ax in (ax_hscroll, ax_vscroll):
                 _ax.set_facecolor(self.mne.bgcolor)
@@ -1034,6 +1048,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         """Instantiate a new MNE dialog figure (with event listeners)."""
         kwargs.setdefault("bgcolor", self.mne.bgcolor)
         kwargs.setdefault("fgcolor", self.mne.fgcolor)
+        kwargs.setdefault("dark", self.mne.dark)
         fig = _figure(
             toolbar=False,
             parent_fig=self,
@@ -1296,7 +1311,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         )
 
         # apply theme colors to annotation dialog (dark mode only)
-        if fig.mne.bgcolor == _DARK_BGCOLOR:
+        if fig.mne.dark:
             fig.patch.set_facecolor(fig.mne.bgcolor)
             for _ax in fig.axes:
                 _ax.set_facecolor(fig.mne.bgcolor)
@@ -1579,6 +1594,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
 
     def _create_selection_fig(self):
         """Create channel selection dialog window."""
+        from matplotlib.colors import to_rgba
         from matplotlib.widgets import RadioButtons
 
         # make figure
@@ -1610,10 +1626,15 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         selections_dict = self.mne.ch_selections
         selections_dict.update(Custom=np.array([], dtype=int))  # for lasso
         labels = list(selections_dict)
-        # make & style the radio buttons; this dialog keeps a light background in
-        # both themes, so don't use mne.fgcolor (light gray under the dark theme)
+        # make & style the radio buttons (fgcolor is black under the light theme, so
+        # these match matplotlib's defaults there)
         radio_ax.buttons = RadioButtons(
-            radio_ax, labels, activecolor="k", **_BLIT_KWARGS
+            radio_ax,
+            labels,
+            activecolor=self.mne.fgcolor,
+            radio_props=dict(edgecolor=self.mne.fgcolor),
+            label_props=dict(color=[self.mne.fgcolor] * len(labels)),
+            **_BLIT_KWARGS,
         )
         fig.mne.old_selection = 0
         fig._style_radio_buttons_butterfly()
@@ -1626,10 +1647,27 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             "existing selection."
         )
         instructions_ax = fig.add_subplot(gs[-3:], frame_on=False)
-        instructions_ax.text(
-            0.04, 0.08, instructions, va="bottom", ha="left", ma="left", wrap=True
+        instr_text = instructions_ax.text(
+            0.04,
+            0.08,
+            instructions,
+            va="bottom",
+            ha="left",
+            ma="left",
+            wrap=True,
+            color=self.mne.fgcolor,
         )
         instructions_ax.set_axis_off()
+        # apply theme colors (dark mode only)
+        if fig.mne.dark:
+            fig.patch.set_facecolor(fig.mne.bgcolor)
+            for _ax in fig.axes:
+                _ax.set_facecolor(fig.mne.bgcolor)
+            instr_text.set_color(fig.mne.fgcolor)
+            # head outline / nose / ears are drawn black; the lasso line is red
+            for _line in fig.mne.sensor_ax.lines:
+                if to_rgba(_line.get_color()) == to_rgba("black"):
+                    _line.set_color(fig.mne.fgcolor)
         # add event listeners
         radio_ax.buttons.on_clicked(fig._radiopress)
         fig.lasso.callbacks.append(fig._set_custom_selection)
@@ -1747,6 +1785,14 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         )
         # save params
         fig.mne.proj_checkboxes = checkboxes
+        # apply theme colors (dark mode only); the checkbox labels already use fgcolor
+        if fig.mne.dark:
+            fig.patch.set_facecolor(fig.mne.bgcolor)
+            ax.set_facecolor(fig.mne.bgcolor)
+            ax.title.set_color(fig.mne.fgcolor)
+            ax_all.set_facecolor(_DARK_BUTTON_COLOR)
+            fig.mne.proj_all.color = _DARK_BUTTON_COLOR
+            fig.mne.proj_all.label.set_color(fig.mne.fgcolor)
         # show figure
         self.mne.fig_proj.canvas.draw()
         plt_show(fig=self.mne.fig_proj, warn=False)

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -9,7 +9,6 @@ import os
 import platform
 import signal
 import sys
-from colorsys import rgb_to_hls
 from contextlib import contextmanager
 from ctypes import c_char_p, c_void_p, cdll
 from pathlib import Path
@@ -18,7 +17,7 @@ import numpy as np
 
 from ...fixes import _compare_version, _reshape_view
 from ...utils import _check_qt_version, _validate_type, logger, warn
-from ..utils import _get_cmap
+from ..utils import _get_cmap, _is_dark
 
 VALID_BROWSE_BACKENDS = (
     "qt",
@@ -342,10 +341,9 @@ def _qt_raise_window(widget):
 
 
 def _qt_is_dark(widget):
-    # Ideally this would use CIELab, but this should be good enough
     win = widget.window()
     bgcolor = win.palette().color(win.backgroundRole()).getRgbF()[:3]
-    return rgb_to_hls(*bgcolor)[1] < 0.5
+    return _is_dark(bgcolor, name="bgcolor")
 
 
 def _pixmap_to_ndarray(pixmap):

--- a/mne/viz/backends/tests/test_utils.py
+++ b/mne/viz/backends/tests/test_utils.py
@@ -2,8 +2,6 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from colorsys import rgb_to_hls
-
 import numpy as np
 import pytest
 
@@ -15,6 +13,7 @@ from mne.viz.backends._utils import (
     _pixmap_to_ndarray,
     _qt_is_dark,
 )
+from mne.viz.utils import _is_dark
 
 
 def test_get_colormap_from_array():
@@ -52,7 +51,7 @@ def _assert_correct_darkness(widget, want_dark):
     __tracebackhide__ = True  # noqa
     # The override propagates to children, so both palette and pixels should match.
     bgcolor = widget.palette().color(widget.backgroundRole()).getRgbF()[:3]
-    dark = rgb_to_hls(*bgcolor)[1] < 0.5
+    dark = _is_dark(bgcolor)
     assert dark == want_dark, f"{widget} palette dark={dark} want_dark={want_dark}"
     colors = _pixmap_to_ndarray(widget.grab())[:, :, :3]
     dark = colors.mean() < 0.5

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -55,6 +55,7 @@ from .utils import (
     _draw_proj_checkbox,
     _get_cmap,
     _get_color_list,
+    _is_dark,
     _make_combine_callable,
     _plot_masked_image,
     _prepare_joint_axes,
@@ -1256,7 +1257,7 @@ def plot_evoked_topo(
         evoked = [evoked]
 
     background_color = _to_rgb(background_color, name="background_color")
-    dark_background = np.mean(background_color) < 0.5
+    dark_background = _is_dark(background_color, name="background_color")
     if dark_background:
         fig_facecolor = background_color
         axis_facecolor = background_color

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -24,6 +24,7 @@ from mne.viz.utils import (
     _fake_keypress,
     _fake_scroll,
     _get_color_list,
+    _is_dark,
     _make_event_color_dict,
     _setup_vmin_vmax,
     _validate_if_list_of_axes,
@@ -75,6 +76,25 @@ def test_get_color_list():
         colors_no_red = _get_color_list(remove=("#ff0000",))
         assert "#ff0000" not in colors_no_red
         assert len(colors_no_red) == 1
+
+
+def test_is_dark():
+    """Test that background darkness is judged perceptually."""
+    wants = {
+        "k": True,
+        "w": False,
+        "#1e1e1e": True,  # dark theme background
+        "#d0d0d0": False,  # dark theme foreground
+        (0.5, 0.5, 0.5): False,  # midtone gray reads as light in Oklab
+        (0.0, 0.0, 0.0, 1.0): True,  # RGBA is okay, too
+        # saturated colors need perceptual lightness to get right
+        "b": True,
+        "yellow": False,
+    }
+    for color, want in wants.items():
+        assert _is_dark(color) is want, color
+    with pytest.raises(ValueError, match="Invalid RGB argument.*for bgcolor"):
+        _is_dark("not_a_color", name="bgcolor")
 
 
 def test_mne_analyze_colormap():

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -13,7 +13,7 @@ from scipy import ndimage
 
 from .._fiff.pick import _FNIRS_CH_TYPES_SPLIT, _picks_to_idx, channel_type, pick_types
 from ..defaults import _handle_default
-from ..utils import Bunch, _check_option, _clean_names, _is_numeric, _to_rgb, fill_doc
+from ..utils import Bunch, _check_option, _clean_names, _is_numeric, fill_doc
 from .ui_events import ChannelsSelect, TimeChange, link, publish, subscribe
 from .utils import (
     DraggableColorbar,
@@ -21,6 +21,7 @@ from .utils import (
     _check_cov,
     _check_delayed_ssp,
     _draw_proj_checkbox,
+    _is_dark,
     _plot_masked_image,
     _setup_ax_spines,
     _setup_vmin_vmax,
@@ -658,12 +659,11 @@ def _plot_timeseries(
 
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
-    facecol = _to_rgb(ax.get_facecolor())
-    face_brightness = np.dot(facecol, [299, 587, 114])
-    ax._cursorcolor = "white" if face_brightness < 150 else "black"
+    line_color = "white" if _is_dark(ax.get_facecolor()) else "black"
+    ax._cursorcolor = line_color
 
     ax._selectline = None
-    ax._selectcolor = "white" if face_brightness < 150 else "black"
+    ax._selectcolor = line_color
     if orig_fig._current_time is not None:
         _update_selectline(orig_fig._current_time)
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1811,6 +1811,28 @@ def _get_color_list(*, remove=None):
     return colors
 
 
+# sRGB -> LMS and LMS -> Oklab. Adapted from https://bottosson.github.io/posts/oklab/
+# by Björn Ottosson, released to the public domain (or MIT), BSD-compatible
+_M_SRGB_TO_LMS = np.array(
+    [
+        [0.4122214708, 0.5363325363, 0.0514459929],
+        [0.2119034982, 0.6806995451, 0.1073969566],
+        [0.0883024619, 0.2817188376, 0.6299787005],
+    ]
+)
+_V_LMS_TO_OKLAB_L = np.array([0.2104542553, 0.7936177850, -0.0040720468])
+
+
+def _is_dark(color, *, name="color"):
+    """Check whether a background color calls for light foreground colors."""
+    # Oklab lightness below 0.5, which is what mne-qt-browser uses
+    rgb = np.array(_to_rgb(color, name=name), float)
+    mask = rgb > 0.04045  # sRGB -> linear sRGB
+    rgb[mask] = ((rgb[mask] + 0.055) / 1.055) ** 2.4
+    rgb[~mask] /= 12.92
+    return bool(_V_LMS_TO_OKLAB_L @ np.cbrt(_M_SRGB_TO_LMS @ rgb) < 0.5)
+
+
 def _merge_annotations(start, stop, description, annotations, current=()):
     """Handle drawn annotations."""
     ends = annotations.onset + annotations.duration


### PR DESCRIPTION
#14108 unsurfaced that we don't consistently or correctly honor dark mode in our subpanels. This PR fixes it:
```
from pathlib import Path
import matplotlib.pyplot as plt
import mne

mne.viz.set_browser_backend("matplotlib")
fname = Path(mne.__file__).parent / "io" / "tests" / "data" / "test_raw.fif"
raw = mne.io.read_raw_fif(fname, verbose="error").crop(0, 5).pick("mag").load_data()
raw.set_annotations(mne.Annotations([1.0], [0.5], ["bad_x"]))

fig = raw.plot(group_by="selection", theme="dark", show=False)
for key in "?ja":  # help, SSP projectors, annotations
    fig._fake_keypress(key)
```
In this PR gives

<img width="1593" height="1073" alt="Screenshot 2026-07-27 at 4 42 51 PM" src="https://github.com/user-attachments/assets/04491432-27af-41cf-8ec2-91436fb57ea7" />

Don't think a test is needed for this one but could add if needed. Drafted changes with Opus 4.8.