### PR TITLE
ENH: read EGI MFF `channelStatus` into raw.info["bads"]

### DIFF
--- a/doc/changes/dev/14156.newfeature.rst
+++ b/doc/changes/dev/14156.newfeature.rst
@@ -1,1 +1,1 @@
-:func:`mne.io.read_raw_egi` now reads bad channels from ``categories.xml`` (when present in the MFF directory) and populates :attr:`mne.Info.bads` with channels marked ``exclusion="badChannels"`` in NetStation. By `Pragnya Khandelwal`_.
+:func:`mne.io.read_raw_egi` now reads bad channels from ``categories.xml`` (when present in the MFF directory) and populates :class:`info["bads"] <mne.Info>` with channels marked ``exclusion="badChannels"`` in NetStation. By `Pragnya Khandelwal`_.

--- a/doc/changes/dev/14156.newfeature.rst
+++ b/doc/changes/dev/14156.newfeature.rst
@@ -1,0 +1,1 @@
+:func:`mne.io.read_raw_egi` now reads bad channels from ``categories.xml`` (when present in the MFF directory) and populates :attr:`mne.Info.bads` with channels marked ``exclusion="badChannels"`` in NetStation. By `Pragnya Khandelwal`_.

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -6,7 +6,6 @@
 
 import datetime
 import math
-import os.path as op
 import re
 from collections import OrderedDict
 from pathlib import Path
@@ -114,7 +113,7 @@ def _read_mff_header(filepath):
     eeg_info_file = all_files["EEG"]["info"]
 
     # 1. Parse info.xml natively via absolute path
-    info_filepath = op.join(filepath, "info.xml")
+    info_filepath = Path(filepath) / "info.xml"
     info_obj = XML.from_file(info_filepath)
 
     mff_vers_elem = info_obj.find("mffVersion")
@@ -186,7 +185,7 @@ def _read_mff_header(filepath):
     summaryinfo["disk_samps"] = disk_samps
 
     # 2. Parse sensorLayout.xml natively via absolute path
-    sensor_layout_filepath = op.join(filepath, "sensorLayout.xml")
+    sensor_layout_filepath = Path(filepath) / "sensorLayout.xml"
     sensor_layout_obj = XML.from_file(sensor_layout_filepath)
 
     summaryinfo["device"] = getattr(sensor_layout_obj, "name", "Unknown")
@@ -227,7 +226,7 @@ def _read_mff_header(filepath):
             )
 
         # 3. Parse pnsSet.xml using the fallback shim in fixes.py
-        pns_set_filepath = op.join(filepath, "pnsSet.xml")
+        pns_set_filepath = Path(filepath) / "pnsSet.xml"
         pns_obj = XML.from_file(pns_set_filepath)
 
         pns_types = []
@@ -325,8 +324,8 @@ def _read_locs(filepath, egi_info, channel_naming):
     _soft_import("mffpy", "reading EGI MFF data")
     from mffpy.xml_files import XML
 
-    fname = op.join(filepath, "coordinates.xml")
-    if not op.exists(fname):
+    fname = filepath / "coordinates.xml"
+    if not fname.exists():
         warn("File coordinates.xml not found, not setting channel locations")
         ch_names = [channel_naming % (i + 1) for i in range(egi_info["n_channels"])]
         return ch_names, None
@@ -556,7 +555,7 @@ class RawMff(BaseRaw):
             with info._unlock():
                 info["bads"] = bads
 
-        file_bin = op.join(input_fname, egi_info["eeg_fname"])
+        file_bin = input_fname / egi_info["eeg_fname"]
         egi_info["egi_events"] = egi_events
         egi_info["mff_path"] = input_fname
 
@@ -593,7 +592,7 @@ class RawMff(BaseRaw):
 
         if len(idx["pns"]):
             # PNS Data is present and should be read:
-            egi_info["pns_filepath"] = op.join(input_fname, egi_info["pns_fname"])
+            egi_info["pns_filepath"] = input_fname / egi_info["pns_fname"]
             # Check for PNS bug immediately
             pns_samples = np.sum(egi_info["pns_sample_blocks"]["samples_block"])
             eeg_samples = np.sum(egi_info["samples_block"])

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -82,7 +82,7 @@ def _read_channel_status_bads(filepath, ch_names, pns_names):
     from mffpy.xml_files import XML
 
     try:
-        cats_obj = XML.from_file(cats_path)
+        cats_obj = XML.from_file(str(cats_path))
     except Exception:
         return []
     bads = set()
