### PR TITLE
Fix `statsmodels` `FutureWarning` for Yule-Walker estimation

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import numpy as np
 import pytest
+from packaging.version import Version
 from pytest import StashKey, register_assert_rewrite
 from refleak.testing import Snapshot, assert_no_instances, gc_collect_once
 
@@ -235,9 +236,19 @@ def pytest_configure(config: pytest.Config):
         if warning_line and not warning_line.startswith("#"):
             config.addinivalue_line("filterwarnings", warning_line)
     try:
-        pass
+        import pandas
     except Exception:
         pass
+    else:
+        if Version(pandas.__version__) >= Version("3.1.0.dev0"):
+            # TODO VERSION once statsmodels dev has updated for pip-pre
+            # (failing as of 2026/08/05)
+            config.addinivalue_line(
+                "filterwarnings",
+                "ignore:"
+                ".+ is deprecated and will be removed in a future version.*:"
+                "pandas.errors.Pandas4Warning",
+            )
 
     # Deal with pytest-qt -- everything should already be skipped for example by not
     # having pyvistaqt installed, so we just need to take care of defining dummy

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -20,7 +20,6 @@ from unittest import mock
 
 import numpy as np
 import pytest
-from packaging.version import Version
 from pytest import StashKey, register_assert_rewrite
 from refleak.testing import Snapshot, assert_no_instances, gc_collect_once
 
@@ -236,19 +235,9 @@ def pytest_configure(config: pytest.Config):
         if warning_line and not warning_line.startswith("#"):
             config.addinivalue_line("filterwarnings", warning_line)
     try:
-        import pandas
+        pass
     except Exception:
         pass
-    else:
-        if Version(pandas.__version__) >= Version("3.1.0.dev0"):
-            # TODO VERSION once statsmodels dev has updated for pip-pre
-            # (failing as of 2026/02/04)
-            config.addinivalue_line(
-                "filterwarnings",
-                "ignore:"
-                ".+ is deprecated and will be removed in a future version.*:"
-                "pandas.errors.Pandas4Warning",
-            )
 
     # Deal with pytest-qt -- everything should already be skipped for example by not
     # having pyvistaqt installed, so we just need to take care of defining dummy

--- a/mne/time_frequency/tests/test_ar.py
+++ b/mne/time_frequency/tests/test_ar.py
@@ -11,6 +11,7 @@ from scipy.signal import lfilter
 
 from mne import io
 from mne.time_frequency.ar import _yule_walker, fit_iir_model_raw
+from mne.utils import check_version
 
 raw_fname = Path(__file__).parents[2] / "io" / "tests" / "data" / "test_raw.fif"
 
@@ -21,9 +22,13 @@ def test_yule_walker():
     pytest.importorskip("statsmodels", "0.8")
     from statsmodels.regression.linear_model import yule_walker as sm_yw
 
+    yw_kwargs = dict()
+    if check_version("statsmodels", "0.15"):
+        yw_kwargs.update(use_namedtuple=False)
+
     rng = np.random.default_rng(0)
     d = rng.standard_normal(100)
-    sm_rho, sm_sigma = sm_yw(d, order=2)
+    sm_rho, sm_sigma = sm_yw(d, order=2, **yw_kwargs)
     rho, sigma = _yule_walker(d[np.newaxis], order=2)
     assert_array_almost_equal(sm_sigma, sigma)
     assert_array_almost_equal(sm_rho, rho)


### PR DESCRIPTION
`pip-pre` test runs failing due to a `statsmodels` `FutureWarning` (see e.g., https://github.com/mne-tools/mne-python/actions/runs/31015622468/job/92338994830?pr=13971):
```
mne/time_frequency/tests/test_ar.py:26: in test_yule_walker
    sm_rho, sm_sigma = sm_yw(d, order=2)
                       ^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/statsmodels/regression/linear_model.py:1618: in yule_walker
    warnings.warn(
E   FutureWarning: yule_walker currently returns a plain tuple whose length depends on the inv argument. In release 0.16 or after July 2028, whichever is later, the default behavior will switch to always returning a YuleWalkerResult NamedTuple. Set use_namedtuple=True to switch now, or use_namedtuple=False to keep the current behavior and silence this warning.
```

These changes retain the current behaviour and silence the warning.