### PR TITLE
Deprecate matplotlib 3D backend for STC plotting

### DIFF
--- a/doc/changes/dev/14160.apichange.rst
+++ b/doc/changes/dev/14160.apichange.rst
@@ -1,0 +1,1 @@
+The ``matplotlib`` 3D backend for plotting source estimates (``backend="matplotlib"`` in :func:`mne.viz.plot_source_estimates`, along with the ``spacing`` argument that only affects it) has been deprecated and will be removed in 1.15; use a proper 3D backend such as ``pyvistaqt`` instead, by `Eric Larson`_.

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -4545,6 +4545,8 @@ class Report:
 
         # Plot using 3d backend if available, and use Matplotlib
         # otherwise.
+        # TODO: the Matplotlib fallback below is deprecated, remove it (and require a
+        # 3D backend here) once the mpl 3D backend goes away in 1.15
         import matplotlib.pyplot as plt
 
         stc_plot_kwargs = _handle_default("report_stc_plot_kwargs", stc_plot_kwargs)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2169,6 +2169,12 @@ def _smooth_plot(this_time, params, *, draw=True):
         ax.figure.canvas.draw()
 
 
+_MPL_STC_DEPRECATION = (
+    "Plotting source estimates with the matplotlib 3D backend is deprecated and will "
+    "be removed in MNE 1.15, use a proper 3D backend (e.g., pyvistaqt) instead"
+)
+
+
 def _plot_mpl_stc(
     stc,
     subject=None,
@@ -2515,6 +2521,8 @@ def plot_source_estimates(
         pyvistaqt, but resorts to matplotlib if no 3d backend is available.
 
         .. versionadded:: 0.15.0
+        .. versionchanged:: 1.13
+           The ``'matplotlib'`` backend is deprecated and will be removed in 1.15.
     spacing : str
         Only affects the matplotlib backend.
         The spacing to use for the source space. Can be ``'ico#'`` for a
@@ -2524,6 +2532,8 @@ def plot_source_estimates(
         Defaults  to 'oct6'.
 
         .. versionadded:: 0.15.0
+        .. deprecated:: 1.13
+           Will be removed in 1.15 along with the ``'matplotlib'`` backend.
     %(title_stc)s
 
         .. versionadded:: 0.17.0
@@ -2566,6 +2576,8 @@ def plot_source_estimates(
             except (ImportError, ModuleNotFoundError):
                 warn("No 3D backend found. Resorting to matplotlib 3d.")
                 plot_mpl = True
+    if plot_mpl:
+        warn(f"{_MPL_STC_DEPRECATION}.", FutureWarning)
     kwargs = dict(
         subject=subject,
         surface=surface,

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -1174,50 +1174,57 @@ def test_stc_mpl():
     stc_data = np.ones(n_verts * n_time)
     stc_data = _reshape_view(stc_data, (n_verts, n_time))
     stc = SourceEstimate(stc_data, vertices, 1, 1, "sample")
-    stc.plot(
-        subjects_dir=subjects_dir,
-        time_unit="s",
-        views="ven",
-        hemi="rh",
-        smoothing_steps=7,
-        subject="sample",
-        backend="matplotlib",
-        spacing="oct1",
-        initial_time=0.001,
-        colormap="Reds",
-    )
-    fig = stc.plot(
-        subjects_dir=subjects_dir,
-        time_unit="ms",
-        views="dor",
-        hemi="lh",
-        smoothing_steps=7,
-        subject="sample",
-        backend="matplotlib",
-        spacing="ico2",
-        time_viewer=True,
-        colormap="mne",
-    )
+    dep_match = "matplotlib 3D backend is deprecated"
+    with pytest.warns(FutureWarning, match=dep_match):
+        stc.plot(
+            subjects_dir=subjects_dir,
+            time_unit="s",
+            views="ven",
+            hemi="rh",
+            smoothing_steps=7,
+            subject="sample",
+            backend="matplotlib",
+            spacing="oct1",
+            initial_time=0.001,
+            colormap="Reds",
+        )
+    with pytest.warns(FutureWarning, match=dep_match):
+        fig = stc.plot(
+            subjects_dir=subjects_dir,
+            time_unit="ms",
+            views="dor",
+            hemi="lh",
+            smoothing_steps=7,
+            subject="sample",
+            backend="matplotlib",
+            spacing="ico2",
+            time_viewer=True,
+            colormap="mne",
+        )
     time_viewer = fig.time_viewer
     _fake_click(time_viewer, time_viewer.axes[0], (0.5, 0.5))  # change t
     _fake_keypress(time_viewer, "ctrl+right")
     _fake_keypress(time_viewer, "left")
-    pytest.raises(
-        ValueError,
-        stc.plot,
-        subjects_dir=subjects_dir,
-        hemi="both",
-        subject="sample",
-        backend="matplotlib",
-    )
-    pytest.raises(
-        ValueError,
-        stc.plot,
-        subjects_dir=subjects_dir,
-        time_unit="ss",
-        subject="sample",
-        backend="matplotlib",
-    )
+    with (
+        pytest.warns(FutureWarning, match=dep_match),
+        pytest.raises(ValueError, match="Invalid value for the 'hemi'"),
+    ):
+        stc.plot(
+            subjects_dir=subjects_dir,
+            hemi="both",
+            subject="sample",
+            backend="matplotlib",
+        )
+    with (
+        pytest.warns(FutureWarning, match=dep_match),
+        pytest.raises(ValueError, match="time_unit must be 's' or 'ms'"),
+    ):
+        stc.plot(
+            subjects_dir=subjects_dir,
+            time_unit="ss",
+            subject="sample",
+            backend="matplotlib",
+        )
 
 
 @pytest.mark.slowtest

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -52,8 +52,9 @@ python -c "import vtk"
 echo "::endgroup::"
 
 echo "::group::Everything else"
+# TODO: PyVista can go back to refs/heads/main once https://github.com/pyvista/pyvista/pull/8908 lands
 python -m pip install $STD_ARGS \
-	"pyvista @ https://github.com/pyvista/pyvista/archive/refs/heads/main.zip" \
+	"pyvista @ https://github.com/pyvista/pyvista/archive/2419dedb23322d926fff74b2c017497ac6e5f3d8.zip" \
 	"pyvistaqt @ https://github.com/larsoner/pyvistaqt/archive/refs/heads/qvtk-opengl-widget.zip" \
 	"git+https://github.com/nilearn/nilearn" \
 	"git+https://github.com/pierreablin/picard" \

--- a/tutorials/inverse/60_visualize_stc.py
+++ b/tutorials/inverse/60_visualize_stc.py
@@ -88,17 +88,6 @@ brain.add_annotation("HCPMMP1_combined", borders=2)
 # %%
 # Note that here we used ``initial_time=0.1``, but we can also browse through
 # time using ``time_viewer=True``.
-#
-# In case ``PyVista`` is not available, we also offer a ``matplotlib``
-# backend. Here we use verbose='error' to ignore a warning that not all
-# vertices were used in plotting.
-mpl_fig = stc.plot(
-    subjects_dir=subjects_dir,
-    initial_time=initial_time,
-    backend="matplotlib",
-    verbose="error",
-    smoothing_steps=7,
-)
 
 # %%
 #


### PR DESCRIPTION
Closes #13904

It occurred to me that we could also simplify our code by routing through nilearn's surf plotting code, but I still think it's cleaner just to deprecate this. I let Claude Opus 5 draft changes and I reviewed. Marking for merge-when-green since this one is pretty straightforward. Also sneaking in a workaround for the PyVista error in case it takes them a while to merge https://github.com/pyvista/pyvista/pull/8908