### PR TITLE
MAINT: Deploy versioned docs and fix version switcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,18 +509,20 @@ jobs:
             git reset --hard origin/main
             git clean -xdf
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
-              rm -Rf dev;
-              cp -a /tmp/build/html dev;
-              git add -A;
-              git commit -m "CircleCI update of dev docs (${CIRCLE_BUILD_NUM}).";
+              DIR=dev;
             else
-              echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
-              rm -Rf stable;
-              cp -a /tmp/build/html stable;
-              git add -A;
-              git commit -m "CircleCI update of stable docs (${CIRCLE_BUILD_NUM}).";
+              DIR=${CIRCLE_BRANCH#maint/};
             fi;
+            if ! echo "${DIR}" | grep -qE '^([0-9]+\.[0-9]+|dev)$'; then
+              echo "Refusing to deploy: branch ${CIRCLE_BRANCH} maps to invalid directory '${DIR}'.";
+              circleci-agent step halt;
+            fi;
+            echo "Deploying ${DIR} docs for ${CIRCLE_BRANCH}.";
+            rm -Rf "${DIR}";
+            cp -a /tmp/build/html "${DIR}";
+            git add -A;
+            git commit -m "CircleCI update of ${DIR} docs (${CIRCLE_BUILD_NUM})." \
+              -m "Deployed-version: ${DIR}" -m "Source-sha: ${CIRCLE_SHA1}";
             git push origin main;
       - save_cache:
           key: website-cache-1

--- a/doc/_static/versions.json
+++ b/doc/_static/versions.json
@@ -6,8 +6,9 @@
     },
     {
         "name": "1.12 (stable)",
-        "version": "stable",
-        "url": "https://mne.tools/stable/"
+        "version": "1.12",
+        "url": "https://mne.tools/stable/",
+        "preferred": true
     },
     {
         "name": "1.11",

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -13,8 +13,3 @@
   {% endif %}
 </div>
 {% endblock %}
-
-{%- block scripts_end %}
-    {{ super() }}
-    <script src="https://mne.tools/versionwarning.js"></script>
-{%- endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -850,6 +850,7 @@ html_theme_options = {
         "json_url": "https://mne.tools/dev/_static/versions.json",
         "version_match": switcher_version_match,
     },
+    "show_version_warning_banner": True,
     "back_to_top_button": False,
 }
 


### PR DESCRIPTION
A few things we can do to make our release process simpler:

1. Symlink `stable` rather than copying files (I will do this manually)
2. Fix the `"version"` for 1.12 (should be `1.12` not `stable`;  theme matches version by string equality against the build's version_match). Should fix this just being "choose version" on 1.12 docs:

   <img width="275" height="72" alt="Screenshot 2026-08-14 at 9 45 15 AM" src="https://github.com/user-attachments/assets/e6c540a4-604f-4627-9a9a-98f57f3131cb" />

3. Use the builtin warning banner

Drafted with Claude Fable 5 but I reviewed and revised myself.