@@ -114,7 +114,7 @@ def _read_mff_header(filepath):
 
     # 1. Parse info.xml natively via absolute path
     info_filepath = Path(filepath) / "info.xml"
-    info_obj = XML.from_file(info_filepath)
+    info_obj = XML.from_file(str(info_filepath))
 
     mff_vers_elem = info_obj.find("mffVersion")
     if mff_vers_elem is None:
@@ -186,7 +186,7 @@ def _read_mff_header(filepath):
 
     # 2. Parse sensorLayout.xml natively via absolute path
     sensor_layout_filepath = Path(filepath) / "sensorLayout.xml"
-    sensor_layout_obj = XML.from_file(sensor_layout_filepath)
+    sensor_layout_obj = XML.from_file(str(sensor_layout_filepath))
 
     summaryinfo["device"] = getattr(sensor_layout_obj, "name", "Unknown")
     chan_type = list()
@@ -227,7 +227,7 @@ def _read_mff_header(filepath):
 
         # 3. Parse pnsSet.xml using the fallback shim in fixes.py
         pns_set_filepath = Path(filepath) / "pnsSet.xml"
-        pns_obj = XML.from_file(pns_set_filepath)
+        pns_obj = XML.from_file(str(pns_set_filepath))
 
         pns_types = []
         pns_units = []

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -67,6 +67,42 @@ def _disk_range_to_epochs(egi_info, disk_start, disk_stop):
         yield ei, t0, dt, ov_start - disk_start, ov_stop - disk_start
 
 
+def _read_channel_status_bads(filepath, ch_names, pns_names):
+    """Return bad channel names from categories.xml channelStatus, if present.
+
+    EGI NetStation writes per-epoch bad-channel lists into ``categories.xml``
+    as ``<channelStatus>`` elements.  This function collects the union of all
+    channels marked ``exclusion="badChannels"`` across every category and
+    segment and maps them back to MNE channel names.
+
+    Returns an empty list when ``categories.xml`` is absent or unparseable.
+    """
+    cats_path = op.join(filepath, "categories.xml")
+    if not op.isfile(cats_path):
+        return []
+    from mffpy.xml_files import XML
+
+    try:
+        cats_obj = XML.from_file(cats_path)
+    except Exception:
+        return []
+    bads = set()
+    for segments in cats_obj.categories.values():
+        for seg in segments:
+            for entry in seg.get("channelStatus") or []:
+                if entry["exclusion"] != "badChannels":
+                    continue
+                if entry["signalBin"] == 1:
+                    for ch in entry["channels"]:
+                        if 1 <= ch <= len(ch_names):
+                            bads.add(ch_names[ch - 1])
+                elif entry["signalBin"] == 2:
+                    for ch in entry["channels"]:
+                        if 1 <= ch <= len(pns_names):
+                            bads.add(pns_names[ch - 1])
+    return sorted(bads)
+
+
 def _read_mff_header(filepath):
     """Read mff header."""
     _soft_import("mffpy", "reading EGI MFF data")
@@ -513,6 +549,14 @@ class RawMff(BaseRaw):
                 for chan in info["chs"]:
                     if chan["kind"] == FIFF.FIFFV_EEG_CH:
                         chan["loc"][3:6] = ref_coords
+
+        # Mark bad channels from categories.xml channelStatus if present
+        bads = _read_channel_status_bads(
+            input_fname, ch_names, egi_info.get("pns_names", [])
+        )
+        if bads:
+            with info._unlock():
+                info["bads"] = bads
 
         file_bin = op.join(input_fname, egi_info["eeg_fname"])
         egi_info["egi_events"] = egi_events

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -77,8 +77,8 @@ def _read_channel_status_bads(filepath, ch_names, pns_names):
 
     Returns an empty list when ``categories.xml`` is absent or unparsable.
     """
-    cats_path = op.join(filepath, "categories.xml")
-    if not op.isfile(cats_path):
+    cats_path = Path(filepath) / "categories.xml"
+    if not cats_path.is_file():
         return []
     from mffpy.xml_files import XML
 
@@ -444,14 +444,12 @@ class RawMff(BaseRaw):
         verbose=None,
     ):
         """Init the RawMff class."""
-        input_fname = str(
-            _check_fname(
-                input_fname,
-                "read",
-                True,
-                "input_fname",
-                need_dir=True,
-            )
+        input_fname = _check_fname(
+            input_fname,
+            "read",
+            True,
+            "input_fname",
+            need_dir=True,
         )
         logger.info(f"Reading EGI MFF Header from {input_fname}...")
         egi_info = _read_header(input_fname)

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -75,7 +75,7 @@ def _read_channel_status_bads(filepath, ch_names, pns_names):
     channels marked ``exclusion="badChannels"`` across every category and
     segment and maps them back to MNE channel names.
 
-    Returns an empty list when ``categories.xml`` is absent or unparseable.
+    Returns an empty list when ``categories.xml`` is absent or unparsable.
     """
     cats_path = op.join(filepath, "categories.xml")
     if not op.isfile(cats_path):

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -82,7 +82,7 @@ def _read_channel_status_bads(filepath, ch_names, pns_names):
     from mffpy.xml_files import XML
 
     try:
