### PR TITLE
Make copy_function_doc_to_method_doc lazy

### DIFF
--- a/mne/_fiff/_digitization.py
+++ b/mne/_fiff/_digitization.py
@@ -349,15 +349,51 @@ def _get_data_as_dict_from_dig(dig, exclude_ref_channel=True):
     )
 
 
-def _get_fid_coords(dig, raise_error=True):
+_FIDUCIAL_ORDER = ("lpa", "nasion", "rpa")
+
+
+def _get_fid_coords(dig, raise_error=True, *, coord_frame=None, ctf_fallback=False):
+    """Get the cardinal fiducials from a list of dig points.
+
+    Parameters
+    ----------
+    dig : list of dict
+        The dig points.
+    raise_error : bool
+        Whether to raise if fiducials are missing or in mixed coordinate frames.
+    coord_frame : int | None
+        If not None, only consider points already in this coordinate frame.
+    ctf_fallback : bool
+        Whether to fall back to deriving the fiducials from CTF HPI coils when no
+        cardinal points are present. Only the plotting code wants this.
+    """
     fid_coords = Bunch(nasion=None, lpa=None, rpa=None)
     fid_coord_frames = dict()
+
+    if coord_frame is not None:
+        dig = [d for d in dig if d["coord_frame"] == coord_frame]
 
     for d in dig:
         if d["kind"] == FIFF.FIFFV_POINT_CARDINAL:
             key = _cardinal_ident_mapping[d["ident"]]
             fid_coords[key] = d["r"]
             fid_coord_frames[key] = d["coord_frame"]
+
+    if not fid_coord_frames and ctf_fallback:
+        # XXX eventually this should probably live in montage.py
+        if coord_frame in (None, FIFF.FIFFV_COORD_HEAD):
+            # Try converting CTF HPI coils to fiducials
+            out = np.full((3, 3), np.nan)
+            for d in dig:
+                if d["kind"] == FIFF.FIFFV_POINT_HPI:
+                    if np.isclose(d["r"][1:], 0, atol=1e-6).all():
+                        out[0 if d["r"][0] < 0 else 2] = d["r"]
+                    elif np.isclose(d["r"][::2], 0, atol=1e-6).all():
+                        out[1] = d["r"]
+            if np.isfinite(out).all():
+                for key, r in zip(_FIDUCIAL_ORDER, out):
+                    fid_coords[key] = r
+                    fid_coord_frames[key] = FIFF.FIFFV_COORD_HEAD
 
     if len(fid_coord_frames) > 0 and raise_error:
         if set(fid_coord_frames.keys()) != set(["nasion", "lpa", "rpa"]):
@@ -374,6 +410,16 @@ def _get_fid_coords(dig, raise_error=True):
     coord_frame = fid_coord_frames.popitem()[1] if fid_coord_frames else None
 
     return fid_coords, coord_frame
+
+
+def _fiducial_coords(points, coord_frame=None):
+    """Generate 3x3 array of fiducial coordinates, in LPA/nasion/RPA order."""
+    fid_coords, _ = _get_fid_coords(
+        points or [], raise_error=False, coord_frame=coord_frame, ctf_fallback=True
+    )
+    if any(fid_coords[key] is None for key in _FIDUCIAL_ORDER):
+        return np.array([])
+    return np.array([fid_coords[key] for key in _FIDUCIAL_ORDER])
 
 
 def _coord_frame_const(coord_frame):

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -67,7 +67,6 @@ from .utils import (
     verbose,
     warn,
 )
-from .viz.misc import plot_bem
 
 # ############################################################################
 # Compute BEM solution
