### PR TITLE
Assign instead of compare when marking explicit zeros in spatio_temporal_dist_adjacency

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3232,7 +3232,7 @@ def spatio_temporal_dist_adjacency(src, n_times, dist, verbose=None):
         if isinstance(block, np.ndarray):
             block[block == 0] = -np.inf
         else:
-            block.data[block.data == 0] == -1
+            block.data[block.data == 0] = -1
         blocks[bi] = sparse.csr_array(block)  # avoid SciPy dep warning about mat->arr
     edges = sparse.block_diag(blocks)
     edges.data[:] = np.less_equal(edges.data, dist)


### PR DESCRIPTION
#### Reference issue (if any)

None.

#### What does this implement/fix?

In `spatio_temporal_dist_adjacency` the sparse branch of the "keep explicit zeros" loop is a comparison, not an assignment:

```python
# Ensure we keep explicit zeros; deal with changes in SciPy
for bi, block in enumerate(blocks):
    if isinstance(block, np.ndarray):
        block[block == 0] = -np.inf
    else:
        block.data[block.data == 0] == -1   # result discarded
```

The dense branch one line up does assign. The sparse one has read `==` since the guard was added in 3545c3f (#8050, Jul 2020), so for sparse `src['dist']` the explicit zeros have never actually been marked.

#### Additional information

I could not find a case where this changes the returned adjacency, and I do not want to claim more than I checked. With SciPy 1.13 the explicit zeros survive both the `csr_array` conversion and `block_diag`, and `np.less_equal` maps a stored `0` and a stored `-1` to the same `True`, so the two branches agree today:

```python
import numpy as np
from scipy import sparse

rows = [0, 0, 0, 1, 1, 1, 2, 2, 2]
cols = [0, 1, 2, 0, 1, 2, 0, 1, 2]
data = [0.0, 0.02, 0.5, 0.02, 0.0, 0.03, 0.5, 0.03, 0.0]
blk = sparse.csr_matrix((data, (rows, cols)), shape=(3, 3))     # 3 explicit zeros

def run(block, dist=0.1):
    e = sparse.csr_array(sparse.block_diag([sparse.csr_array(block)]).tocsr())
    e.data[:] = np.less_equal(e.data, dist)
    e.eliminate_zeros()
    return e.toarray()

marked = blk.copy()
marked.data[marked.data == 0] = -1
assert np.array_equal(run(blk), run(marked))    # passes
```

So this is not a behaviour fix on current SciPy. It is the line doing what the comment next to it says it does, and what the dense branch already does — the comment's "deal with changes in SciPy" is exactly the case the marking is meant to survive, and right now it would not.

Slicing does preserve the explicit zeros (`src['dist'][vertno, :][:, vertno]` keeps `nnz` including the stored `0`s on SciPy 1.13), so there is something for the assignment to act on.

No changelog entry, since there is no user-facing change; happy to add one if you would rather have it recorded.

AI assistance, per the policy: the line was surfaced by a static-analysis sweep (ruff `B015`) run with Claude Opus in Claude Code, which also wrote the one-character patch and the SciPy check above. I reviewed the diff, the blame and the reasoning about whether it changes results before submitting.