-        cats_obj = XML.from_file(str(cats_path))
+        cats_obj = XML.from_file(cats_path)  # ty: ignore[invalid-argument-type]
     except Exception:
         return []
     bads = set()
@@ -114,7 +114,7 @@ def _read_mff_header(filepath):
 
     # 1. Parse info.xml natively via absolute path
     info_filepath = Path(filepath) / "info.xml"
-    info_obj = XML.from_file(str(info_filepath))
+    info_obj = XML.from_file(info_filepath)  # ty: ignore[invalid-argument-type]
 
     mff_vers_elem = info_obj.find("mffVersion")
     if mff_vers_elem is None:
@@ -186,7 +186,7 @@ def _read_mff_header(filepath):
 
     # 2. Parse sensorLayout.xml natively via absolute path
     sensor_layout_filepath = Path(filepath) / "sensorLayout.xml"
-    sensor_layout_obj = XML.from_file(str(sensor_layout_filepath))
+    sensor_layout_obj = XML.from_file(sensor_layout_filepath)  # ty: ignore[invalid-argument-type]
 
     summaryinfo["device"] = getattr(sensor_layout_obj, "name", "Unknown")
     chan_type = list()
@@ -227,7 +227,7 @@ def _read_mff_header(filepath):
 
         # 3. Parse pnsSet.xml using the fallback shim in fixes.py
         pns_set_filepath = Path(filepath) / "pnsSet.xml"
-        pns_obj = XML.from_file(str(pns_set_filepath))
+        pns_obj = XML.from_file(pns_set_filepath)  # ty: ignore[invalid-argument-type]
 
         pns_types = []
         pns_units = []

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -605,6 +605,35 @@ def test_egi_mff_bad_xml(tmp_path):
 
 
 @requires_testing_data
+def test_egi_mff_channel_status(tmp_path):
+    """Test that bad channels from categories.xml channelStatus are read."""
+    mff_fname = copytree_rw(egi_pause_fname, tmp_path / "paused_status.mff")
+    # Minimal categories.xml marking EEG channels 5 and 23 as bad
+    cats_xml = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<categories xmlns="http://www.egi.com/categories_mff">
+    <cat>
+        <name>Recording</name>
+        <segments>
+            <seg status="unedited">
+                <beginTime>0</beginTime>
+                <endTime>1300000</endTime>
+                <evtBegin>0</evtBegin>
+                <evtEnd>0</evtEnd>
+                <channelStatus>
+                    <channels signalBin="1" exclusion="badChannels">5 23</channels>
+                </channelStatus>
+            </seg>
+        </segments>
+    </cat>
+</categories>
+"""
+    (mff_fname / "categories.xml").write_text(cats_xml, encoding="utf-8")
+    raw = read_raw_egi(mff_fname, events_as_annotations=False, verbose=False)
+    assert raw.info["bads"] == ["E23", "E5"]  # sorted alphabetically
+
+
+@requires_testing_data
 @pytest.mark.parametrize(
     "fname, expected",
     [pytest.param(egi_pause_fname, "AM40_3", id="paused")],

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -608,7 +608,10 @@ def test_egi_mff_bad_xml(tmp_path):
 def test_egi_mff_channel_status(tmp_path):
     """Test that bad channels from categories.xml channelStatus are read."""
     mff_fname = copytree_rw(egi_pause_fname, tmp_path / "paused_status.mff")
-    # Minimal categories.xml marking EEG channels 5 and 23 as bad
+    # categories.xml exercising all branches of _read_channel_status_bads:
+    #   - EEG channels 5 and 23 bad (signalBin=1, exclusion=badChannels) — main path
+    #   - channel 9999 out of range — covers the bounds-check false branch
+    #   - goodChannels entry — covers the exclusion != "badChannels" continue path
     cats_xml = """\
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <categories xmlns="http://www.egi.com/categories_mff">
@@ -621,7 +624,9 @@ def test_egi_mff_channel_status(tmp_path):
                 <evtBegin>0</evtBegin>
                 <evtEnd>0</evtEnd>
                 <channelStatus>
