### PR TITLE
fix for scipy sparse deprecations

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -228,6 +228,8 @@ def pytest_configure(config: pytest.Config):
     # nitime <-> NumPy 2.5 (https://github.com/nipy/nitime/pull/236)
     ignore:Setting the shape on a NumPy array has been deprecated.*:DeprecationWarning
     ignore:Implicitly cleaning up.*:ResourceWarning
+    # Scipy deprecation warning via sklearn (present as of sklearn 1.10.dev0 2026-09-31)
+    ignore:(csr|csc|coo)_matrix is being replaced by \1_array
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -229,7 +229,7 @@ def pytest_configure(config: pytest.Config):
     ignore:Setting the shape on a NumPy array has been deprecated.*:DeprecationWarning
     ignore:Implicitly cleaning up.*:ResourceWarning
     # Scipy deprecation warning via sklearn (present as of sklearn 1.10.dev0 2026-09-31)
-    ignore:(csr|csc|coo|dok)_matrix is being replaced by \1_array
+    ignore:(csr|csc|coo|dok|lil)_matrix is being replaced by \1_array
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -229,7 +229,7 @@ def pytest_configure(config: pytest.Config):
     ignore:Setting the shape on a NumPy array has been deprecated.*:DeprecationWarning
     ignore:Implicitly cleaning up.*:ResourceWarning
     # Scipy deprecation warning via sklearn (present as of sklearn 1.10.dev0 2026-09-31)
-    ignore:(csr|csc|coo|dok|lil)_matrix is being replaced by \1_array
+    ignore:(bsr|coo|csc|csr|dia|dok|lil)_matrix is being replaced by \1_array
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -229,7 +229,7 @@ def pytest_configure(config: pytest.Config):
     ignore:Setting the shape on a NumPy array has been deprecated.*:DeprecationWarning
     ignore:Implicitly cleaning up.*:ResourceWarning
     # Scipy deprecation warning via sklearn (present as of sklearn 1.10.dev0 2026-09-31)
-    ignore:(csr|csc|coo)_matrix is being replaced by \1_array
+    ignore:(csr|csc|coo|dok)_matrix is being replaced by \1_array
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -45,17 +45,17 @@ def combine_adjacency(*structure):
     dimension by passing a matrix of zeros. For example:
 
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from mne.stats import combine_adjacency
     >>> n_times, n_freqs, n_chans = (50, 7, 16)
-    >>> chan_adj = diags([1., 1.], offsets=(-1, 1), shape=(n_chans, n_chans))
+    >>> chan_adj = diags_array([1., 1.], offsets=(-1, 1), shape=(n_chans, n_chans))
     >>> combine_adjacency(
     ...     n_times,  # regular lattice adjacency for times
     ...     np.zeros((n_freqs, n_freqs)),  # no adjacency between freq. bins
     ...     chan_adj,  # custom matrix, or use mne.channels.find_ch_adjacency
     ...     )  # doctest: +SKIP
-    <5600x5600 sparse array of type '<class 'numpy.float64'>'
-            with 27076 stored elements in COOrdinate format>
+    <COOrdinate sparse array of dtype 'float64'
+            with 27076 stored elements and shape (5600, 5600)>
     """
     structure = list(structure)
     for di, dim in enumerate(structure):

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -263,9 +263,9 @@ def linear_regression_raw(
         if solver == "cholesky":
 
             def solver(X, y):
-                a = (X.T * X).toarray()  # dot product of sparse matrices
+                a = (X.T @ X).toarray()  # dot product of sparse matrices
                 return linalg.solve(
-                    a, X.T * y, assume_a="pos", overwrite_a=True, overwrite_b=True
+                    a, X.T @ y, assume_a="pos", overwrite_a=True, overwrite_b=True
                 ).T
 
     elif callable(solver):

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -391,7 +391,7 @@ def _prepare_rerp_preds(
             values = np.ones((len(onsets), n_lags)) * v[:, np.newaxis]
 
         cond_length[cond] = len(onsets)
-        xs.append(sparse.dia_matrix((values, onsets), shape=(n_samples, n_lags)))
+        xs.append(sparse.dia_array((values, onsets), shape=(n_samples, n_lags)))
 
     return sparse.hstack(xs), conds, cond_length, tmin_s, tmax_s
 

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -7,8 +7,7 @@ from inspect import signature
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
-from scipy.sparse import csr_array
-from scipy.sparse import eye as speye
+from scipy.sparse import csr_array, eye_array
 from scipy.spatial.distance import cdist
 
 import mne
@@ -276,7 +275,7 @@ def test_surface_source_morph_shortcut(subjects_dir_tmp):
     )
     stc_back = morph_identity.apply(stc)
     assert_allclose(stc_back.data, stc.data, rtol=1e-4)
-    abs_sum = morph_identity.morph_mat - speye(len(stc.data), format="csc")
+    abs_sum = morph_identity.morph_mat - eye_array(len(stc.data), format="csc")
     abs_sum = np.abs(abs_sum.data).sum()
     assert abs_sum < 1e-4
 

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -15,7 +15,6 @@ from datetime import date, datetime, timedelta, timezone
 from io import BytesIO, StringIO
 from math import ceil, sqrt
 from pathlib import Path
-from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 from scipy import sparse
@@ -732,17 +731,9 @@ def object_size(x, memo=None):
 
 
 def _is_sparse_cs(x):
-    with catch_warnings(category=DeprecationWarning):
-        filterwarnings(
-            action="ignore",
-            message=r"(csr|csc)_matrix is being replaced by \1_array",
-            category=DeprecationWarning,
-            module="scipy",
-        )
-        return isinstance(
-            x,
-            sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array,
-        )
+    return isinstance(
+        x, sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array
+    )
 
 
 def _sort_keys(x):

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -15,6 +15,7 @@ from datetime import date, datetime, timedelta, timezone
 from io import BytesIO, StringIO
 from math import ceil, sqrt
 from pathlib import Path
+from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 from scipy import sparse
@@ -731,9 +732,17 @@ def object_size(x, memo=None):
 
 
 def _is_sparse_cs(x):
-    return isinstance(
-        x, sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array
-    )
+    with catch_warnings(category=DeprecationWarning):
+        filterwarnings(
+            action="ignore",
+            message=r"(csr|csc)_matrix is being replaced by \1_array",
+            category=DeprecationWarning,
+            module="scipy",
+        )
+        return isinstance(
+            x,
+            sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array,
+        )
 
 
 def _sort_keys(x):


### PR DESCRIPTION
some of these are coming in via sklearn and need to be ignored, but I've also removed the few instances in our code where we call sparse.eye, csc_matrix, etc.