@@ -1246,6 +1245,8 @@ def make_watershed_bem(
 
     .. versionadded:: 0.10
     """
+    from .viz.misc import plot_bem
+
     env, mri_dir, bem_dir = _prepare_env(subject, subjects_dir)
     tempdir = _TempDir()  # fsl and FreeSurfer create some random junk in CWD
     run_subprocess_env = partial(run_subprocess, env=env, cwd=tempdir)
@@ -2150,6 +2151,8 @@ def make_flash_bem(
     outer skin) from a FLASH 5 MRI image synthesized from multiecho FLASH
     images acquired with spin angles of 5 and 30 degrees.
     """
+    from .viz.misc import plot_bem
+
     env, mri_dir, bem_dir = _prepare_env(subject, subjects_dir)
     tempdir = _TempDir()  # fsl and FreeSurfer create some random junk in CWD
     run_subprocess_env = partial(run_subprocess, env=env, cwd=tempdir)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -27,7 +27,6 @@ from ..utils import (
     verbose,
     warn,
 )
-from ..viz.topomap import plot_layout
 from .channels import _get_ch_info
 
 
@@ -140,6 +139,8 @@ class Layout:
         -----
         .. versionadded:: 0.12.0
         """
+        from ..viz.topomap import plot_layout
+
         return plot_layout(self, picks=picks, show_axes=show_axes, show=show)
 
     @verbose

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -55,7 +55,6 @@ from ..utils import (
     warn,
 )
 from ..utils.docs import docdict
-from ..viz import plot_montage
 from ._dig_montage_utils import (
     _parse_brainvision_dig_montage,
     _read_dig_montage_curry,
@@ -411,7 +410,7 @@ class DigMontage:
             " {fid:d} fiducials, {eeg:d} channels>"
         ).format(**n_points)
 
-    @copy_function_doc_to_method_doc(plot_montage)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_montage")
     def plot(
         self,
         *,
@@ -423,6 +422,9 @@ class DigMontage:
         axes=None,
         verbose=None,
     ):
+
+        from ..viz import plot_montage
+
         return plot_montage(
             self,
             scale=scale,

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -32,6 +32,7 @@ from mne import (
 )
 from mne._fiff._digitization import (
     _count_points_by_type,
+    _fiducial_coords,
     _format_dig_points,
     _get_dig_eeg,
     _get_fid_coords,
@@ -77,7 +78,6 @@ from mne.preprocessing import compute_current_source_density
 from mne.transforms import _ensure_trans, _get_trans, apply_trans, invert_transform
 from mne.utils import _record_warnings, assert_dig_allclose
 from mne.utils._testing import assert_object_equal
-from mne.viz._3d import _fiducial_coords
 
 data_path = testing.data_path(download=False)
 fif_dig_montage_fname = data_path / "montage" / "eeganes07.fif"

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy.optimize import leastsq
 from scipy.spatial.distance import cdist
 
-from ._fiff._digitization import _get_data_as_dict_from_dig
+from ._fiff._digitization import _fiducial_coords, _get_data_as_dict_from_dig
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import Info, read_fiducials, read_info, write_fiducials
 
@@ -76,7 +76,6 @@ from .utils import (
     verbose,
     warn,
 )
-from .viz._3d import _fiducial_coords
 
 # some path templates
 trans_fname = os.path.join("{raw_dir}", "{subject}-trans.fif")
@@ -1620,6 +1619,7 @@ class Coregistration:
             self._bem_low_res = _read_surface(low_res_path, on_defects=self._on_defects)
 
     def _setup_fiducials(self, fids):
+
         _validate_type(fids, (str, dict, list))
         # find fiducials file
         fid_accurate = None

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -9,7 +9,6 @@ from math import log
 import numpy as np
 from scipy.sparse import issparse
 
-from . import viz
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import _read_bad_channels, _write_bad_channels, create_info
 from ._fiff.pick import (
@@ -299,8 +298,8 @@ class Covariance(dict):
 
         return self
 
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_cov")
     @verbose
-    @copy_function_doc_to_method_doc(viz.plot_cov)
     def plot(
         self,
         info,
@@ -311,6 +310,8 @@ class Covariance(dict):
         show=True,
         verbose=None,
     ):
+        from . import viz
+
         return viz.plot_cov(
             self, info, exclude, colorbar, proj, show_svd, show, verbose
         )

--- a/mne/decoding/spatial_filter.py
+++ b/mne/decoding/spatial_filter.py
@@ -10,7 +10,6 @@ import numpy as np
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT, _INTERPOLATION_DEFAULT
 from ..evoked import EvokedArray
 from ..utils import _check_option, fill_doc, verbose
-from ..viz.utils import plt_show
 from .base import LinearModel, _GEDTransformer, get_coef
 
 
@@ -638,6 +637,8 @@ class SpatialFilter:
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
+        from ..viz.utils import plt_show
+
         if self.evals is None:
             raise AttributeError("Can't plot scree if eigenvalues are not provided.")
 

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -405,6 +405,9 @@ def _handle_default(k, v=None):
 
 
 HEAD_SIZE_DEFAULT = 0.095  # in [m]
+# default clipping for Raw.plot; it lives here rather than in mne.viz.raw so
+# that mne.io.base can use it as a default argument without importing mne.viz
+_RAW_CLIP_DEF: Final = 3
 _BORDER_DEFAULT: Final = "mean"
 _INTERPOLATION_DEFAULT: Final = "cubic"
 _EXTRAPOLATE_DEFAULT: Final = "auto"

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -52,8 +52,6 @@ from .utils import (
     verbose,
     warn,
 )
-from .viz import plot_dipole_amplitudes, plot_dipole_locations
-from .viz.evoked import _plot_evoked
 
 
 @fill_doc
@@ -269,8 +267,8 @@ class Dipole(TimeMixin):
         """
         return deepcopy(self)
 
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_dipole_locations")
     @verbose
-    @copy_function_doc_to_method_doc(plot_dipole_locations)
     def plot_locations(
         self,
         trans,
@@ -294,6 +292,8 @@ class Dipole(TimeMixin):
         width=None,
         verbose=None,
     ):
+        from .viz import plot_dipole_locations
+
         return plot_dipole_locations(
             self,
             trans,
@@ -425,6 +425,8 @@ class Dipole(TimeMixin):
         fig : matplotlib.figure.Figure
             The figure object containing the plot.
         """
+        from .viz import plot_dipole_amplitudes
+
         return plot_dipole_amplitudes([self], [color], show)
 
     def __getitem__(self, item):
@@ -623,6 +625,8 @@ class DipoleFixed(ExtendedTimeMixin):
         fig : instance of matplotlib.figure.Figure
             The figure containing the time courses.
         """
+        from .viz.evoked import _plot_evoked
+
         return _plot_evoked(
             self,
             picks=None,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -112,7 +112,6 @@ from .utils import (
 )
 from .utils._typing import Color, FileLike, Self
 from .utils.docs import fill_doc
-from .viz import plot_drop_log, plot_epochs, plot_epochs_image, plot_topo_image_epochs
 
 if TYPE_CHECKING:
     # Heavy/optional deps kept out of the runtime import path (see
@@ -1360,7 +1359,7 @@ class BaseEpochs(
         """Channel names."""
         return self.info["ch_names"]
 
-    @copy_function_doc_to_method_doc(plot_epochs)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_epochs")
     def plot(
         self,
         picks: str | np.ndarray | slice | None = None,
@@ -1391,6 +1390,9 @@ class BaseEpochs(
         annotation_colors: dict | None = None,
         figure_class: type | None = None,
     ) -> "Figure | MNEQtBrowser":
+
+        from .viz import plot_epochs
+
         return plot_epochs(
             self,
             picks=picks,
@@ -1421,7 +1423,7 @@ class BaseEpochs(
             figure_class=figure_class,
         )
 
-    @copy_function_doc_to_method_doc(plot_topo_image_epochs)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_topo_image_epochs")
     def plot_topo_image(
         self,
         layout: "Layout | None" = None,
@@ -1441,6 +1443,9 @@ class BaseEpochs(
         select: bool = False,
         show: bool = True,
     ) -> "Figure":
+
+        from .viz import plot_topo_image_epochs
+
         return plot_topo_image_epochs(
             self,
             layout=layout,
@@ -1530,7 +1535,7 @@ class BaseEpochs(
         """
         return _drop_log_stats(self.drop_log, ignore)
 
-    @copy_function_doc_to_method_doc(plot_drop_log)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_drop_log")
     def plot_drop_log(
         self,
         threshold: float = 0,
@@ -1547,6 +1552,9 @@ class BaseEpochs(
                 "epochs have not yet been dropped. "
                 "Use epochs.drop_bad()."
             )
+
+        from .viz import plot_drop_log
+
         return plot_drop_log(
             self.drop_log,
             threshold,
@@ -1558,7 +1566,7 @@ class BaseEpochs(
             show=show,
         )
 
-    @copy_function_doc_to_method_doc(plot_epochs_image)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_epochs_image")
     def plot_image(
         self,
         picks: str | np.ndarray | slice | None = None,
@@ -1581,6 +1589,9 @@ class BaseEpochs(
         title: str | None = None,
         clear: bool = False,
     ) -> "list[Figure]":
+
+        from .viz import plot_epochs_image
+
         return plot_epochs_image(
             self,
             picks=picks,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -69,15 +69,6 @@ from .utils import (
     warn,
 )
 from .utils._typing import Color, Self
-from .viz import (
-    plot_evoked,
-    plot_evoked_field,
-    plot_evoked_image,
-    plot_evoked_topo,
-    plot_evoked_topomap,
-)
-from .viz.evoked import plot_evoked_joint, plot_evoked_white
-from .viz.topomap import _topomap_animation
 
 if TYPE_CHECKING:
     # Heavy/optional deps kept out of the runtime import path (see
@@ -527,7 +518,7 @@ class Evoked(
         """Channel names."""
         return self.info["ch_names"]
 
-    @copy_function_doc_to_method_doc(plot_evoked)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_evoked")
     def plot(
         self,
         picks: str | np.ndarray | slice | None = None,
@@ -554,6 +545,8 @@ class Evoked(
         highlight: np.ndarray | None = None,
         verbose: bool | str | int | None = None,
     ) -> "Figure":
+        from .viz import plot_evoked
+
         return plot_evoked(
             self,
             picks=picks,
@@ -580,7 +573,7 @@ class Evoked(
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_image)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_evoked_image")
     def plot_image(
         self,
         picks: str | np.ndarray | slice | None = None,
@@ -605,6 +598,8 @@ class Evoked(
         group_by: dict | None = None,
         sphere: "float | np.ndarray | ConductorModel | str | list[str] | None" = None,
     ) -> "Figure":
+        from .viz import plot_evoked_image
+
         return plot_evoked_image(
             self,
             picks=picks,
@@ -630,7 +625,7 @@ class Evoked(
             sphere=sphere,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_topo)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_evoked_topo")
     def plot_topo(
         self,
         layout: Layout | None = None,
@@ -652,6 +647,8 @@ class Evoked(
         select: bool = False,
         show: bool = True,
     ) -> "Figure":
+        from .viz import plot_evoked_topo
+
         return plot_evoked_topo(
             self,
             layout=layout,
@@ -674,7 +671,7 @@ class Evoked(
             show=show,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_topomap)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_evoked_topomap")
     def plot_topomap(
         self,
         times: float | np.ndarray | Literal["auto", "peaks", "interactive"] = "auto",
@@ -709,6 +706,8 @@ class Evoked(
         ncols: int | Literal["auto"] = "auto",
         show: bool = True,
     ) -> "Figure":
+        from .viz import plot_evoked_topomap
+
         return plot_evoked_topomap(
             self,
             times=times,
@@ -743,7 +742,7 @@ class Evoked(
             ncols=ncols,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_field)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_evoked_field")
     def plot_field(
         self,
         surf_maps: list,
@@ -761,6 +760,8 @@ class Evoked(
         time_viewer: bool | str = "auto",
         verbose: bool | str | int | None = None,
     ) -> "Figure3D | EvokedField":
+        from .viz import plot_evoked_field
+
         return plot_evoked_field(
             self,
             surf_maps,
@@ -778,7 +779,7 @@ class Evoked(
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_white)
+    @copy_function_doc_to_method_doc("func:mne.viz.evoked.plot_evoked_white")
     def plot_white(
         self,
         noise_cov: "list | Covariance | Path | str",
@@ -791,6 +792,8 @@ class Evoked(
         spatial_colors: bool | Literal["auto"] = "auto",
         verbose: bool | str | int | None = None,
     ) -> "Figure":
+        from .viz.evoked import plot_evoked_white
+
         return plot_evoked_white(
             self,
             noise_cov=noise_cov,
@@ -803,7 +806,7 @@ class Evoked(
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_evoked_joint)
+    @copy_function_doc_to_method_doc("func:mne.viz.evoked.plot_evoked_joint")
     def plot_joint(
         self,
         times: float | np.ndarray | Literal["auto", "peaks"] = "peaks",
@@ -814,6 +817,8 @@ class Evoked(
         ts_args: dict | None = None,
         topomap_args: dict | None = None,
     ) -> "Figure | list":
+        from .viz.evoked import plot_evoked_joint
+
         return plot_evoked_joint(
             self,
             times=times,
@@ -944,6 +949,8 @@ class Evoked(
            :meth:`~mne.Evoked.plot_topomap`.
         .. versionadded:: 0.12.0
         """
+        from .viz.topomap import _topomap_animation
+
         return _topomap_animation(
             evoked=self,
             times=times,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -59,7 +59,7 @@ from ..annotations import (
     _write_annotations,
 )
 from ..channels.channels import InterpolationMixin, ReferenceMixin, UpdateChannelsMixin
-from ..defaults import _handle_default
+from ..defaults import _RAW_CLIP_DEF, _handle_default
 from ..event import concatenate_events, find_events
 from ..filter import (
     FilterMixin,
@@ -105,7 +105,6 @@ from ..utils import (
     warn,
 )
 from ..utils._typing import Color, Self
-from ..viz import _RAW_CLIP_DEF, plot_raw
 
 if TYPE_CHECKING:
     # Heavy/optional deps kept out of the runtime import path (see
@@ -2023,7 +2022,7 @@ class BaseRaw(
             raise ValueError(f"tmin ({tmin}) and tmax ({tmax}) yielded no samples")
         return start, stop
 
-    @copy_function_doc_to_method_doc(plot_raw)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_raw")
     def plot(
         self,
         events: np.ndarray | None = None,
@@ -2068,6 +2067,8 @@ class BaseRaw(
         verbose: bool | str | int | None = None,
         figure_class: type | None = None,
     ) -> "Figure | MNEQtBrowser":
+        from ..viz import plot_raw
+
         return plot_raw(
             self,
             events,

--- a/mne/preprocessing/_regress.py
+++ b/mne/preprocessing/_regress.py
@@ -20,7 +20,6 @@ from ..utils import (
     fill_doc,
     verbose,
 )
-from ..viz import plot_regression_weights
 
 
 @verbose
@@ -263,7 +262,7 @@ class EOGRegression:
             this_data -= (self.coef_[pi] @ ref_data).reshape(this_data.shape)
         return inst
 
-    @copy_function_doc_to_method_doc(plot_regression_weights)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_regression_weights")
     def plot(
         self,
         ch_type=None,
@@ -289,6 +288,8 @@ class EOGRegression:
         title=None,
         show=True,
     ):
+        from ..viz import plot_regression_weights
+
         return plot_regression_weights(
             self,
             ch_type=ch_type,

--- a/mne/preprocessing/eyetracking/calibration.py
+++ b/mne/preprocessing/eyetracking/calibration.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from ...io.eyelink._utils import _parse_calibration
 from ...utils import _check_fname, _validate_type, fill_doc, logger
-from ...viz.utils import plt_show
 
 
 @fill_doc
@@ -134,6 +133,8 @@ class Calibration(dict):
             The resulting figure object for the calibration plot.
         """
         import matplotlib.pyplot as plt
+
+        from ...viz.utils import plt_show
 
         msg = "positions and gaze keys must both be 2D numpy arrays."
         assert isinstance(self["positions"], np.ndarray), msg

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -86,14 +86,6 @@ from ..utils import (
     verbose,
     warn,
 )
-from ..viz import (
-    plot_ica_components,
-    plot_ica_overlay,
-    plot_ica_scores,
-    plot_ica_sources,
-)
-from ..viz.ica import plot_ica_properties
-from ..viz.topomap import _plot_corrmap
 from .bads import _find_outliers
 from .ctps_ import ctps
 from .ecg import _get_ecg_channel_index, _make_ecg, create_ecg_epochs, qrs_detector
@@ -2470,7 +2462,7 @@ class ICA(ContainsMixin):
         """
         return deepcopy(self)
 
-    @copy_function_doc_to_method_doc(plot_ica_components)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_ica_components")
     def plot_components(
         self,
         picks=None,
@@ -2503,6 +2495,10 @@ class ICA(ContainsMixin):
         psd_args=None,
         verbose=None,
     ):
+        from ..viz import (
+            plot_ica_components,
+        )
+
         return plot_ica_components(
             self,
             picks=picks,
@@ -2535,7 +2531,7 @@ class ICA(ContainsMixin):
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_ica_properties)
+    @copy_function_doc_to_method_doc("func:mne.viz.ica.plot_ica_properties")
     def plot_properties(
         self,
         inst,
@@ -2555,6 +2551,8 @@ class ICA(ContainsMixin):
         estimate="power",
         verbose=None,
     ):
+        from ..viz.ica import plot_ica_properties
+
         return plot_ica_properties(
             self,
             inst,
@@ -2574,7 +2572,7 @@ class ICA(ContainsMixin):
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_ica_sources)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_ica_sources")
     def plot_sources(
         self,
         inst,
@@ -2597,6 +2595,10 @@ class ICA(ContainsMixin):
         overview_mode=None,
         splash=True,
     ):
+        from ..viz import (
+            plot_ica_sources,
+        )
+
         return plot_ica_sources(
             self,
             inst=inst,
@@ -2619,7 +2621,7 @@ class ICA(ContainsMixin):
             splash=splash,
         )
 
-    @copy_function_doc_to_method_doc(plot_ica_scores)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_ica_scores")
     def plot_scores(
         self,
         scores,
@@ -2631,6 +2633,10 @@ class ICA(ContainsMixin):
         n_cols=None,
         show=True,
     ):
+        from ..viz import (
+            plot_ica_scores,
+        )
+
         return plot_ica_scores(
             ica=self,
             scores=scores,
@@ -2643,7 +2649,7 @@ class ICA(ContainsMixin):
             show=show,
         )
 
-    @copy_function_doc_to_method_doc(plot_ica_overlay)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_ica_overlay")
     def plot_overlay(
         self,
         inst,
@@ -2658,6 +2664,10 @@ class ICA(ContainsMixin):
         on_baseline="warn",
         verbose=None,
     ):
+        from ..viz import (
+            plot_ica_overlay,
+        )
+
         return plot_ica_overlay(
             self,
             inst=inst,
@@ -3348,6 +3358,8 @@ def corrmap(
     ----------
     .. footbibliography::
     """
+    from ..viz.topomap import _plot_corrmap
+
     if not isinstance(plot, bool):
         raise ValueError("`plot` must be of type `bool`")
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -61,11 +61,6 @@ from .utils import (
     verbose,
     warn,
 )
-from .viz import (
-    plot_source_estimates,
-    plot_vector_source_estimates,
-    plot_volume_source_estimates,
-)
 
 
 def _read_stc(filename):
@@ -752,7 +747,7 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
             overwrite=True,
         )
 
-    @copy_function_doc_to_method_doc(plot_source_estimates)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_source_estimates")
     def plot(
         self,
         subject=None,
@@ -787,6 +782,8 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
         brain_kwargs=None,
         verbose=None,
     ):
+        from .viz import plot_source_estimates
+
         brain = plot_source_estimates(
             self,
             subject,
@@ -2242,7 +2239,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
         )
         return stc, directions
 
-    @copy_function_doc_to_method_doc(plot_vector_source_estimates)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_vector_source_estimates")
     def plot(
         self,
         subject=None,
@@ -2277,6 +2274,8 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
         brain_kwargs=None,
         verbose=None,
     ):
+        from .viz import plot_vector_source_estimates
+
         return plot_vector_source_estimates(
             self,
             subject=subject,
@@ -2316,7 +2315,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
     _src_type = "volume"
     _src_count = None
 
-    @copy_function_doc_to_method_doc(plot_source_estimates)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_source_estimates")
     def plot_3d(
         self,
         subject=None,
@@ -2383,7 +2382,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
             verbose=verbose,
         )
 
-    @copy_function_doc_to_method_doc(plot_volume_source_estimates)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_volume_source_estimates")
     def plot(
         self,
         src,
@@ -2400,7 +2399,10 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         initial_pos=None,
         verbose=None,
     ):
+        from .viz import plot_volume_source_estimates
+
         data = self.magnitude() if self._data_ndim == 3 else self
+
         return plot_volume_source_estimates(
             data,
             src=src,
@@ -2756,7 +2758,7 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate, _BaseVectorSourceEstimate)
     _scalar_class = VolSourceEstimate
 
     # defaults differ: hemi='both', views='axial'
-    @copy_function_doc_to_method_doc(plot_vector_source_estimates)
+    @copy_function_doc_to_method_doc("func:mne.viz.plot_vector_source_estimates")
     def plot_3d(
         self,
         subject=None,

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -91,7 +91,6 @@ from ..utils import (
     verbose,
     warn,
 )
-from ..viz import plot_alignment
 
 _src_kind_dict = {
     "vol": "volume",
@@ -374,6 +373,8 @@ class SourceSpaces(list):
         fig : instance of Figure3D
             The figure.
         """
+        from ..viz import plot_alignment
+
         surfaces = list()
         bem = None
 

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -73,6 +73,14 @@ NON_ALL_SUBMODULES = (
     "utils",
 )
 IGNORE_SUBMODULES = ("commands",)  # historically these are always root level
+# mne.viz pulls in matplotlib, so importing it must always be nested rather than
+# done at module level, whatever the hierarchy above would otherwise say. Checking
+# this directly means a stray import is reported with its file and line, rather
+# than having to be traced back from "matplotlib got imported".
+MUST_ALWAYS_NEST = ("viz",)
+# ...except in the submodules that are themselves about plotting, where importing
+# mne.viz at module level is the whole point
+MUST_ALWAYS_NEST_EXEMPT = ("gui", "report")
 
 
 def test_import_nesting_hierarchy():
@@ -124,7 +132,7 @@ def test_import_nesting_hierarchy():
                         if node.col_offset:  # nested
                             if (
                                 module_name in self.must_not_nest
-                                and node.module != "viz.backends.renderer"
+                                and module_name not in MUST_ALWAYS_NEST
                             ):
                                 self.errors.append(
                                     err + (f"hierarchy: must not nest {module_name}",)
@@ -194,6 +202,8 @@ def test_import_nesting_hierarchy():
     for si, submodule_name in enumerate(IMPORT_NESTING_ORDER):
         must_not_nest = IMPORT_NESTING_ORDER[:si]
         must_nest = IMPORT_NESTING_ORDER[si + 1 :]
+        if submodule_name not in MUST_ALWAYS_NEST_EXEMPT:
+            must_nest = must_nest + MUST_ALWAYS_NEST
         submodule_path = root_dir / submodule_name
         if submodule_path.is_dir():
             # Get all .py files to parse

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -26,7 +26,6 @@ from ..utils import (
     verbose,
     warn,
 )
-from ..viz.misc import plot_csd
 from .tfr import EpochsTFR, _cwt_array, _get_nfft, morlet
 
 
@@ -419,7 +418,7 @@ class CrossSpectralDensity:
         else:
             return data
 
-    @copy_function_doc_to_method_doc(plot_csd)
+    @copy_function_doc_to_method_doc("func:mne.viz.misc.plot_csd")
     def plot(
         self,
         info=None,
@@ -429,6 +428,8 @@ class CrossSpectralDensity:
         n_cols=None,
         show=True,
     ):
+        from ..viz.misc import plot_csd
+
         return plot_csd(
             self,
             info=info,

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -51,16 +51,6 @@ from ..utils.spectrum import (
     _get_instance_type_string,
     _split_psd_kwargs,
 )
-from ..viz.topo import _plot_timeseries, _plot_timeseries_unified, _plot_topo
-from ..viz.topomap import _make_head_outlines, _prepare_topomap_plot, plot_psds_topomap
-from ..viz.utils import (
-    _format_units_psd,
-    _get_plot_ch_type,
-    _make_combine_callable,
-    _plot_psd,
-    _prepare_sensor_names,
-    plt_show,
-)
 from .multitaper import _psd_from_mt, psd_array_multitaper
 from .psd import _check_nfft, psd_array_welch
 
@@ -656,6 +646,10 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         # Must nest this _mpl_figure import because of the BACKEND global
         # stuff
         from ..viz._mpl_figure import _line_figure, _split_picks_by_type
+        from ..viz.utils import (
+            _plot_psd,
+            plt_show,
+        )
 
         # arg checking
         ci = _check_ci(ci)
@@ -751,6 +745,11 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         fig : instance of matplotlib.figure.Figure
             Figure distributing one image per channel across sensor topography.
         """
+        from ..viz.topo import _plot_timeseries, _plot_timeseries_unified, _plot_topo
+        from ..viz.utils import (
+            plt_show,
+        )
+
         if layout is None:
             layout = find_layout(self.info)
 
@@ -862,6 +861,16 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         fig : instance of Figure
             Figure showing one scalp topography per frequency band.
         """
+        from ..viz.topomap import (
+            _make_head_outlines,
+            _prepare_topomap_plot,
+            plot_psds_topomap,
+        )
+        from ..viz.utils import (
+            _get_plot_ch_type,
+            _prepare_sensor_names,
+        )
+
         ch_type = _get_plot_ch_type(self, ch_type)
         if units is None:
             units = _handle_default("units", None)
@@ -1080,6 +1089,10 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
             Mapping from channel type to a string representation of the units
             for that channel type.
         """
+        from ..viz.utils import (
+            _format_units_psd,
+        )
+
         units = _handle_default("si_units", None)
         return {
             ch_type: _format_units_psd(units[ch_type], power=True, latex=latex)
@@ -1540,6 +1553,10 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
         spectrum : instance of Spectrum
             The aggregated spectrum object.
         """
+        from ..viz.utils import (
+            _make_combine_callable,
+        )
+
         _validate_type(method, ("str", "callable"), "method")
         method = _make_combine_callable(
             method, axis=0, valid=("mean", "median"), keepdims=False

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -11,7 +11,6 @@ import inspect
 from copy import deepcopy
 from functools import partial
 
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy.fft import fft, ifft
 from scipy.signal import argrelmax
@@ -60,24 +59,6 @@ from ..utils import (
     warn,
 )
 from ..utils.spectrum import _convert_old_birthday_format, _get_instance_type_string
-from ..viz.topo import _imshow_tfr, _imshow_tfr_unified, _plot_topo
-from ..viz.topomap import (
-    _add_colorbar,
-    _get_pos_outlines,
-    _set_contour_locator,
-    plot_tfr_topomap,
-    plot_topomap,
-)
-from ..viz.utils import (
-    _make_combine_callable,
-    _prepare_joint_axes,
-    _set_title_multiple_electrodes,
-    _setup_cmap,
-    _setup_vmin_vmax,
-    add_background_image,
-    figure_nobar,
-    plt_show,
-)
 from .multitaper import dpss_windows, tfr_array_multitaper
 from .spectrum import EpochsSpectrum
 
@@ -1597,6 +1578,16 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         verbose=None,
     ):
         """Respond to rectangle selector in TFR image plots with a topomap plot."""
+        from ..viz.topomap import (
+            _add_colorbar,
+            plot_tfr_topomap,
+            plot_topomap,
+        )
+        from ..viz.utils import (
+            figure_nobar,
+            plt_show,
+        )
+
         if abs(eclick.x - erelease.x) < 0.1 or abs(eclick.y - erelease.y) < 0.1:
             return
         t_range = (min(eclick.xdata, erelease.xdata), max(eclick.xdata, erelease.xdata))
@@ -2001,6 +1992,15 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         # so we keep a reference to that state here, and (because the topomap plotting
         # function wants an AverageTFR) update it with `comment` and `nave` values in
         # case we started out with a singleton EpochsTFR or RawTFR
+        from ..viz.topo import _imshow_tfr
+        from ..viz.utils import (
+            _make_combine_callable,
+            _set_title_multiple_electrodes,
+            _setup_cmap,
+            _setup_vmin_vmax,
+            plt_show,
+        )
+
         initial_state = self.__getstate__()
         initial_state.setdefault("comment", "")
         initial_state.setdefault("nave", 1)
@@ -2082,6 +2082,8 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         vmin, vmax = _setup_vmin_vmax(data, *vlim, norm=norm)
         cmap = _setup_cmap(cmap, norm=norm)
         # prepare figure(s)
+        import matplotlib.pyplot as plt
+
         if axes is None:
             figs = [plt.figure(layout="constrained") for _ in range(data.shape[0])]
             axes = [fig.add_subplot() for fig in figs]
@@ -2240,6 +2242,17 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         """
         from matplotlib import ticker
         from matplotlib.patches import ConnectionPatch
+
+        from ..viz.topomap import (
+            _set_contour_locator,
+            plot_topomap,
+        )
+        from ..viz.utils import (
+            _prepare_joint_axes,
+            _setup_cmap,
+            _setup_vmin_vmax,
+            plt_show,
+        )
 
         # handle recursion
         picks = _picks_to_idx(
@@ -2525,6 +2538,13 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
             The figure containing the topography.
         """
         # convenience vars
+        from ..viz.topo import _imshow_tfr, _imshow_tfr_unified, _plot_topo
+        from ..viz.utils import (
+            _setup_vmin_vmax,
+            add_background_image,
+            plt_show,
+        )
+
         times = self.times.copy()
         freqs = self.freqs
         data = self.data
@@ -2598,7 +2618,7 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         plt_show(show)
         return fig
 
-    @copy_function_doc_to_method_doc(plot_tfr_topomap)
+    @copy_function_doc_to_method_doc("func:mne.viz.topomap.plot_tfr_topomap")
     def plot_topomap(
         self,
         tmin=None,
@@ -2631,6 +2651,10 @@ class BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin):
         axes=None,
         show=True,
     ):
+        from ..viz.topomap import (
+            plot_tfr_topomap,
+        )
+
         return plot_tfr_topomap(
             self,
             tmin=tmin,
@@ -3413,8 +3437,8 @@ class EpochsTFR(BaseTFR, GetEpochsMixin):
             state["nave"] = 1
             yield AverageTFR(inst=state, method=None, freqs=None, comment=str(event_id))
 
+    @copy_doc("meth:mne.time_frequency.tfr.BaseTFR.plot")
     @verbose
-    @copy_doc(BaseTFR.plot)
     def plot(
         self,
         picks=None,
@@ -3471,8 +3495,8 @@ class EpochsTFR(BaseTFR, GetEpochsMixin):
             verbose=verbose,
         )
 
+    @copy_doc("meth:mne.time_frequency.tfr.BaseTFR.plot_topo")
     @verbose
-    @copy_doc(BaseTFR.plot_topo)
     def plot_topo(
         self,
         picks=None,
@@ -3524,8 +3548,8 @@ class EpochsTFR(BaseTFR, GetEpochsMixin):
             verbose=verbose,
         )
 
+    @copy_doc("meth:mne.time_frequency.tfr.BaseTFR.plot_joint")
     @verbose
-    @copy_doc(BaseTFR.plot_joint)
     def plot_joint(
         self,
         *,
@@ -3576,7 +3600,7 @@ class EpochsTFR(BaseTFR, GetEpochsMixin):
             verbose=verbose,
         )
 
-    @copy_doc(BaseTFR.plot_topomap)
+    @copy_doc("meth:mne.time_frequency.tfr.BaseTFR.plot_topomap")
     def plot_topomap(
         self,
         tmin=None,
@@ -4238,6 +4262,10 @@ def _check_tfr_complex(tfr, reason="source space estimation"):
 
 
 def _merge_if_grads(data, info, ch_type, sphere, combine=None):
+    from ..viz.topomap import (
+        _get_pos_outlines,
+    )
+
     if ch_type == "grad":
         grad_picks = _pair_grad_sensors(info, topomap_coords=False)
         pos = _find_topomap_coords(info, picks=grad_picks[::2], sphere=sphere)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -10,6 +10,8 @@ import os.path as op
 import re
 import sys
 from copy import deepcopy
+from functools import partial
+from importlib import import_module
 
 from decorator import FunctionMaker
 
@@ -5362,17 +5364,28 @@ def copy_doc(source):
     this gets appended
     <BLANKLINE>
     """
+    if isinstance(source, str):
+        # "meth:mne.time_frequency.tfr.BaseTFR.plot" -- copying from a lazily
+        # documented method has to stay lazy too, otherwise reading source.__doc__
+        # here would import the plotting module at class definition time
+        _check_lazy_doc_source(source, "meth")
+        return partial(_LazyMethodDoc, source=source)
 
     def wrapper(func):
-        if source.__doc__ is None or len(source.__doc__) == 0:
-            raise ValueError("Cannot copy docstring: docstring was empty.")
-        doc = source.__doc__
-        if func.__doc__ is not None:
-            doc += f"\n{inspect.cleandoc(func.__doc__)}\n"
-        func.__doc__ = doc
+        _copy_doc(source, func)
         return func
 
     return wrapper
+
+
+def _copy_doc(source, func):
+    """Prepend ``source``'s docstring to ``func``'s."""
+    if source.__doc__ is None or len(source.__doc__) == 0:
+        raise ValueError("Cannot copy docstring: docstring was empty.")
+    doc = source.__doc__
+    if func.__doc__ is not None:
+        doc += f"\n{inspect.cleandoc(func.__doc__)}\n"
+    func.__doc__ = doc
 
 
 def copy_function_doc_to_method_doc(source):
@@ -5448,82 +5461,139 @@ def copy_function_doc_to_method_doc(source):
     .. versionadded:: 0.13.0
     <BLANKLINE>
     """  # noqa: D410, D411, D214, D215
+    if isinstance(source, str):
+        # "func:mne.viz.plot_evoked", resolved on first lookup -- see _LazyMethodDoc
+        _check_lazy_doc_source(source, "func")
+        return partial(_LazyMethodDoc, source=source)
 
     def wrapper(func):
-        # Work with cleandoc'ed sources (py3.13-compat)
-        doc = inspect.cleandoc(source.__doc__).split("\n")
-        if func.__doc__ is not None:
-            func_doc = inspect.cleandoc(func.__doc__)
-            if func_doc[:2] == ".\n":
-                func_doc = func_doc[2:]
-            func_doc = f"\n{func_doc}"
-        else:
-            func_doc = ""
-
-        if len(doc) == 1:
-            func.__doc__ = f"{doc[0]}{func_doc}"
-            return func
-
-        # Find parameter block
-        for line, text in enumerate(doc[:-2]):
-            if text.strip() == "Parameters" and doc[line + 1].strip() == "----------":
-                parameter_block = line
-                break
-        else:
-            # No parameter block found
-            raise ValueError(
-                "Cannot copy function docstring: no parameter "
-                "block found. To simply copy the docstring, use "
-                "the @copy_doc decorator instead."
-            )
-
-        # Find first parameter
-        for line, text in enumerate(doc[parameter_block:], parameter_block):
-            if ":" in text:
-                first_parameter = line
-                parameter_indentation = len(text) - len(text.lstrip(" "))
-                break
-        else:
-            raise ValueError(
-                "Cannot copy function docstring: no parameters "
-                "found. To simply copy the docstring, use the "
-                "@copy_doc decorator instead."
-            )
-
-        # Find end of first parameter
-        for line, text in enumerate(doc[first_parameter + 1 :], first_parameter + 1):
-            # Ignore empty lines
-            if len(text.strip()) == 0:
-                continue
-
-            line_indentation = len(text) - len(text.lstrip(" "))
-            if line_indentation <= parameter_indentation:
-                # Reach end of first parameter
-                first_parameter_end = line
-
-                # Of only one parameter is defined, remove the Parameters
-                # heading as well
-                if ":" not in text:
-                    first_parameter = parameter_block
-
-                break
-        else:
-            # End of docstring reached
-            first_parameter_end = line + 1
-            first_parameter = parameter_block
-
-        # Copy the docstring, but remove the first parameter
-        doc = (
-            "\n".join(doc[:first_parameter])
-            + "\n"
-            + "\n".join(doc[first_parameter_end:])
-        )
-        func.__doc__ = f"{doc}{func_doc}"
-        if not func.__doc__.endswith("\n\n"):
-            func.__doc__ = func.__doc__ + "\n"
+        _copy_function_doc(source, func)
         return func
 
     return wrapper
+
+
+def _check_lazy_doc_source(source, kind):
+    """Check a lazy docstring source like ``"func:mne.viz.plot_evoked"``."""
+    got = source.partition(":")[0]
+    if got != kind or source.count(":") != 1:
+        raise ValueError(
+            f'Lazy docstring source must look like "{kind}:some.dotted.path", got '
+            f"{source!r}"
+        )
+
+
+class _LazyMethodDoc:
+    """Copy ``source``'s docstring onto ``func`` the first time it is looked up.
+
+    ``source`` is a dotted path like ``"mne.viz.plot_evoked"``; resolving it eagerly
+    is what forces core modules (mne.evoked, mne.cov, mne.time_frequency.tfr) to
+    import mne.viz -- and therefore matplotlib -- at class-definition time.
+
+    Must be the outermost decorator, since what it returns is a descriptor rather
+    than a function.
+    """
+
+    def __init__(self, func, *, source):
+        self._func = func
+        self._source = source  # dotted path, or the _LazyMethodDoc to extend
+        self._materialized = False
+        # keep introspection working before the docstring is materialized
+        self.__name__ = func.__name__
+        self.__qualname__ = func.__qualname__
+        self.__module__ = func.__module__
+        self.__wrapped__ = func
+
+    def __set_name__(self, owner, name):
+        self._owner = owner
+        self._name = name
+        if self._materialized:  # an outer decorator already read __doc__
+            setattr(owner, name, self._func)
+
+    def _materialize(self):
+        if self._materialized:
+            return self._func
+        kind, _, path = self._source.partition(":")
+        module_name, _, attr = path.rpartition(".")
+        if kind == "func":
+            _copy_function_doc(getattr(import_module(module_name), attr), self._func)
+        else:  # "meth": look the parent up in the class __dict__ rather than with
+            # getattr, so that a lazily documented parent is not materialized (and
+            # its plotting module imported) just to be read here
+            module_name, _, cls_name = module_name.rpartition(".")
+            parent = vars(getattr(import_module(module_name), cls_name))[attr]
+            if isinstance(parent, _LazyMethodDoc):
+                parent = parent._materialize()
+            _copy_doc(parent, self._func)
+        self._materialized = True
+        # swap ourselves out so later lookups have no descriptor overhead; _owner is
+        # unset if the docstring is read from inside the class body (e.g. by an outer
+        # @verbose), in which case there is nothing to replace yet
+        if getattr(self, "_owner", None) is not None:
+            setattr(self._owner, self._name, self._func)
+        return self._func
+
+    @property
+    def __doc__(self):
+        return self._materialize().__doc__
+
+    def __get__(self, obj, objtype=None):
+        return self._materialize().__get__(obj, objtype)
+
+
+def _first_parameter_span(doc):
+    """Get the (start, stop) line span of the first entry of a Parameters block.
+
+    If the block holds a single parameter, the span covers the heading and its
+    underline too, so that removing it does not leave an empty section behind.
+    """
+    head = next(
+        (
+            ii
+            for ii, (this, next_) in enumerate(zip(doc, doc[1:]))
+            if this.strip() == "Parameters" and next_.strip() == "----------"
+        ),
+        None,
+    )
+    if head is None:
+        raise ValueError(
+            "Cannot copy function docstring: no parameter block found. To simply "
+            "copy the docstring, use the @copy_doc decorator instead."
+        )
+    first = next((ii for ii in range(head, len(doc)) if ":" in doc[ii]), None)
+    if first is None:
+        raise ValueError(
+            "Cannot copy function docstring: no parameters found. To simply copy "
+            "the docstring, use the @copy_doc decorator instead."
+        )
+    indent = len(doc[first]) - len(doc[first].lstrip(" "))
+    for stop in range(first + 1, len(doc)):
+        text = doc[stop]
+        if not text.strip():  # blank lines belong to the parameter
+            continue
+        if len(text) - len(text.lstrip(" ")) <= indent:
+            # dedented again, so the first parameter ends here; if what follows is
+            # not another parameter it was the only one, so drop the heading as well
+            return (first if ":" in text else head), stop
+    return head, len(doc)  # the first parameter runs to the end
+
+
+def _copy_function_doc(source, func):
+    """Prepend ``source``'s docstring to ``func``'s, dropping the first parameter."""
+    # Work with cleandoc'ed sources (py3.13-compat)
+    doc = inspect.cleandoc(source.__doc__).split("\n")
+    func_doc = ""
+    if func.__doc__ is not None:
+        func_doc = "\n" + inspect.cleandoc(func.__doc__).removeprefix(".\n")
+
+    if len(doc) == 1:  # a one-line source has no parameters to drop
+        func.__doc__ = doc[0] + func_doc
+        return
+
+    start, stop = _first_parameter_span(doc)
+    func.__doc__ = "\n".join(doc[:start]) + "\n" + "\n".join(doc[stop:]) + func_doc
+    if not func.__doc__.endswith("\n\n"):
+        func.__doc__ += "\n"
 
 
 def linkcode_resolve(domain, info):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -19,6 +19,7 @@ from scipy.spatial import ConvexHull, Delaunay
 from scipy.spatial.distance import cdist
 from scipy.stats import rankdata
 
+from .._fiff._digitization import _fiducial_coords
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info, create_info, read_fiducials
 from .._fiff.pick import (
@@ -91,33 +92,6 @@ from .utils import (
 )
 
 verbose_dec = verbose
-FIDUCIAL_ORDER = (FIFF.FIFFV_POINT_LPA, FIFF.FIFFV_POINT_NASION, FIFF.FIFFV_POINT_RPA)
-
-
-# XXX: to unify with digitization
-def _fiducial_coords(points, coord_frame=None):
-    """Generate 3x3 array of fiducial coordinates."""
-    points = points or []  # None -> list
-    if coord_frame is not None:
-        points = [p for p in points if p["coord_frame"] == coord_frame]
-    points_ = {p["ident"]: p for p in points if p["kind"] == FIFF.FIFFV_POINT_CARDINAL}
-    if points_:
-        return np.array([points_[i]["r"] for i in FIDUCIAL_ORDER])
-    else:
-        # XXX eventually this should probably live in montage.py
-        if coord_frame is None or coord_frame == FIFF.FIFFV_COORD_HEAD:
-            # Try converting CTF HPI coils to fiducials
-            out = np.empty((3, 3))
-            out.fill(np.nan)
-            for p in points:
-                if p["kind"] == FIFF.FIFFV_POINT_HPI:
-                    if np.isclose(p["r"][1:], 0, atol=1e-6).all():
-                        out[0 if p["r"][0] < 0 else 2] = p["r"]
-                    elif np.isclose(p["r"][::2], 0, atol=1e-6).all():
-                        out[1] = p["r"]
-            if np.isfinite(out).all():
-                return out
-        return np.array([])
 
 
 @fill_doc

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 import numpy as np
 
 from .._fiff.pick import _picks_to_idx, pick_channels, pick_types
-from ..defaults import _handle_default
+from ..defaults import _RAW_CLIP_DEF, _handle_default
 from ..filter import create_filter
 from ..utils import (
     _check_option,
@@ -29,8 +29,6 @@ from .utils import (
     _normalize_annotation_colors,
     _shorten_path_from_middle,
 )
-
-_RAW_CLIP_DEF = 3
 
 
 @verbose


### PR DESCRIPTION
Second part of the plan from https://github.com/mne-tools/mne-python/pull/14161, nest `viz` imports and make function-copy docstring copy resolve on demand. This one is again a functional no-op and pretty straightforward (mostly code moves plus a little extra doc resolve logic) so I'll self-mark for merge-when-green!