-                    <channels signalBin="1" exclusion="badChannels">5 23</channels>
+                    <channels signalBin="1" exclusion="badChannels">5 23 9999</channels>
+                    <channels signalBin="1" exclusion="goodChannels">1 2 3</channels>
+                    <channels signalBin="3" exclusion="badChannels">1</channels>
                 </channelStatus>
             </seg>
         </segments>
@@ -630,7 +635,37 @@ def test_egi_mff_channel_status(tmp_path):
 """
     (mff_fname / "categories.xml").write_text(cats_xml, encoding="utf-8")
     raw = read_raw_egi(mff_fname, events_as_annotations=False, verbose=False)
-    assert raw.info["bads"] == ["E23", "E5"]  # sorted alphabetically
+    assert raw.info["bads"] == ["E23", "E5"]  # 9999 ignored (out of range); goodChannels ignored
+
+    # Corrupted categories.xml must not raise — returns empty bads gracefully
+    (mff_fname / "categories.xml").write_text("NOT VALID XML", encoding="utf-8")
+    raw2 = read_raw_egi(mff_fname, events_as_annotations=False, verbose=False)
+    assert raw2.info["bads"] == []
+
+    # PNS file: write categories.xml with signalBin=2 to exercise the PNS bads path
+    pns_fname = copytree_rw(egi_mff_pns_fname, tmp_path / "pns_status.mff")
+    cats_pns_xml = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<categories xmlns="http://www.egi.com/categories_mff">
+    <cat>
+        <name>Recording</name>
+        <segments>
+            <seg status="unedited">
+                <beginTime>0</beginTime>
+                <endTime>4000000</endTime>
+                <evtBegin>0</evtBegin>
+                <evtEnd>0</evtEnd>
+                <channelStatus>
+                    <channels signalBin="2" exclusion="badChannels">1 9999</channels>
+                </channelStatus>
+            </seg>
+        </segments>
+    </cat>
+</categories>
+"""
+    (pns_fname / "categories.xml").write_text(cats_pns_xml, encoding="utf-8")
+    raw3 = read_raw_egi(pns_fname, verbose=False)
+    assert len(raw3.info["bads"]) >= 1  # at least PNS channel 1 marked bad
 
 
 @requires_testing_data

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -635,7 +635,10 @@ def test_egi_mff_channel_status(tmp_path):
 """
     (mff_fname / "categories.xml").write_text(cats_xml, encoding="utf-8")
     raw = read_raw_egi(mff_fname, events_as_annotations=False, verbose=False)
-    assert raw.info["bads"] == ["E23", "E5"]  # 9999 ignored (out of range); goodChannels ignored
+    assert raw.info["bads"] == [
+        "E23",
+        "E5",
+    ]  # 9999 ignored (out of range); goodChannels ignored
 
     # Corrupted categories.xml must not raise — returns empty bads gracefully
     (mff_fname / "categories.xml").write_text("NOT VALID XML", encoding="utf-8")


### PR DESCRIPTION
### Reference issue (if any)
Part of #13926 (GSoC 2026 meta-issue, Phase 1).

### What does this implement/fix?
EGI NetStation marks bad channels per recording epoch inside `categories.xml` using `<channelStatus>` elements with `exclusion="badChannels"`. Previously, `read_raw_egi` ignored this file entirely and always returned `raw.info["bads"] == []`.
This PR adds a helper `_read_channel_status_bads` that:

- Checks whether `categories.xml` exists in the MFF directory (gracefully skips if absent or unparseable)
- Uses mffpy's `Categories` XML class to iterate over every category and segment
- Collects the union of all channels marked `exclusion="badChannels"` across all segments (both EEG `signalBin=1` and PNS `signalBin=2`)
- Maps 1-indexed channel numbers to MNE channel names and populates `raw.info["bads"]`

A test is added that copies an existing test MFF file to a temp directory, injects a minimal `categories.xml` with two EEG channels marked bad, reads the file, and asserts the bads list is set correctly.

Additional information
`categories.xml` is absent in most of the existing test MFF files (it is only present in `test_egi_evoked.mff`, which is an averaged file handled by `read_evokeds_mff`). The new test therefore constructs a minimal `categories.xml` in a temp copy of the paused multi-epoch test file to exercise the raw reader path.

All 26 EGI tests pass.