### PR TITLE
Nest SciPy imports

### DIFF
--- a/mne/_fiff/open.py
+++ b/mne/_fiff/open.py
@@ -7,7 +7,6 @@ from io import SEEK_SET, BytesIO
 from pathlib import Path
 
 import numpy as np
-from scipy.sparse import issparse
 
 from ..utils import _check_fname, _file_like, _validate_type, logger, verbose, warn
 from .constants import FIFF
@@ -295,6 +294,8 @@ def _show_tree(
     show_bytes=False,
 ):
     """Show FIFF tree."""
+    from scipy.sparse import issparse
+
     this_idt = indent * level
     next_idt = indent * (level + 1)
     # print block-level information

--- a/mne/_fiff/proc_history.py
+++ b/mne/_fiff/proc_history.py
@@ -5,7 +5,6 @@
 from functools import partial
 
 import numpy as np
-from scipy.sparse import csc_array
 
 from ..utils import _check_fname, logger, warn
 from .constants import FIFF
@@ -240,12 +239,21 @@ _sss_ctc_writers = (
     write_float_sparse,
     partial(write_name_list_sanitized, name="ch_names"),
 )
+
+
+def _csc_array(*args, **kwargs):
+    """Defer the scipy.sparse import (see mne/tests/test_import_nesting.py)."""
+    from scipy.sparse import csc_array
+
+    return csc_array(*args, **kwargs)
+
+
 _sss_ctc_casters = (
     dict,
     dict,
     np.array,
     str,
-    csc_array,
+    _csc_array,
     _sss_ctc_ch_name_clean,
 )
 

--- a/mne/_fiff/tag.py
+++ b/mne/_fiff/tag.py
@@ -10,7 +10,6 @@ from functools import partial
 from typing import Any
 
 import numpy as np
-from scipy.sparse import csc_array, csr_array
 
 from ..fixes import _reshape_view
 from ..utils import _check_option, warn
@@ -149,6 +148,8 @@ def _read_matrix(fid, tag, shape, rlims):
     """Read a matrix (dense or sparse) tag."""
     # This should be easy to implement (see _frombuffer_rows)
     # if we need it, but for now, it's not...
+    from scipy.sparse import csc_array, csr_array
+
     if shape is not None or rlims is not None:
         raise ValueError("Row reading not implemented for matrices yet")
 

--- a/mne/_fiff/write.py
+++ b/mne/_fiff/write.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 from gzip import GzipFile
 
 import numpy as np
-from scipy.sparse import csc_array, csr_array
 
 from ..utils import _check_fname, _file_like, _validate_type, logger
 from ..utils.numerics import _date_to_julian
@@ -418,6 +417,8 @@ def write_float_sparse_rcs(fid, kind, mat):
 
 def write_float_sparse(fid, kind, mat, fmt="auto"):
     """Write a single-precision floating-point sparse matrix tag."""
+    from scipy.sparse import csc_array, csr_array
+
     if fmt == "auto":
         fmt = "csr" if isinstance(mat, csr_array) else "csc"
     need = csr_array if fmt == "csr" else csc_array

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -16,8 +16,10 @@ from .surface import _read_mri_surface, read_surface
 from .transforms import (
     Transform,
     _ensure_trans,
+    _trans_from_params,
     apply_trans,
     combine_transforms,
+    fit_matched_points,
     invert_transform,
     read_ras_mni_t,
 )
@@ -841,8 +843,6 @@ def _get_skull_surface(surf, subject, subjects_dir, bem=None, verbose=None):
 
 
 def _estimate_talxfm_rigid(subject, subjects_dir):
-    from .coreg import _trans_from_params, fit_matched_points
-
     xfm = read_talxfm(subject, subjects_dir)
     # XYZ+origin + halfway
     pts_tal = np.concatenate([np.eye(4)[:, :3], np.eye(3) * 0.5])

--- a/mne/_ola.py
+++ b/mne/_ola.py
@@ -3,7 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy.signal import get_window
 
 from .utils import _ensure_int, _validate_type, logger, verbose
 
@@ -302,6 +301,8 @@ class _COLA:
         offset=0,
         verbose=None,
     ):
+        from scipy.signal import get_window
+
         self._offset = _ensure_int(offset, "offset")
         n_samples = _ensure_int(n_samples, "n_samples")
         n_overlap = _ensure_int(n_overlap, "n_overlap")

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -13,7 +13,6 @@ from itertools import takewhile
 from textwrap import shorten
 
 import numpy as np
-from scipy.io import loadmat
 
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import Info
@@ -2123,6 +2122,7 @@ def _read_brainstorm_annotations(fname, orig_time=None):
     annot : instance of Annotations | None
         The annotations.
     """
+    from scipy.io import loadmat
 
     def get_duration_from_times(t):
         return t[1] - t[0] if t.shape[0] == 2 else np.zeros(len(t[0]))

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -16,7 +16,6 @@ from functools import cache, partial
 from pathlib import Path
 
 import numpy as np
-from scipy.optimize import fmin_cobyla
 
 from ._fiff._digitization import _dig_kind_dict, _dig_kind_ints, _dig_kind_rev
 from ._fiff.constants import FIFF, FWD
@@ -810,6 +809,8 @@ def _fwd_eeg_fit_berg_scherg(m, nterms, nfit):
 @cache
 def _fit_berg_scherg_cached(rel_rads, sigmas, nterms, nfit):
     """Fit Berg-Scherg params (pure function of relative radii and sigmas)."""
+    from scipy.optimize import fmin_cobyla
+
     assert nfit >= 2
     # Only rel_rad and sigma are read to compute the coefficients and weighting.
     m = dict(layers=[dict(rel_rad=r, sigma=s) for r, s in zip(rel_rads, sigmas)])
@@ -1403,6 +1404,8 @@ def make_watershed_bem(
 
     # Show computed BEM surfaces
     if show:
+        from .viz.misc import plot_bem
+
         plot_bem(
             subject=subject,
             subjects_dir=subjects_dir,
@@ -2299,6 +2302,8 @@ def make_flash_bem(
     )
     # Show computed BEM surfaces
     if show:
+        from .viz.misc import plot_bem
+
         plot_bem(
             subject=subject,
             subjects_dir=subjects_dir,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -13,10 +13,6 @@ from functools import partial
 from pathlib import Path
 
 import numpy as np
-from scipy.io import loadmat
-from scipy.sparse import csr_array, lil_array
-from scipy.spatial import Delaunay
-from scipy.stats import zscore
 
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import (  # noqa F401
@@ -1529,6 +1525,8 @@ def read_ch_adjacency(fname, picks=None):
     :func:`mne.stats.combine_adjacency` to prepare a final "adjacency"
     to pass to the eventual function.
     """
+    from scipy.io import loadmat
+
     if op.isabs(fname):
         fname = str(
             _check_fname(
@@ -1592,6 +1590,8 @@ def _ch_neighbor_adjacency(ch_names, neighbors):
     ch_adjacency : scipy.sparse.spmatrix
         The adjacency matrix.
     """
+    from scipy.sparse import csr_array
+
     if len(ch_names) != len(neighbors):
         raise ValueError("`ch_names` and `neighbors` must have the same length")
     set_neighbors = {c for d in neighbors for c in d}
@@ -1748,6 +1748,9 @@ def _compute_ch_adjacency(info, ch_type):
     ch_names : list
         The list of channel names present in adjacency matrix.
     """
+    from scipy.sparse import csr_array, lil_array
+    from scipy.spatial import Delaunay
+
     from ..channels.layout import _find_topomap_coords, _pair_grad_sensors
     from ..source_estimate import spatial_tris_adjacency
 
@@ -2186,6 +2189,8 @@ _EEG_SELECTIONS = ["EEG 1-32", "EEG 33-64", "EEG 65-96", "EEG 97-128"]
 
 def _divide_to_regions(info, add_stim=True):
     """Divide channels to regions by positions."""
+    from scipy.stats import zscore
+
     picks = _pick_data_channels(info, exclude=[])
     chs_in_lobe = len(picks) // 4
     pos = np.array([ch["loc"][:3] for ch in info["chs"]])

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.polynomial.legendre import legval
 from scipy.interpolate import RectBivariateSpline
 from scipy.linalg import pinv
-from scipy.spatial.distance import pdist, squareform
 
 from .._fiff.meas_info import _simplify_info, create_info
 from .._fiff.pick import pick_channels, pick_info, pick_types
@@ -257,6 +256,8 @@ def _interpolate_bads_meeg(
 
 @verbose
 def _interpolate_bads_nirs(inst, exclude=(), verbose=None):
+    from scipy.spatial.distance import pdist, squareform
+
     from ..preprocessing.nirs import _validate_nirs_info
 
     if len(pick_types(inst.info, fnirs=True, exclude=())) == 0:
@@ -302,6 +303,8 @@ def _find_seeg_electrode_shaft(pos, tol_shaft=0.002, tol_spacing=1):
     # 1) find nearest neighbor to define the electrode shaft line
     # 2) find all contacts on the same line
     # 3) remove contacts with large distances
+
+    from scipy.spatial.distance import pdist, squareform
 
     dist = squareform(pdist(pos))
     np.fill_diagonal(dist, np.inf)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -9,7 +9,6 @@ from itertools import combinations
 from pathlib import Path
 
 import numpy as np
-from scipy.spatial.distance import pdist, squareform
 
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info
@@ -768,6 +767,7 @@ def _box_size(points, width=None, height=None, padding=0.0):
     height : float
         Height of the box
     """
+    from scipy.spatial.distance import pdist
 
     def xdiff(a, b):
         return np.abs(a[0] - b[0])
@@ -896,6 +896,8 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
     locs : array, shape = (n_sensors, 2)
         An array of positions of the 2 dimensional map.
     """
+    from scipy.spatial.distance import pdist, squareform
+
     sphere = _check_sphere(sphere, info)
     logger.debug(f"Generating coords using: {sphere}")
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -27,8 +27,6 @@ from functools import partial
 
 import numpy as np
 from scipy.linalg import orth
-from scipy.optimize import fmin_cobyla
-from scipy.spatial.distance import cdist
 
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import Info, _simplify_info
@@ -540,6 +538,8 @@ def _magnetic_dipole_delta_multi(whitened_fwd_svd, B, B2):
 
 def _fit_magnetic_dipole(B_orig, x0, too_close, whitener, coils, guesses):
     """Fit a single bit of data (x0 = pos)."""
+    from scipy.optimize import fmin_cobyla
+
     B = whitener @ B_orig
     B2 = B @ B
     objective = partial(
@@ -952,6 +952,8 @@ def compute_head_pos(
     -----
     .. versionadded:: 0.20
     """
+    from scipy.spatial.distance import cdist
+
     _check_chpi_param(chpi_locs, "chpi_locs")
     _validate_type(info, Info, "info")
     if weighted is None:
@@ -1647,6 +1649,8 @@ def _subtract_chpi(raw, hpi, meg_picks, n_step, n_remove, include_line, interp):
 
 def _compute_good_distances(hpi_coil_dists, new_pos, dist_limit=0.005):
     """Compute good coils based on distances."""
+    from scipy.spatial.distance import cdist
+
     these_dists = cdist(new_pos, new_pos)
     these_dists = np.abs(hpi_coil_dists - these_dists)
     # there is probably a better algorithm for finding the bad ones...

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -17,8 +17,6 @@ from functools import reduce
 from glob import glob, iglob
 
 import numpy as np
-from scipy.optimize import leastsq
-from scipy.spatial.distance import cdist
 
 from ._fiff._digitization import _fiducial_coords, _get_data_as_dict_from_dig
 from ._fiff.constants import FIFF
@@ -278,6 +276,8 @@ def _decimate_points(pts, res=10):
     pts : array, shape = (n_points, 3)
         The decimated points.
     """
+    from scipy.spatial.distance import cdist
+
     pts = np.asarray(pts)
 
     # find the bin edges for the voxel space
@@ -467,6 +467,8 @@ def fit_matched_points(
 
 
 def _generic_fit(src_pts, tgt_pts, param_info, weights, x0):
+    from scipy.optimize import leastsq
+
     if param_info[1]:  # translate
         src_pts = np.hstack((src_pts, np.ones((len(src_pts), 1))))
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -13,7 +13,6 @@ import shutil
 import stat
 import sys
 from copy import deepcopy
-from functools import reduce
 from glob import glob, iglob
 
 import numpy as np
@@ -45,14 +44,16 @@ from .surface import (
     read_surface,
     write_surface,
 )
-from .transforms import (
+from .transforms import (  # noqa: F401  (re-exported for backward compatibility)
     Transform,
     _angle_between_quats,
     _quat_to_euler,
     _read_fs_xfm,
+    _trans_from_params,
     _write_fs_xfm,
     apply_trans,
     combine_transforms,
+    fit_matched_points,
     invert_transform,
     rot_to_quat,
     rotation,
@@ -325,219 +326,6 @@ def _decimate_points(pts, res=10):
     # """
 
     return out
-
-
-def _trans_from_params(param_info, params):
-    """Convert transformation parameters into a transformation matrix."""
-    do_rotate, do_translate, do_scale = param_info
-    i = 0
-    trans = []
-
-    if do_rotate:
-        x, y, z = params[:3]
-        trans.append(rotation(x, y, z))
-        i += 3
-
-    if do_translate:
-        x, y, z = params[i : i + 3]
-        trans.insert(0, translation(x, y, z))
-        i += 3
-
-    if do_scale == 1:
-        s = params[i]
-        trans.append(scaling(s, s, s))
-    elif do_scale == 3:
-        x, y, z = params[i : i + 3]
-        trans.append(scaling(x, y, z))
-
-    trans = reduce(np.dot, trans)
-    return trans
-
-
-_ALLOW_ANALITICAL = True
-
-
-# XXX this function should be moved out of coreg as used elsewhere
-def fit_matched_points(
-    src_pts,
-    tgt_pts,
-    rotate=True,
-    translate=True,
-    scale=False,
-    tol=None,
-    x0=None,
-    out="trans",
-    weights=None,
-):
-    """Find a transform between matched sets of points.
-
-    This minimizes the squared distance between two matching sets of points.
-
-    Uses :func:`scipy.optimize.leastsq` to find a transformation involving
-    a combination of rotation, translation, and scaling (in that order).
-
-    Parameters
-    ----------
-    src_pts : array, shape = (n, 3)
-        Points to which the transform should be applied.
-    tgt_pts : array, shape = (n, 3)
-        Points to which src_pts should be fitted. Each point in tgt_pts should
-        correspond to the point in src_pts with the same index.
-    rotate : bool
-        Allow rotation of the ``src_pts``.
-    translate : bool
-        Allow translation of the ``src_pts``.
-    scale : bool
-        Number of scaling parameters. With False, points are not scaled. With
-        True, points are scaled by the same factor along all axes.
-    tol : scalar | None
-        The error tolerance. If the distance between any of the matched points
-        exceeds this value in the solution, a RuntimeError is raised. With
-        None, no error check is performed.
-    x0 : None | tuple
-        Initial values for the fit parameters.
-    out : 'params' | 'trans'
-        In what format to return the estimate: 'params' returns a tuple with
-        the fit parameters; 'trans' returns a transformation matrix of shape
-        (4, 4).
-
-    Returns
-    -------
-    trans : array, shape (4, 4)
-        Transformation that, if applied to src_pts, minimizes the squared
-        distance to tgt_pts. Only returned if out=='trans'.
-    params : array, shape (n_params, )
-        A single tuple containing the rotation, translation, and scaling
-        parameters in that order (as applicable).
-    """
-    src_pts = np.atleast_2d(src_pts)
-    tgt_pts = np.atleast_2d(tgt_pts)
-    if src_pts.shape != tgt_pts.shape:
-        raise ValueError(
-            "src_pts and tgt_pts must have same shape "
-            f"(got {src_pts.shape}, {tgt_pts.shape})"
-        )
-    if weights is not None:
-        weights = np.asarray(weights, src_pts.dtype)
-        if weights.ndim != 1 or weights.size not in (src_pts.shape[0], 1):
-            raise ValueError(
-                f"weights (shape={weights.shape}) must be None or have shape "
-                f"({src_pts.shape[0]},)"
-            )
-        weights = weights[:, np.newaxis]
-
-    param_info = (bool(rotate), bool(translate), int(scale))
-    del rotate, translate, scale
-
-    # very common use case, rigid transformation (maybe with one scale factor,
-    # with or without weighted errors)
-    if param_info in ((True, True, 0), (True, True, 1)) and _ALLOW_ANALITICAL:
-        src_pts = np.asarray(src_pts, float)
-        tgt_pts = np.asarray(tgt_pts, float)
-        if weights is not None:
-            weights = np.asarray(weights, float)
-        from ._transforms_numba import _fit_matched_points
-
-        x, s = _fit_matched_points(src_pts, tgt_pts, weights, bool(param_info[2]))
-        x[:3] = _quat_to_euler(x[:3])
-        x = np.concatenate((x, [s])) if param_info[2] else x
-    else:
-        x = _generic_fit(src_pts, tgt_pts, param_info, weights, x0)
-
-    # re-create the final transformation matrix
-    if (tol is not None) or (out == "trans"):
-        trans = _trans_from_params(param_info, x)
-
-    # assess the error of the solution
-    if tol is not None:
-        src_pts = np.hstack((src_pts, np.ones((len(src_pts), 1))))
-        est_pts = np.dot(src_pts, trans.T)[:, :3]
-        err = np.sqrt(np.sum((est_pts - tgt_pts) ** 2, axis=1))
-        if np.any(err > tol):
-            raise RuntimeError(f"Error exceeds tolerance. Error = {err!r}")
-
-    if out == "params":
-        return x
-    elif out == "trans":
-        return trans
-    else:
-        raise ValueError(
-            f"Invalid out parameter: {out!r}. Needs to be 'params' or 'trans'."
-        )
-
-
-def _generic_fit(src_pts, tgt_pts, param_info, weights, x0):
-    from scipy.optimize import leastsq
-
-    if param_info[1]:  # translate
-        src_pts = np.hstack((src_pts, np.ones((len(src_pts), 1))))
-
-    if param_info == (True, False, 0):
-
-        def error(x):
-            rx, ry, rz = x
-            trans = rotation3d(rx, ry, rz)
-            est = np.dot(src_pts, trans.T)
-            d = tgt_pts - est
-            if weights is not None:
-                d *= weights
-            return d.ravel()
-
-        if x0 is None:
-            x0 = (0, 0, 0)
-    elif param_info == (True, True, 0):
-
-        def error(x):
-            rx, ry, rz, tx, ty, tz = x
-            trans = np.dot(translation(tx, ty, tz), rotation(rx, ry, rz))
-            est = np.dot(src_pts, trans.T)[:, :3]
-            d = tgt_pts - est
-            if weights is not None:
-                d *= weights
-            return d.ravel()
-
-        if x0 is None:
-            x0 = (0, 0, 0, 0, 0, 0)
-    elif param_info == (True, True, 1):
-
-        def error(x):
-            rx, ry, rz, tx, ty, tz, s = x
-            trans = reduce(
-                np.dot,
-                (translation(tx, ty, tz), rotation(rx, ry, rz), scaling(s, s, s)),
-            )
-            est = np.dot(src_pts, trans.T)[:, :3]
-            d = tgt_pts - est
-            if weights is not None:
-                d *= weights
-            return d.ravel()
-
-        if x0 is None:
-            x0 = (0, 0, 0, 0, 0, 0, 1)
-    elif param_info == (True, True, 3):
-
-        def error(x):
-            rx, ry, rz, tx, ty, tz, sx, sy, sz = x
-            trans = reduce(
-                np.dot,
-                (translation(tx, ty, tz), rotation(rx, ry, rz), scaling(sx, sy, sz)),
-            )
-            est = np.dot(src_pts, trans.T)[:, :3]
-            d = tgt_pts - est
-            if weights is not None:
-                d *= weights
-            return d.ravel()
-
-        if x0 is None:
-            x0 = (0, 0, 0, 0, 0, 0, 1, 1, 1)
-    else:
-        raise NotImplementedError(
-            "The specified parameter combination is not implemented: "
-            "rotate={!r}, translate={!r}, scale={!r}".format(*param_info)
-        )
-
-    x, _, _, _, _ = leastsq(error, x0, full_output=True)
-    return x
 
 
 def _find_label_paths(subject="fsaverage", pattern=None, subjects_dir=None):

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from math import log
 
 import numpy as np
-from scipy.sparse import issparse
 
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import _read_bad_channels, _write_bad_channels, create_info
@@ -2442,6 +2441,8 @@ def whiten_evoked(
 def _read_cov(fid, node, cov_kind, limited=False, verbose=None):
     """Read a noise covariance matrix."""
     #   Find all covariance matrices
+    from scipy.sparse import issparse
+
     from ._fiff.write import _safe_read_name_list
 
     covs = dir_tree_find(node, FIFF.FIFFB_MNE_COV)

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -3,7 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy.fft import irfft, rfft
 
 from .utils import (
     _check_option,
@@ -166,6 +165,8 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft, kind="FFT FIR filtering"
     -----
     This function is designed to be used with fft_multiply_repeated().
     """
+    from scipy.fft import irfft, rfft
+
     cuda_dict = dict(n_fft=n_fft, rfft=rfft, irfft=irfft, h_fft=rfft(h, n=n_fft))
     if isinstance(n_jobs, str):
         _check_option("n_jobs", n_jobs, ("cuda",))
@@ -261,6 +262,8 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
     -----
     This function is designed to be used with fft_resample().
     """
+    from scipy.fft import irfft, rfft
+
     cuda_dict = dict(use_cuda=False, rfft=rfft, irfft=irfft)
     rfft_len_x = len(W) // 2 + 1
     # fold the window onto inself (should be symmetric) and truncate

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -5,7 +5,6 @@
 import numbers
 
 import numpy as np
-from scipy.stats import pearsonr
 from sklearn.base import (
     BaseEstimator,
     MetaEstimatorMixin,
@@ -554,6 +553,8 @@ def _reshape_for_est(X_del):
 
 # Create a correlation scikit-learn-style scorer
 def _corr_score(y_true, y, multioutput=None):
+    from scipy.stats import pearsonr
+
     assert multioutput == "raw_values"
     for this_y in (y_true, y):
         if this_y.ndim != 2:

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -5,7 +5,6 @@
 import logging
 
 import numpy as np
-from scipy.stats import rankdata
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, clone
 from sklearn.metrics import check_scoring
 from sklearn.preprocessing import LabelEncoder
@@ -799,6 +798,8 @@ def _make_batched_score(score_func, response_method, method, y, sign, kwargs):
             # Mann-Whitney U identity with average-rank tie correction.
             # Equivalent to sklearn's roc_auc within floating point precision,
             # but different computation.
+            from scipy.stats import rankdata
+
             ranks = rankdata(y_pred, method="average", axis=0)
             return (
                 sign

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -7,7 +7,6 @@
 import numpy as np
 from scipy import linalg
 from scipy.signal import fftconvolve
-from scipy.sparse.csgraph import laplacian
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -155,6 +154,8 @@ def _toeplitz_dot(a, b):
 
 def _compute_reg_neighbors(n_ch_x, n_delays, reg_type, method="direct", normed=False):
     """Compute regularization parameter from neighbors."""
+    from scipy.sparse.csgraph import laplacian
+
     known_types = ("ridge", "laplacian")
     if isinstance(reg_type, str):
         reg_type = (reg_type,) * 2

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -11,7 +11,6 @@ from functools import partial
 
 import numpy as np
 from scipy.linalg import eigh
-from scipy.optimize import fmin_cobyla
 
 from ._fiff.constants import FIFF
 from ._fiff.pick import pick_types
@@ -1069,6 +1068,8 @@ def _fit_dipoles(
     rhoend,
 ):
     """Fit a single dipole to the given whitened, projected data."""
+    from scipy.optimize import fmin_cobyla
+
     parallel, p_fun, n_jobs = parallel_func(fun, n_jobs)
     # parallel over time points
     res = parallel(

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from numpy.random import RandomState
-from scipy.interpolate import interp1d
 
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import (
@@ -75,7 +74,6 @@ from .fixes import _reshape_view, rng_uniform
 from .html_templates import _get_html_template
 from .parallel import parallel_func
 from .time_frequency.spectrum import EpochsSpectrum, SpectrumMixin, _validate_method
-from .time_frequency.tfr import AverageTFR, EpochsTFR
 from .utils import (
     ExtendedTimeMixin,
     GetEpochsMixin,
@@ -124,6 +122,7 @@ if TYPE_CHECKING:
     from .channels.layout import Layout
     from .cov import Covariance
     from .io import BaseRaw
+    from .time_frequency.tfr import AverageTFR, EpochsTFR
     from .transforms import Transform
 
     # The optional ``mne_qt_browser`` window subclasses the first-party
@@ -2730,7 +2729,7 @@ class BaseEpochs(
         n_jobs: int | None = None,
         verbose: bool | str | int | None = None,
         **method_kw,
-    ) -> EpochsTFR | AverageTFR | tuple:
+    ) -> "EpochsTFR | AverageTFR | tuple":
         """Compute a time-frequency representation of epoched data.
 
         Parameters
@@ -2774,6 +2773,8 @@ class BaseEpochs(
         ----------
         .. footbibliography::
         """
+        from .time_frequency.tfr import AverageTFR, EpochsTFR
+
         if method == "stockwell" and not average:  # stockwell method *must* average
             logger.info(
                 'Requested `method="stockwell"` so ignoring parameter `average=False`.'
@@ -4042,6 +4043,8 @@ def equalize_epoch_counts(
     --------
     >>> equalize_epoch_counts([epochs1, epochs2])  # doctest: +SKIP
     """
+    from .time_frequency.tfr import EpochsTFR
+
     if not all(isinstance(epoch, BaseEpochs | EpochsTFR) for epoch in epochs_list):
         raise ValueError("All inputs must be Epochs instances")
     # make sure bad epochs are dropped
@@ -4079,6 +4082,8 @@ def _get_drop_indices(sample_nums, method, random_state):
 
 def _minimize_time_diff(t_shorter, t_longer):
     """Find a boolean mask to minimize timing differences."""
+    from scipy.interpolate import interp1d
+
     keep = np.ones((len(t_longer)), dtype=bool)
     # special case: length zero or one
     if len(t_shorter) < 2:  # interp1d won't work

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -45,7 +45,6 @@ from .filter import FilterMixin, _check_fun, detrend
 from .html_templates import _get_html_template
 from .parallel import parallel_func
 from .time_frequency.spectrum import Spectrum, SpectrumMixin, _validate_method
-from .time_frequency.tfr import AverageTFR
 from .utils import (
     ExtendedTimeMixin,
     SizeMixin,
@@ -81,6 +80,7 @@ if TYPE_CHECKING:
 
     from .bem import ConductorModel
     from .cov import Covariance
+    from .time_frequency.tfr import AverageTFR
     from .viz import Brain, EvokedField, Figure3D
 
 _aspect_dict = {
@@ -1304,7 +1304,7 @@ class Evoked(
         n_jobs: int | None = None,
         verbose: bool | str | int | None = None,
         **method_kw,
-    ) -> AverageTFR:
+    ) -> "AverageTFR":
         """Compute a time-frequency representation of evoked data.
 
         Parameters
@@ -1333,6 +1333,8 @@ class Evoked(
         ----------
         .. footbibliography::
         """
+        from .time_frequency.tfr import AverageTFR
+
         _check_option("output", output, ("power", "phase", "complex"))
         method_kw["output"] = output
         return AverageTFR(

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -10,8 +10,6 @@ from functools import lru_cache, partial
 from math import gcd
 
 import numpy as np
-from scipy import fft, signal
-from scipy.stats import f as fstat
 
 from ._fiff.pick import _picks_to_idx
 from ._ola import _COLA
@@ -387,6 +385,8 @@ def _1d_overlap_filter(x, n_h, n_edge, phase, cuda_dict, pad, n_fft):
 
 def _filter_attenuation(h, freq, gain):
     """Compute minimum attenuation at stop frequency."""
+    from scipy import signal
+
     _, filt_resp = signal.freqz(h.ravel(), worN=np.pi * freq)
     filt_resp = np.abs(filt_resp)  # use amplitude response
     filt_resp[np.where(gain == 1)] = 0
@@ -420,6 +420,8 @@ def _prep_for_filtering(x, copy, picks=None):
 
 def _firwin_design(N, freq, gain, window, sfreq):
     """Construct a FIR filter using firwin."""
+    from scipy import signal
+
     assert freq[0] == 0
     assert len(freq) > 1
     assert len(freq) == len(gain)
@@ -473,6 +475,8 @@ def _construct_fir_filter(
 
     If x is multi-dimensional, this operates along the last dimension.
     """
+    from scipy import signal
+
     assert freq[0] == 0
     if fir_design == "firwin2":
         fir_design = signal.firwin2
@@ -525,6 +529,8 @@ def _check_zero_phase_length(N, phase, gain_nyq=0):
 
 def _check_coefficients(system):
     """Check for filter stability."""
+    from scipy import signal
+
     if isinstance(system, tuple):
         z, p, k = signal.tf2zpk(*system)
     else:  # sos
@@ -555,6 +561,8 @@ def _picks_chunks(picks, n_times, max_size=2**22):
 def _iir_filter(x, iir_params, picks, n_jobs, copy, phase="zero"):
     """Call filtfilt or lfilter."""
     # set up array for filtering, reshape to 2D, operate on last axis
+    from scipy import signal
+
     x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
     if phase in ("zero", "zero-double"):
         padlen = min(iir_params["padlen"], x.shape[-1] - 1)
@@ -613,6 +621,8 @@ def estimate_ringing_samples(system, max_try=100000):
     n : int
         The approximate ringing.
     """
+    from scipy import signal
+
     if isinstance(system, tuple):  # TF
         kind = "ba"
         b, a = system
@@ -792,6 +802,8 @@ def construct_iir_filter(
     For more information, see the tutorials
     :ref:`disc-filtering` and :ref:`tut-filter-resample`.
     """  # noqa: E501
+    from scipy import signal
+
     known_filters = (
         "bessel",
         "butter",
@@ -1604,6 +1616,8 @@ def notch_filter(
 
 @lru_cache
 def _get_window_thresh(n_times, sfreq, mt_bandwidth, p_value):
+    from scipy.stats import f as fstat
+
     from .time_frequency.multitaper import _compute_mt_params
 
     # figure out what tapers to use
@@ -1911,6 +1925,8 @@ def resample(
 
 
 def _prep_polyphase(ratio, x_len, final_len, window):
+    from scipy import signal
+
     if isinstance(window, str) and window == "auto":
         window = ("kaiser", 5.0)  # SciPy default
     up = final_len
@@ -1929,6 +1945,8 @@ def _prep_polyphase(ratio, x_len, final_len, window):
 
 
 def _resample_polyphase(x, *, up, down, pad, window, n_jobs):
+    from scipy import signal
+
     if pad == "auto":
         pad = "reflect"
     kwargs = dict(padtype=pad, window=window, up=up, down=down)
@@ -1944,6 +1962,8 @@ def _resample_polyphase(x, *, up, down, pad, window, n_jobs):
 
 
 def _resample_fft(x_flat, *, ratio, final_len, pad, window, npad, n_jobs):
+    from scipy import fft, signal
+
     x_len = x_flat.shape[-1]
     pad = "reflect_limited" if pad == "auto" else pad
     if (isinstance(window, str) and window == "auto") or window is None:
@@ -2078,6 +2098,8 @@ def detrend(x, order=1, axis=-1):
         >>> bool((detrend(x) - noise).max() < 0.01)
         True
     """
+    from scipy import signal
+
     if axis > len(x.shape):
         raise ValueError(f"x does not have {axis} axes")
     if order == 0:
@@ -2435,6 +2457,8 @@ class FilterMixin:
         >>> evoked.savgol_filter(10.)  # low-pass at around 10 Hz # doctest:+SKIP
         >>> evoked.plot()  # doctest:+SKIP
         """  # noqa: E501
+        from scipy import signal
+
         from .source_estimate import _BaseSourceEstimate
 
         _check_preload(self, "inst.savgol_filter")
@@ -2827,6 +2851,8 @@ def _my_hilbert(x, n_fft=None, envelope=False):
     out : array, shape (n_times)
         The hilbert transform of the signal, or the envelope.
     """
+    from scipy import signal
+
     n_x = x.shape[-1]
     out = signal.hilbert(x, N=n_fft, axis=-1)[..., :n_x]
     if envelope:
@@ -2875,6 +2901,8 @@ def design_mne_c_filter(
     4197 frequencies are directly constructed, with zeroes in the stop-band
     and ones in the passband, with squared cosine ramps in between.
     """
+    from scipy import fft
+
     n_freqs = (4096 + 2 * 2048) // 2 + 1
     freq_resp = np.ones(n_freqs)
     l_freq = 0 if l_freq is None else float(l_freq)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from time import time
 
 import numpy as np
-from scipy import sparse
 
 from .._fiff.constants import FIFF
 from .._fiff.matrix import (
@@ -294,6 +293,8 @@ def _block_diag(A, n):
     bd : scipy.sparse.csc_array
         The block diagonal matrix
     """
+    from scipy import sparse
+
     if sparse.issparse(A):  # then make block sparse
         raise NotImplementedError("sparse reversal not implemented yet")
     ma, na = A.shape
@@ -739,6 +740,8 @@ def convert_forward_solution(
     fwd : Forward
         The modified forward solution.
     """
+    from scipy import sparse
+
     fwd = fwd.copy() if copy else fwd
 
     if force_fixed is True:

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from scipy.spatial.distance import cdist
 
 from ..._fiff._digitization import DigPoint, _make_dig_points
 from ..._fiff.constants import FIFF
@@ -342,6 +341,8 @@ class RawArtemis123(BaseRaw):
         pos_fname=None,
         add_head_trans=True,
     ):
+        from scipy.spatial.distance import cdist
+
         from ...chpi import (
             _fit_coil_order_dev_head_trans,
             compute_chpi_amplitudes,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -73,7 +73,6 @@ from ..filter import (
 from ..html_templates import _get_html_template
 from ..parallel import parallel_func
 from ..time_frequency.spectrum import Spectrum, SpectrumMixin, _validate_method
-from ..time_frequency.tfr import RawTFR
 from ..utils import (
     SizeMixin,
     TimeMixin,
@@ -113,6 +112,7 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
     from ..cov import Covariance
+    from ..time_frequency.tfr import RawTFR
 
     # The optional ``mne_qt_browser`` window subclasses the first-party
     # ``BrowserBase``, so alias it to annotate ``.plot()`` returns without the dep.
@@ -2507,7 +2507,7 @@ class BaseRaw(
         n_jobs: int | None = None,
         verbose: bool | str | int | None = None,
         **method_kw,
-    ) -> RawTFR:
+    ) -> "RawTFR":
         """Compute a time-frequency representation of sensor data.
 
         Parameters
@@ -2537,6 +2537,8 @@ class BaseRaw(
         ----------
         .. footbibliography::
         """
+        from ..time_frequency.tfr import RawTFR
+
         _check_option("output", output, ("power", "phase", "complex"))
         method_kw["output"] = output
         return RawTFR(

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
-from scipy.interpolate import interp1d
 
 from ..._fiff.constants import FIFF
 from ..._fiff.meas_info import _empty_info, _unique_channel_names
@@ -611,6 +610,8 @@ def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):
 
 def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames, cals, mult):
     """Read a chunk of raw data."""
+    from scipy.interpolate import interp1d
+
     n_samps = raw_extras["n_samps"]
     buf_len = int(raw_extras["max_samp"])
     dtype = raw_extras["dtype_np"]

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -3,8 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy.io import loadmat
-from scipy.io.matlab import MatlabFunction, MatlabOpaque
 
 from ...fixes import _whosmat
 from ...utils import _import_pymatreader_funcs, warn
@@ -33,6 +31,8 @@ def _todict_from_np_struct(data):  # taken from pymatreader.utils
 
 
 def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
+    from scipy.io.matlab import MatlabFunction
+
     if data.dtype == np.dtype("object") and not isinstance(data, MatlabFunction):
         as_list = []
         for element in data:
@@ -50,6 +50,8 @@ def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
 
 def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
     """Convert all scipy.io.matlab.mio5_params.mat_struct elements."""
+    from scipy.io.matlab import MatlabOpaque
+
     if isinstance(data, dict):
         for key in data:
             data[key] = _check_for_scipy_mat_struct(data[key])
@@ -69,6 +71,8 @@ def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
 
 def _scipy_reader(file_name, variable_names=None, uint16_codec=None):
     """Load with scipy and then run the check function."""
+    from scipy.io import loadmat
+
     mat_data = loadmat(
         file_name,
         squeeze_me=True,

--- a/mne/io/kit/coreg.py
+++ b/mne/io/kit/coreg.py
@@ -22,6 +22,7 @@ from ...transforms import (
     Transform,
     als_ras_trans,
     apply_trans,
+    fit_matched_points,
     get_ras_to_neuromag_trans,
 )
 from ...utils import _check_fname, _check_option, warn
@@ -133,7 +134,7 @@ def _set_dig_kit(mrk, elp, hsp, eeg, *, bad_coils=()):
     hpi_results : list
         The hpi results.
     """
-    from ...coreg import _decimate_points, fit_matched_points
+    from ...coreg import _decimate_points
 
     if isinstance(hsp, str | Path | PathLike):
         hsp = _read_dig_kit(hsp)

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -11,7 +11,6 @@ from configparser import ConfigParser, RawConfigParser
 from pathlib import Path
 
 import numpy as np
-from scipy.io import loadmat
 
 from ..._fiff.constants import FIFF
 from ..._fiff.meas_info import _format_dig_points, create_info
@@ -104,6 +103,8 @@ class RawNIRX(BaseRaw):
 
     @verbose
     def __init__(self, fname, saturated, *, preload=False, encoding=None, verbose=None):
+        from scipy.io import loadmat
+
         logger.info(f"Loading {fname}")
         _validate_type(fname, "path-like", "fname")
         _validate_type(saturated, str, "saturated")

--- a/mne/label.py
+++ b/mne/label.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from colorsys import hsv_to_rgb, rgb_to_hsv
 
 import numpy as np
-from scipy import linalg, sparse
+from scipy import linalg
 
 from .fixes import _safe_svd
 from .morph_map import read_morph_map
@@ -916,6 +916,8 @@ class Label:
 
         .. versionadded:: 0.24
         """
+        from scipy import sparse
+
         rr, tris = self._load_surface(subject, subjects_dir, surface)
         adjacency = mesh_dist(tris, rr)
         mask = np.zeros(len(rr))
@@ -2560,6 +2562,8 @@ def _check_values_labels(values, n_labels):
 
 
 def _labels_to_stc_surf(labels, values, tmin, tstep, subject):
+    from scipy import sparse
+
     subject = _check_labels_subject(labels, subject, "subject")
     _check_values_labels(values, len(labels))
     vertices = dict(lh=[], rh=[])

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -7,7 +7,6 @@ from math import sqrt
 
 import numpy as np
 from scipy import linalg
-from scipy.stats import chi2
 
 from .._fiff.constants import FIFF
 from .._fiff.matrix import (
@@ -2196,6 +2195,8 @@ def estimate_snr(evoked, inv, verbose=None):
 
     .. versionadded:: 0.9.0
     """  # noqa: E501
+    from scipy.stats import chi2
+
     _check_reference(evoked, inv["info"]["ch_names"])
     _check_ch_names(inv, evoked.info)
     inv = prepare_inverse_operator(inv, evoked.nave, 1.0 / 9.0, "MNE", copy="non-src")

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -7,7 +7,6 @@ import os.path as op
 import warnings
 
 import numpy as np
-from scipy import sparse
 
 from .fixes import _get_img_fdata, _reshape_view
 from .morph_map import read_morph_map
@@ -607,6 +606,7 @@ class SourceMorph:
 
     def _morph_vols(self, vols, mesg, subselect=True):
         from dipy.align.reslice import reslice
+        from scipy import sparse
 
         interp = self.src_data["interpolator"].tocsc()[
             :, np.concatenate(self._vol_vertices_from)
@@ -1179,6 +1179,8 @@ def _compute_morph_matrix(
     xhemi=False,
 ):
     """Compute morph matrix."""
+    from scipy import sparse
+
     logger.info("Computing morph matrix...")
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
@@ -1221,6 +1223,8 @@ def _compute_morph_matrix(
 
 
 def _hemi_morph(tris, vertices_to, vertices_from, smooth, maps, warn):
+    from scipy import sparse
+
     _validate_type(smooth, (str, None, "int-like"), "smoothing steps")
     if len(vertices_from) == 0:
         return sparse.csr_array((len(vertices_to), 0))
@@ -1334,6 +1338,8 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=None, verbose=No
 @_custom_lru_cache(20)
 def _surf_nearest(vertices, adj_mat):
     # Vertices can be out of order, so sort them to start ...
+    from scipy import sparse
+
     order = np.argsort(vertices)
     vertices = vertices[order]
     # work around https://github.com/scipy/scipy/issues/20904
@@ -1371,6 +1377,8 @@ def _csr_row_norm(data, row_norm):
 def _surf_upsampling_mat(idx_from, e, smooth):
     """Upsample data on a subject's surface given mesh edges."""
     # we're in CSR format and it's to==from
+    from scipy import sparse
+
     assert isinstance(e, sparse.csr_array)
     n_tot = e.shape[0]
     assert e.shape == (n_tot, n_tot)

--- a/mne/morph_map.py
+++ b/mne/morph_map.py
@@ -8,7 +8,6 @@
 import os
 
 import numpy as np
-from scipy.sparse import csr_array, eye_array
 
 from ._fiff.constants import FIFF
 from ._fiff.open import fiff_open
@@ -204,6 +203,8 @@ def _make_morph_map(subject_from, subject_to, subjects_dir, xhemi):
 
 def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from, reg_to):
     """Construct morph map for one hemisphere."""
+    from scipy.sparse import csr_array, eye_array
+
     from ._surface_numba import _find_nearest_tri_pts
 
     # add speedy short-circuit for self-maps

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -12,7 +12,6 @@
 
 import numpy as np
 from scipy.optimize import minimize_scalar
-from scipy.stats import gaussian_kde
 
 from .._fiff.constants import FIFF
 from .._fiff.pick import pick_types
@@ -261,6 +260,8 @@ def compute_bridged_electrodes(
     ----------
     .. footbibliography::
     """
+    from scipy.stats import gaussian_kde
+
     _check_preload(inst, "Computing bridged electrodes")
     inst = inst.copy()  # don't modify original
     picks = pick_types(inst.info, eeg=True)

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -4,9 +4,7 @@
 
 
 import numpy as np
-from scipy.ndimage import distance_transform_edt, label
 from scipy.signal import find_peaks
-from scipy.stats import zscore
 
 from ..annotations import (
     Annotations,
@@ -89,6 +87,9 @@ def annotate_muscle_zscore(
     ----------
     .. footbibliography::
     """
+    from scipy.ndimage import label
+    from scipy.stats import zscore
+
     raw_copy = raw.copy()
 
     if ch_type is None:
@@ -406,6 +407,8 @@ def _raw_hp_weights(raw, pos):
 
 def _annotations_from_mask(times, mask, annot_name, orig_time=None):
     """Construct annotations from boolean mask of the data."""
+    from scipy.ndimage import distance_transform_edt
+
     mask_tf = distance_transform_edt(mask)
     # Overcome the shortcoming of find_peaks
     # in finding a marginal peak, by

--- a/mne/preprocessing/bads.py
+++ b/mne/preprocessing/bads.py
@@ -3,7 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy.stats import zscore
 
 
 def _find_outliers(X, threshold=3.0, max_iter=2, tail=0):
@@ -30,6 +29,8 @@ def _find_outliers(X, threshold=3.0, max_iter=2, tail=0):
     bad_idx : np.ndarray of int, shape (n_features)
         The outlier indices.
     """
+    from scipy.stats import zscore
+
     my_mask = np.zeros(len(X), dtype=bool)
     for _ in range(max_iter):
         X = np.ma.masked_array(X, my_mask)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -16,8 +16,6 @@ from time import time
 from typing import Literal
 
 import numpy as np
-from scipy import stats
-from scipy.spatial import distance
 from scipy.special import expit
 
 from .._fiff.constants import FIFF
@@ -133,6 +131,9 @@ def get_score_funcs():
     score_funcs : dict
         The score functions.
     """
+    from scipy import stats
+    from scipy.spatial import distance
+
     score_funcs = Bunch()
     xy_arg_dist_funcs = [
         (n, f)
@@ -1990,6 +1991,8 @@ class ICA(ContainsMixin):
         -----
         .. versionadded:: 1.1
         """
+        from scipy.spatial import distance
+
         _validate_type(threshold, "numeric", "threshold")
 
         slope_score, focus_score, smoothness_score = None, None, None

--- a/mne/preprocessing/ieeg/_projection.py
+++ b/mne/preprocessing/ieeg/_projection.py
@@ -5,7 +5,6 @@
 from itertools import combinations
 
 import numpy as np
-from scipy.spatial.distance import pdist, squareform
 
 from ..._fiff.pick import _picks_to_idx
 from ...channels import make_dig_montage
@@ -65,6 +64,8 @@ def project_sensors_onto_brain(
     :ref:`mne watershed_bem` using the T1 or :ref:`mne flash_bem`
     using a FLASH scan.
     """
+    from scipy.spatial.distance import pdist, squareform
+
     n_neighbors = _ensure_int(n_neighbors, "n_neighbors")
     _validate_type(copy, bool, "copy")
     if copy:

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -6,7 +6,6 @@ import math
 
 import numpy as np
 from scipy.special import expit
-from scipy.stats import kurtosis
 
 from ..utils import check_random_state, logger, random_permutation, verbose
 
@@ -116,6 +115,8 @@ def infomax(
            analysis using an extended infomax algorithm for mixed subgaussian
            and supergaussian sources. Neural Computation, 11(2), 417-441, 1999.
     """
+    from scipy.stats import kurtosis
+
     rng = check_random_state(random_state)
 
     # define some default parameters

--- a/mne/preprocessing/interpolate.py
+++ b/mne/preprocessing/interpolate.py
@@ -7,7 +7,6 @@
 from itertools import chain
 
 import numpy as np
-from scipy.sparse.csgraph import connected_components
 
 from .._fiff.meas_info import create_info
 from ..epochs import BaseEpochs, EpochsArray
@@ -108,6 +107,8 @@ def interpolate_bridged_electrodes(inst, bridged_idx, bad_limit=4):
     --------
     mne.preprocessing.compute_bridged_electrodes
     """
+    from scipy.sparse.csgraph import connected_components
+
     _validate_type(inst, (BaseRaw, BaseEpochs, Evoked))
     bad_limit = _ensure_int(bad_limit, "bad_limit")
     if bad_limit <= 0:

--- a/mne/preprocessing/realign.py
+++ b/mne/preprocessing/realign.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 from numpy.polynomial.polynomial import Polynomial
-from scipy.stats import pearsonr
 
 from ..io import BaseRaw
 from ..utils import _validate_type, logger, verbose, warn
@@ -53,6 +52,8 @@ def realign_raw(raw, other, t_raw, t_other, *, verbose=None):
 
     .. versionadded:: 0.22
     """
+    from scipy.stats import pearsonr
+
     _validate_type(raw, BaseRaw, "raw")
     _validate_type(other, BaseRaw, "other")
     t_raw = np.array(t_raw, float)

--- a/mne/simulation/metrics/metrics.py
+++ b/mne/simulation/metrics/metrics.py
@@ -5,7 +5,6 @@
 from functools import partial
 
 import numpy as np
-from scipy.spatial.distance import cdist
 
 from ...utils import _check_option, _validate_type, fill_doc
 
@@ -193,6 +192,8 @@ def _abs_col_sum(x):
 
 def _dle(p, q, src, stc):
     """Aux function to compute dipole localization error."""
+    from scipy.spatial.distance import cdist
+
     p = _abs_col_sum(p)
     q = _abs_col_sum(q)
     idx1 = np.nonzero(p)[0]

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -8,8 +8,6 @@ import os.path as op
 from types import GeneratorType
 
 import numpy as np
-from scipy import sparse
-from scipy.spatial.distance import cdist, pdist
 
 from ._fiff.constants import FIFF
 from ._fiff.meas_info import Info
@@ -3185,6 +3183,8 @@ def spatio_temporal_tris_adjacency(tris, n_times, remap_vertices=False, verbose=
         vertices are time 1, the nodes from 2 to 2N are the vertices
         during time 2, etc.
     """
+    from scipy import sparse
+
     if remap_vertices:
         logger.info("Reassigning vertex indices.")
         tris = np.searchsorted(np.unique(tris), tris)
@@ -3334,6 +3334,9 @@ def spatial_inter_hemi_adjacency(src, dist, verbose=None):
         existing intra-hemispheric adjacency matrix, e.g. computed
         using geodesic distances.
     """
+    from scipy import sparse
+    from scipy.spatial.distance import cdist
+
     src = _ensure_src(src, kind="surface")
     adj = cdist(src[0]["rr"][src[0]["vertno"]], src[1]["rr"][src[1]["vertno"]])
     adj = sparse.csr_array(adj <= dist, dtype=int)
@@ -3347,6 +3350,8 @@ def spatial_inter_hemi_adjacency(src, dist, verbose=None):
 @verbose
 def _get_adjacency_from_edges(edges, n_times, verbose=None):
     """Given edges sparse matrix, create adjacency matrix."""
+    from scipy import sparse
+
     n_vertices = edges.shape[0]
     logger.info("-- number of adjacent vertices : %d", n_vertices)
     nnz = edges.col.size
@@ -3436,6 +3441,8 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
     # of vol src space.
     # If stc=None (i.e. no activation time courses provided) and mode='mean',
     # only computes vertex indices and label_flip will be list of None.
+    from scipy import sparse
+
     from .label import BiHemiLabel, Label, label_sign_flip
 
     # if source estimate provided in stc, get vertices from source space and
@@ -3666,6 +3673,8 @@ def _gen_extract_label_time_course(
     verbose=None,
 ):
     # loop through source estimates and extract time series
+    from scipy import sparse
+
     if src is None and mode in ["mean", "max"]:
         kind = "surface"
     else:
@@ -3924,6 +3933,8 @@ def stc_near_sensors(
 
     .. versionadded:: 0.22
     """
+    from scipy.spatial.distance import cdist, pdist
+
     from .evoked import Evoked
 
     _validate_type(evoked, Evoked, "evoked")

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -11,9 +11,6 @@ from copy import deepcopy
 from functools import partial
 
 import numpy as np
-from scipy.sparse import csr_array, triu
-from scipy.sparse.csgraph import dijkstra
-from scipy.spatial.distance import cdist
 
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info, create_info
@@ -1338,6 +1335,8 @@ def _write_source_spaces(fid, src):
 
 def _write_one_source_space(fid, this, verbose=None):
     """Write one source space."""
+    from scipy.sparse import csr_array, triu
+
     if this["type"] == "surf":
         src_type = FIFF.FIFFV_MNE_SPACE_SURFACE
     elif this["type"] == "vol":
@@ -2354,6 +2353,8 @@ def _src_vol_dims(s):
 def _add_interpolator(sp):
     """Compute a sparse matrix to interpolate the data into an MRI volume."""
     # extract transformation information from mri
+    from scipy.sparse import csr_array
+
     mri_width, mri_height, mri_depth, nvox = _src_vol_dims(sp[0])
 
     #
@@ -2416,6 +2417,8 @@ def _add_interpolator(sp):
 
 def _grid_interp(from_shape, to_shape, trans, order=1, inuse=None):
     """Compute a grid-to-grid linear or nearest interpolation given."""
+    from scipy.sparse import csr_array
+
     from_shape = np.array(from_shape, int)
     to_shape = np.array(to_shape, int)
     trans = np.array(trans, np.float64)  # to -> from
@@ -2731,6 +2734,9 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=None, *, verbose=N
     the source space to disk, as the computed distances will automatically be
     stored along with the source space data for future use.
     """
+    from scipy.sparse import csr_array
+    from scipy.sparse.csgraph import dijkstra
+
     src = _ensure_src(src)
     dist_limit = float(dist_limit)
     if dist_limit < 0:
@@ -2800,6 +2806,8 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=None, *, verbose=N
 
 def _do_src_distances(con, vertno, run_inds, limit):
     """Compute source space distances in chunks."""
+    from scipy.sparse.csgraph import dijkstra
+
     func = partial(dijkstra, limit=limit)
     chunk_size = 20  # save memory by chunking (only a little slower)
     lims = np.r_[np.arange(0, len(run_inds), chunk_size), len(run_inds)]
@@ -3118,6 +3126,7 @@ def _compare_source_spaces(src0, src1, mode="exact", nearest=True, dist_tol=1.5e
         assert_array_less,
         assert_equal,
     )
+    from scipy.spatial.distance import cdist
 
     if mode != "exact" and "approx" not in mode:  # 'nointerp' can be appended
         raise RuntimeError(f"unknown mode {mode}")
@@ -3272,6 +3281,8 @@ def compute_distance_to_sensors(src, info, picks=None, trans=None, verbose=None)
         The Euclidean distances of source space vertices with respect to
         sensors.
     """
+    from scipy.spatial.distance import cdist
+
     assert isinstance(src, SourceSpaces)
     _validate_type(info, (Info,), "info")
 

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -3,7 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy import sparse
 
 from ..utils import _check_option, _validate_type
 from ..utils.check import int_like
@@ -57,6 +56,8 @@ def combine_adjacency(*structure):
     <COOrdinate sparse array of dtype 'float64'
             with 27076 stored elements and shape (5600, 5600)>
     """
+    from scipy import sparse
+
     structure = list(structure)
     for di, dim in enumerate(structure):
         name = f"structure[{di}]"

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -5,10 +5,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy import ndimage, sparse
-from scipy.sparse.csgraph import connected_components
-from scipy.stats import f as fstat
-from scipy.stats import t as tstat
 
 from ..fixes import _reshape_view
 from ..parallel import parallel_func
@@ -36,6 +32,9 @@ def _get_labels_st(x_in, adjacency, max_step):
     of active points rather than with the full ``n_times * n_src`` extent
     of ``x_in`` -- important since this is called on every permutation.
     """
+    from scipy import sparse
+    from scipy.sparse.csgraph import connected_components
+
     n_src = adjacency.shape[0]
     n_total = len(x_in)
     active = np.where(x_in)[0]
@@ -114,6 +113,9 @@ def _get_labels(x_in, adjacency):
     Same idea as :func:`_get_labels_st`, but for a plain (non spatio-temporal)
     sparse adjacency matrix that already spans all of ``x_in``.
     """
+    from scipy import sparse
+    from scipy.sparse.csgraph import connected_components
+
     active = np.where(x_in)[0]
     if len(active) == 0:
         return active, None
@@ -224,6 +226,8 @@ def _find_clusters(
     sums : array
         Sum of x values in clusters.
     """
+    from scipy import ndimage
+
     _check_option("tail", tail, [-1, 0, 1])
 
     x = np.asanyarray(x)
@@ -375,6 +379,8 @@ def _find_clusters_1dir(
     x, x_in, adjacency, max_step, t_power, ndimage, sums_only=False
 ):
     """Actually call the clustering algorithm."""
+    from scipy import sparse
+
     if adjacency is None:
         labels, n_labels = ndimage.label(x_in)
 
@@ -485,6 +491,8 @@ def _pval_from_histogram(T, H0, tail):
 
 
 def _setup_adjacency(adjacency, n_tests, n_times):
+    from scipy import sparse
+
     if not sparse.issparse(adjacency):
         raise ValueError(
             "If adjacency matrix is given, it must be a SciPy sparse matrix."
@@ -1059,6 +1067,9 @@ def _permutation_cluster_test(
 
 def _check_fun(X, stat_fun, threshold, tail=0, kind="within"):
     """Check the stat_fun and threshold values."""
+    from scipy.stats import f as fstat
+    from scipy.stats import t as tstat
+
     if kind == "within":
         if threshold is None:
             if stat_fun is not None and stat_fun is not ttest_1samp_no_p:

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -6,8 +6,6 @@ from functools import reduce
 from string import ascii_uppercase
 
 import numpy as np
-from scipy import stats
-from scipy.signal import detrend
 
 from ..utils import _check_option
 
@@ -262,6 +260,8 @@ def _get_contrast_indices(effect_idx, n_factors):  # noqa: D401
 
 def _iter_contrasts(n_subjects, factor_levels, effect_picks):
     """Set up contrasts."""
+    from scipy.signal import detrend
+
     sc = []
     n_factors = len(factor_levels)
     # prepare computation of Kronecker products
@@ -321,6 +321,8 @@ def f_threshold_mway_rm(n_subjects, factor_levels, effects="A*B", pvalue=0.05):
     -----
     .. versionadded:: 0.10
     """
+    from scipy import stats
+
     effect_picks, _ = _map_effects(len(factor_levels), effects)
 
     F_threshold = []
@@ -386,6 +388,8 @@ def f_mway_rm(data, factor_levels, effects="all", correction=False, return_pvals
     -----
     .. versionadded:: 0.10
     """
+    from scipy import stats
+
     out_reshape = (-1,)
     if data.ndim == 2:  # general purpose support, e.g. behavioural data
         data = data[:, :, np.newaxis]
@@ -438,6 +442,8 @@ def f_mway_rm(data, factor_levels, effects="all", correction=False, return_pvals
 
 def _parametric_ci(arr, ci=0.95):
     """Calculate the `ci`% parametric confidence interval for `arr`."""
+    from scipy import stats
+
     mean = arr.mean(0)
     if len(arr) < 2:  # can't compute standard error
         sigma = np.full_like(mean, np.nan)

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from inspect import isgenerator
 
 import numpy as np
-from scipy import linalg, sparse, stats
+from scipy import linalg
 
 from .._fiff.pick import _picks_to_idx, pick_info, pick_types
 from ..epochs import BaseEpochs
@@ -103,6 +103,8 @@ def linear_regression(inst, design_matrix, names=None):
 
 def _fit_lm(data, design_matrix, names):
     """Aux function."""
+    from scipy import stats
+
     n_samples = len(data)
     n_features = np.prod(data.shape[1:])
     if design_matrix.ndim != 2:
@@ -344,6 +346,8 @@ def _prepare_rerp_preds(
     n_samples, sfreq, events, event_id=None, tmin=-0.1, tmax=1, covariates=None
 ):
     """Build predictor matrix and metadata (e.g. condition time windows)."""
+    from scipy import sparse
+
     conds = list(event_id)
     if covariates is not None:
         conds += list(covariates)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -15,10 +15,6 @@ from os import path as op
 from pathlib import Path
 
 import numpy as np
-from scipy.ndimage import binary_dilation
-from scipy.sparse import coo_array, csr_array
-from scipy.spatial import ConvexHull, Delaunay
-from scipy.spatial.distance import cdist
 
 from ._fiff.constants import FIFF
 from ._fiff.pick import pick_types
@@ -194,6 +190,8 @@ def get_meg_helmet_surf(info, trans=None, *, upsampling=1, verbose=None):
     A built-in helmet is loaded if possible. If not, a helmet surface
     will be approximated based on the sensor locations.
     """
+    from scipy.spatial import ConvexHull, Delaunay
+
     from .bem import _fit_sphere, read_bem_surfaces
     from .channels.channels import _get_meg_system
 
@@ -376,6 +374,8 @@ def _triangle_neighbors(tris, npts):
     # for ti, tri in enumerate(tris):
     #     for t in tri:
     #         neighbor_tri[t].append(ti)
+    from scipy.sparse import coo_array
+
     rows = tris.ravel()
     cols = np.repeat(np.arange(len(tris)), 3)
     data = np.ones(len(cols))
@@ -553,6 +553,8 @@ class _CDist:
         self._xhs = xhs
 
     def query(self, rr):
+        from scipy.spatial.distance import cdist
+
         nearest = list()
         dists = list()
         for r in rr:
@@ -708,6 +710,8 @@ class _CheckInside:
         )
 
     def _init_old(self):
+        from scipy.spatial import Delaunay
+
         self.inner_r = None
         self.center = self.surf["rr"].mean(0)
         # We could use Delaunay or ConvexHull here, Delaunay is slightly slower
@@ -1604,6 +1608,8 @@ def mesh_edges(tris):
 
 @lru_cache(maxsize=10)
 def _mesh_edges(tris=None):
+    from scipy.sparse import coo_array
+
     if np.max(tris) > len(np.unique(tris)):
         raise ValueError("Cannot compute adjacency on a selection of triangles.")
 
@@ -1637,6 +1643,8 @@ def mesh_dist(tris, vert):
     dist_matrix : scipy.sparse.csr_array
         Sparse matrix with distances between adjacent vertices.
     """
+    from scipy.sparse import csr_array
+
     edges = mesh_edges(tris).tocoo()
 
     # Euclidean distances between neighboring vertices
@@ -1830,6 +1838,7 @@ def _marching_cubes(image, level, smooth=0, fill_hole_size=None, use_flying_edge
     # Also vtkDiscreteFlyingEdges3D should be faster.
     # If we ever want not-discrete (continuous/float) marching cubes,
     # we should probably use vtkFlyingEdges3D rather than vtkMarchingCubes.
+    from scipy.ndimage import binary_dilation
     from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
     from vtkmodules.vtkCommonDataModel import vtkDataSetAttributes, vtkImageData
     from vtkmodules.vtkFiltersCore import vtkThreshold

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -24,7 +24,6 @@ from mne.coreg import (
     _is_mri_subject,
     coregister_fiducials,
     create_default_subject,
-    fit_matched_points,
     get_mni_fiducials,
     scale_bem,
     scale_labels,
@@ -38,6 +37,7 @@ from mne.transforms import (
     Transform,
     _angle_between_quats,
     apply_trans,
+    fit_matched_points,
     invert_transform,
     read_trans,
     rot_to_quat,
@@ -358,6 +358,8 @@ def test_scale_mri_xfm(tmp_path, few_surfaces, subjects_dir_tmp_few):
 
 def test_fit_matched_points():
     """Test fit_matched_points: fitting two matching sets of points."""
+    # still reachable from its historical home
+    assert mne.coreg.fit_matched_points is fit_matched_points
     tgt_pts = np.random.default_rng(42).uniform(size=(6, 3))
 
     # rotation only

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -181,6 +181,29 @@ def test_import_nesting_hierarchy():
             "from . import bst_raw, bst_resting, bst_auditory, bst_phantom_ctf, bst_phantom_elekta",  # noqa: E501
             "non-explicit relative import",
         ),
+        # nested on purpose: mne.time_frequency.tfr imports mne.viz.topomap at module
+        # level (for @copy_function_doc_to_method_doc), so the core containers only
+        # touch it when a TFR is actually requested
+        (
+            "mne/evoked.py",
+            "        from .time_frequency.tfr import AverageTFR",
+            "hierarchy: must not nest time_frequency",
+        ),
+        (
+            "mne/epochs.py",
+            "        from .time_frequency.tfr import AverageTFR, EpochsTFR",
+            "hierarchy: must not nest time_frequency",
+        ),
+        (
+            "mne/epochs.py",
+            "    from .time_frequency.tfr import EpochsTFR",
+            "hierarchy: must not nest time_frequency",
+        ),
+        (
+            "mne/io/base.py",
+            "        from ..time_frequency.tfr import RawTFR",
+            "hierarchy: must not nest time_frequency",
+        ),
         (
             "mne/channels/_standard_montage_utils.py",
             "from . import __file__",
@@ -190,11 +213,6 @@ def test_import_nesting_hierarchy():
             "mne/source_space/__init__.py",
             "from . import _source_space",
             "non-explicit relative import",
-        ),
-        (
-            "mne/time_frequency/spectrum.py",
-            "        from ..viz._mpl_figure import _line_figure, _split_picks_by_type",
-            "hierarchy: must not nest viz",
         ),
     )
     root_dir = Path(mne.__file__).parent.resolve()
@@ -249,6 +267,63 @@ def test_import_nesting_hierarchy():
     # scheme obeys the above order
 
 
+# SciPy submodules that must only ever be imported inside a function. They are
+# expensive relative to what MNE uses them for (a handful of call sites each), and
+# leaving one at module level silently drags it onto the import path of whatever
+# imports that module -- see the level-2 test below.
+NESTED_ONLY = ("scipy.ndimage", "scipy.sparse", "scipy.spatial", "scipy.stats")
+
+
+def test_nested_only_imports():
+    """Test that expensive SciPy submodules are only imported inside functions."""
+    roots = {module.split(".")[0] for module in NESTED_ONLY}
+    leaves = {module.split(".")[1] for module in NESTED_ONLY}
+    root_dir = Path(mne.__file__).parent.resolve()
+    bad = list()
+    for file in sorted(root_dir.rglob("*.py")):
+        if file.parent.name == "tests":
+            continue
+        tree = ast.parse(file.read_text(encoding="utf-8"), filename=file)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Import | ast.ImportFrom):
+                continue
+            if node.col_offset:  # indented, i.e. nested inside a function
+                continue
+            if isinstance(node, ast.Import):
+                names = [
+                    n.name
+                    for n in node.names
+                    if any(
+                        n.name == module or n.name.startswith(f"{module}.")
+                        for module in NESTED_ONLY
+                    )
+                ]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                # catches "scipy.spatial", "scipy.spatial.distance", ...
+                if any(
+                    node.module == module or node.module.startswith(f"{module}.")
+                    for module in NESTED_ONLY
+                ):
+                    names = [node.module]
+                elif node.module in roots:
+                    names = [
+                        f"{node.module}.{n.name}"
+                        for n in node.names
+                        if n.name in leaves
+                    ]
+                else:
+                    names = []
+            else:
+                names = []
+            rel_path = ("mne" / file.relative_to(root_dir)).as_posix()
+            bad.extend(f"{rel_path}:{node.lineno}: {name}" for name in names)
+    n = len(bad)
+    assert not bad, (
+        f"{n} module-level import{_pl(n)} of a nested-only SciPy submodule:\n"
+        + "\n".join(bad)
+    )
+
+
 # These tests ensure that modules are lazily loaded by lazy_loader, using an
 # allowlist: rather than naming the packages that must *not* be imported, we name the
 # ones that may be, and work out what those pull in themselves. Anything else is an
@@ -257,9 +332,27 @@ def test_import_nesting_hierarchy():
 
 eager_import = os.getenv("EAGER_IMPORT", "")
 
-# What plain ``import mne`` may pull in. Every addition here costs every MNE user
-# interpreter-startup time, so weigh it carefully.
+# Level 1: what plain ``import mne`` may pull in. Every addition here costs every
+# MNE user interpreter-startup time, so weigh it carefully.
 LEVEL_1_ALLOWED = ("decorator", "lazy_loader", "numpy", "packaging")
+
+# Level 2: submodules that should import without dragging in the heavy optional
+# machinery -- notably numba and matplotlib, which stay off this list on purpose.
+# SciPy is allowed, but submodule by submodule. Grow both tuples as more of MNE gets
+# cleaned up (mne.io and mne.channels are the obvious next candidates).
+LEVEL_2_TARGETS = (
+    "from mne.transforms import *",
+    "from mne import Epochs",
+    "from mne.io import BaseRaw",
+    "from mne.channels import DigMontage",
+)
+LEVEL_2_ALLOWED = LEVEL_1_ALLOWED + (
+    "scipy.constants",
+    "scipy.linalg",
+    "scipy.sparse",
+    "scipy.spatial",
+    "scipy.special",
+)
 
 # Report scipy per-submodule and everything else per top-level package
 _SPLIT_PACKAGES = ("scipy",)
@@ -311,6 +404,12 @@ def _check_imports(targets, allowed, level):
 def test_lazy_loading():
     """Test that ``import mne`` pulls in nothing beyond its allowed dependencies."""
     _check_imports(("import mne",), LEVEL_1_ALLOWED, 1)
+
+
+@pytest.mark.skipif(bool(eager_import), reason=f"EAGER_IMPORT={eager_import}")
+def test_lazy_loading_level_2():
+    """Test that cleaned-up submodules stay free of numba, matplotlib, etc."""
+    _check_imports(LEVEL_2_TARGETS, LEVEL_2_ALLOWED, 2)
 
 
 @pytest.mark.skipif(bool(eager_import), reason=f"EAGER_IMPORT={eager_import}")

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -468,13 +468,13 @@ def _check_fit_matched_points(
     p, x, weights, do_scale, angtol=1e-5, dtol=1e-5, stol=1e-7
 ):
     __tracebackhide__ = True
-    mne.coreg._ALLOW_ANALITICAL = False
+    mne.transforms._ALLOW_ANALITICAL = False
     try:
-        params = mne.coreg.fit_matched_points(
+        params = mne.transforms.fit_matched_points(
             p, x, weights=weights, scale=do_scale, out="params"
         )
     finally:
-        mne.coreg._ALLOW_ANALITICAL = True
+        mne.transforms._ALLOW_ANALITICAL = True
     quat_an, scale_an = _fit_matched_points(p, x, weights, scale=do_scale)
     assert len(params) == 6 + int(do_scale)
     q_co = _euler_to_quat(params[:3])
@@ -491,7 +491,7 @@ def _check_fit_matched_points(
     trans[:3, :3] *= scale_an
     weights = np.ones(1) if weights is None else weights
     err_an = np.linalg.norm(weights[:, np.newaxis] * apply_trans(trans, p) - x)
-    trans = mne.coreg._trans_from_params((True, True, do_scale), params)
+    trans = mne.transforms._trans_from_params((True, True, do_scale), params)
     err_co = np.linalg.norm(weights[:, np.newaxis] * apply_trans(trans, p) - x)
     if err_an > 1e-14:
         assert err_an < err_co * 1.5

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -5,10 +5,6 @@
 # Parts of this code were copied from NiTime http://nipy.sourceforge.net/nitime
 
 import numpy as np
-from scipy.fft import rfft, rfftfreq
-from scipy.integrate import trapezoid
-from scipy.signal import get_window
-from scipy.signal.windows import dpss as sp_dpss
 
 from ..fixes import _reshape_view
 from ..parallel import parallel_func
@@ -66,6 +62,8 @@ def dpss_windows(N, half_nbw, Kmax, *, sym=True, norm=None, low_bias=True):
     """
     # TODO VERSION can be removed with SciPy 1.16 is min,
     # workaround for https://github.com/scipy/scipy/pull/22344
+    from scipy.signal.windows import dpss as sp_dpss
+
     if N <= 1:
         dpss, eigvals = np.ones((1, 1)), np.ones(1)
     else:
@@ -113,6 +111,8 @@ def _psd_from_mt_adaptive(x_mt, eigvals, freq_mask, max_iter=250, return_weights
     The weights to use for making the multitaper estimate, such that
     :math:`S_{mt} = \sum_{k} |w_k|^2S_k^{mt} / \sum_{k} |w_k|^2`
     """
+    from scipy.integrate import trapezoid
+
     n_signals, n_tapers, n_freqs = x_mt.shape
 
     if len(eigvals) != n_tapers:
@@ -264,6 +264,8 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None, remove_dc=True):
     freqs : array, shape=(n_freqs,)
         The frequency points in Hz of the spectra
     """
+    from scipy.fft import rfft, rfftfreq
+
     if n_fft is None:
         n_fft = x.shape[-1]
 
@@ -291,6 +293,8 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None, remove_dc=True):
 def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive, verbose=None):
     """Triage windowing and multitaper parameters."""
     # Compute standardized half-bandwidth
+    from scipy.signal import get_window
+
     if isinstance(bandwidth, str):
         logger.info(f'    Using standard spectrum estimation with "{bandwidth}" window')
         window_fun = get_window(bandwidth, n_times)[np.newaxis]
@@ -404,6 +408,8 @@ def psd_array_multitaper(
     ----------
     .. footbibliography::
     """
+    from scipy.fft import rfftfreq
+
     _check_option("normalization", normalization, ["length", "full"])
 
     # Reshape data so its 2-D for parallelization

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -6,7 +6,6 @@ import warnings
 from functools import partial
 
 import numpy as np
-from scipy.signal import spectrogram
 
 from ..fixes import _reshape_view
 from ..parallel import parallel_func
@@ -174,6 +173,8 @@ def psd_array_welch(
     ----------
     .. footbibliography::
     """
+    from scipy.signal import spectrogram
+
     _check_option("average", average, (None, False, "mean", "median"))
     _check_option("output", output, ("power", "complex"))
     detrend = "constant" if remove_dc else False

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -12,8 +12,6 @@ from copy import deepcopy
 from functools import partial
 
 import numpy as np
-from scipy.fft import fft, ifft
-from scipy.signal import argrelmax
 
 from .._fiff.meas_info import ContainsMixin, Info
 from .._fiff.pick import _picks_to_idx, pick_info
@@ -350,6 +348,8 @@ def _cwt_gen(X, Ws, *, fsize=0, mode="same", decim=1, use_fft=True):
     out : array, shape (n_signals, n_freqs, n_time_decim)
         The time-frequency transform of the signals.
     """
+    from scipy.fft import fft, ifft
+
     _check_option("mode", mode, ["same", "valid", "full"])
     decim = _ensure_slice(decim)
     X = np.asarray(X)
@@ -4205,6 +4205,8 @@ def _read_multiple_tfrs(tfr_data, condition=None, *, verbose=None):
 def _get_timefreqs(tfr, timefreqs):
     """Find and/or setup timefreqs for `tfr.plot_joint`."""
     # Input check
+    from scipy.signal import argrelmax
+
     timefreq_error_msg = (
         "Supplied `timefreqs` are somehow malformed. Please supply None, "
         "a list of tuple pairs, or a dict of such tuple pairs, not {}"

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import numpy as np
 from scipy import linalg
-from scipy.spatial.distance import cdist
 
 from ._fiff.constants import FIFF
 from ._fiff.open import fiff_open
@@ -1000,6 +999,8 @@ class _TPSWarp:
     """
 
     def fit(self, source, destination, reg=1e-3):
+        from scipy.spatial.distance import cdist
+
         assert source.shape[1] == destination.shape[1] == 3
         assert source.shape[0] == destination.shape[0]
         # Forward warping, different from image warping, use |dist|**2
@@ -1030,6 +1031,8 @@ class _TPSWarp:
         dest : shape (n_transform, 3)
             The transformed points.
         """
+        from scipy.spatial.distance import cdist
+
         logger.info(f"Transforming {len(pts)} points")
         assert pts.shape[1] == 3
         # for memory reasons, we should do this in ~100 MB chunks

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -7,6 +7,7 @@
 import glob
 import os
 from copy import deepcopy
+from functools import reduce
 from pathlib import Path
 
 import numpy as np
@@ -2061,6 +2062,218 @@ class _MatchedDisplacementFieldInterpolator:
         self._last_deltas = np.linalg.norm(x - out, axis=1)
         out = out[0] if singleton else out
         return out
+
+
+def _trans_from_params(param_info, params):
+    """Convert transformation parameters into a transformation matrix."""
+    do_rotate, do_translate, do_scale = param_info
+    i = 0
+    trans = []
+
+    if do_rotate:
+        x, y, z = params[:3]
+        trans.append(rotation(x, y, z))
+        i += 3
+
+    if do_translate:
+        x, y, z = params[i : i + 3]
+        trans.insert(0, translation(x, y, z))
+        i += 3
+
+    if do_scale == 1:
+        s = params[i]
+        trans.append(scaling(s, s, s))
+    elif do_scale == 3:
+        x, y, z = params[i : i + 3]
+        trans.append(scaling(x, y, z))
+
+    trans = reduce(np.dot, trans)
+    return trans
+
+
+_ALLOW_ANALITICAL = True
+
+
+def fit_matched_points(
+    src_pts,
+    tgt_pts,
+    rotate=True,
+    translate=True,
+    scale=False,
+    tol=None,
+    x0=None,
+    out="trans",
+    weights=None,
+):
+    """Find a transform between matched sets of points.
+
+    This minimizes the squared distance between two matching sets of points.
+
+    Uses :func:`scipy.optimize.leastsq` to find a transformation involving
+    a combination of rotation, translation, and scaling (in that order).
+
+    Parameters
+    ----------
+    src_pts : array, shape = (n, 3)
+        Points to which the transform should be applied.
+    tgt_pts : array, shape = (n, 3)
+        Points to which src_pts should be fitted. Each point in tgt_pts should
+        correspond to the point in src_pts with the same index.
+    rotate : bool
+        Allow rotation of the ``src_pts``.
+    translate : bool
+        Allow translation of the ``src_pts``.
+    scale : bool
+        Number of scaling parameters. With False, points are not scaled. With
+        True, points are scaled by the same factor along all axes.
+    tol : scalar | None
+        The error tolerance. If the distance between any of the matched points
+        exceeds this value in the solution, a RuntimeError is raised. With
+        None, no error check is performed.
+    x0 : None | tuple
+        Initial values for the fit parameters.
+    out : 'params' | 'trans'
+        In what format to return the estimate: 'params' returns a tuple with
+        the fit parameters; 'trans' returns a transformation matrix of shape
+        (4, 4).
+
+    Returns
+    -------
+    trans : array, shape (4, 4)
+        Transformation that, if applied to src_pts, minimizes the squared
+        distance to tgt_pts. Only returned if out=='trans'.
+    params : array, shape (n_params, )
+        A single tuple containing the rotation, translation, and scaling
+        parameters in that order (as applicable).
+    """
+    src_pts = np.atleast_2d(src_pts)
+    tgt_pts = np.atleast_2d(tgt_pts)
+    if src_pts.shape != tgt_pts.shape:
+        raise ValueError(
+            "src_pts and tgt_pts must have same shape "
+            f"(got {src_pts.shape}, {tgt_pts.shape})"
+        )
+    if weights is not None:
+        weights = np.asarray(weights, src_pts.dtype)
+        if weights.ndim != 1 or weights.size not in (src_pts.shape[0], 1):
+            raise ValueError(
+                f"weights (shape={weights.shape}) must be None or have shape "
+                f"({src_pts.shape[0]},)"
+            )
+        weights = weights[:, np.newaxis]
+
+    param_info = (bool(rotate), bool(translate), int(scale))
+    del rotate, translate, scale
+
+    # very common use case, rigid transformation (maybe with one scale factor,
+    # with or without weighted errors)
+    if param_info in ((True, True, 0), (True, True, 1)) and _ALLOW_ANALITICAL:
+        src_pts = np.asarray(src_pts, float)
+        tgt_pts = np.asarray(tgt_pts, float)
+        if weights is not None:
+            weights = np.asarray(weights, float)
+        from ._transforms_numba import _fit_matched_points
+
+        x, s = _fit_matched_points(src_pts, tgt_pts, weights, bool(param_info[2]))
+        x[:3] = _quat_to_euler(x[:3])
+        x = np.concatenate((x, [s])) if param_info[2] else x
+    else:
+        x = _generic_fit(src_pts, tgt_pts, param_info, weights, x0)
+
+    # re-create the final transformation matrix
+    if (tol is not None) or (out == "trans"):
+        trans = _trans_from_params(param_info, x)
+
+    # assess the error of the solution
+    if tol is not None:
+        src_pts = np.hstack((src_pts, np.ones((len(src_pts), 1))))
+        est_pts = np.dot(src_pts, trans.T)[:, :3]
+        err = np.sqrt(np.sum((est_pts - tgt_pts) ** 2, axis=1))
+        if np.any(err > tol):
+            raise RuntimeError(f"Error exceeds tolerance. Error = {err!r}")
+
+    if out == "params":
+        return x
+    elif out == "trans":
+        return trans
+    else:
+        raise ValueError(
+            f"Invalid out parameter: {out!r}. Needs to be 'params' or 'trans'."
+        )
+
+
+def _generic_fit(src_pts, tgt_pts, param_info, weights, x0):
+    from scipy.optimize import leastsq
+
+    if param_info[1]:  # translate
+        src_pts = np.hstack((src_pts, np.ones((len(src_pts), 1))))
+
+    if param_info == (True, False, 0):
+
+        def error(x):
+            rx, ry, rz = x
+            trans = rotation3d(rx, ry, rz)
+            est = np.dot(src_pts, trans.T)
+            d = tgt_pts - est
+            if weights is not None:
+                d *= weights
+            return d.ravel()
+
+        if x0 is None:
+            x0 = (0, 0, 0)
+    elif param_info == (True, True, 0):
+
+        def error(x):
+            rx, ry, rz, tx, ty, tz = x
+            trans = np.dot(translation(tx, ty, tz), rotation(rx, ry, rz))
+            est = np.dot(src_pts, trans.T)[:, :3]
+            d = tgt_pts - est
+            if weights is not None:
+                d *= weights
+            return d.ravel()
+
+        if x0 is None:
+            x0 = (0, 0, 0, 0, 0, 0)
+    elif param_info == (True, True, 1):
+
+        def error(x):
+            rx, ry, rz, tx, ty, tz, s = x
+            trans = reduce(
+                np.dot,
+                (translation(tx, ty, tz), rotation(rx, ry, rz), scaling(s, s, s)),
+            )
+            est = np.dot(src_pts, trans.T)[:, :3]
+            d = tgt_pts - est
+            if weights is not None:
+                d *= weights
+            return d.ravel()
+
+        if x0 is None:
+            x0 = (0, 0, 0, 0, 0, 0, 1)
+    elif param_info == (True, True, 3):
+
+        def error(x):
+            rx, ry, rz, tx, ty, tz, sx, sy, sz = x
+            trans = reduce(
+                np.dot,
+                (translation(tx, ty, tz), rotation(rx, ry, rz), scaling(sx, sy, sz)),
+            )
+            est = np.dot(src_pts, trans.T)[:, :3]
+            d = tgt_pts - est
+            if weights is not None:
+                d *= weights
+            return d.ravel()
+
+        if x0 is None:
+            x0 = (0, 0, 0, 0, 0, 0, 1, 1, 1)
+    else:
+        raise NotImplementedError(
+            "The specified parameter combination is not implemented: "
+            "rotate={!r}, translate={!r}, scale={!r}".format(*param_info)
+        )
+
+    x, _, _, _, _ = leastsq(error, x0, full_output=True)
+    return x
 
 
 def __getattr__(name):

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -17,7 +17,6 @@ from math import ceil, sqrt
 from pathlib import Path
 
 import numpy as np
-from scipy import sparse
 
 from ..fixes import (
     _infer_dimension_,
@@ -638,6 +637,8 @@ def object_hash(x, h=None):
     digest : int
         The digest resulting from the hash.
     """
+    from scipy import sparse
+
     if h is None:
         h = _empty_hash()
     if hasattr(x, "keys"):
@@ -730,6 +731,8 @@ def object_size(x, memo=None):
 
 
 def _is_sparse_cs(x):
+    from scipy import sparse
+
     return isinstance(
         x, sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array
     )
@@ -775,6 +778,8 @@ def object_diff(a, b, pre="", *, allclose=False):
     diffs : str
         A string representation of the differences.
     """
+    from scipy import sparse
+
     out = ""
     if type(a) is not type(b):
         # Deal with NamedInt and NamedFloat

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -15,9 +15,6 @@ from itertools import cycle
 from pathlib import Path
 
 import numpy as np
-from scipy.spatial import ConvexHull, Delaunay
-from scipy.spatial.distance import cdist
-from scipy.stats import rankdata
 
 from .._fiff._digitization import _fiducial_coords
 from .._fiff.constants import FIFF
@@ -156,6 +153,7 @@ def plot_head_positions(
         The figure.
     """
     import matplotlib.pyplot as plt
+    from scipy.spatial.distance import cdist
 
     from ..chpi import head_pos_to_trans_rot_t
     from ..preprocessing.maxwell import _check_destination
@@ -1742,6 +1740,8 @@ def _make_tris_fan(n_vert):
 
 def _sensor_shape(coil):
     """Get the sensor shape vertices."""
+    from scipy.spatial import ConvexHull, Delaunay
+
     id_ = coil["type"] & 0xFFFF
     # Offset for visibility (using heuristic for sanely named Neuromag coils).
     # It depends on the channel name, so keep it out of the cached template.
@@ -2174,6 +2174,7 @@ def _plot_mpl_stc(
     import nibabel as nib
     from matplotlib.widgets import Slider
     from mpl_toolkits.mplot3d import Axes3D
+    from scipy.stats import rankdata
 
     from ..morph import _get_subject_sphere_tris
     from ..source_space._source_space import _check_spacing, _create_surf_spacing

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -14,8 +14,6 @@ from io import BytesIO
 
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.sparse import csr_array
-from scipy.spatial.distance import cdist
 
 from ..._fiff.meas_info import Info
 from ..._fiff.pick import pick_types
@@ -1214,6 +1212,8 @@ class Brain:
 
     def _configure_picking(self):
         # get data for each hemi
+        from scipy.sparse import csr_array
+
         for idx, hemi in enumerate(["vol", "lh", "rh"]):
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:
@@ -2895,6 +2895,8 @@ class Brain:
         resolution : int
             The resolution of the spheres.
         """
+        from scipy.spatial.distance import cdist
+
         hemi = self._check_hemi(hemi, extras=["vol"])
 
         # Figure out how to interpret the first parameter

--- a/mne/viz/_dipole.py
+++ b/mne/viz/_dipole.py
@@ -7,7 +7,6 @@
 import os.path as op
 
 import numpy as np
-from scipy.spatial import ConvexHull
 
 from .._freesurfer import _estimate_talxfm_rigid, _get_head_surface
 from ..surface import read_surface
@@ -44,6 +43,7 @@ def _plot_dipole_mri_outlines(
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection, PatchCollection
     from matplotlib.patches import Circle
+    from scipy.spatial import ConvexHull
 
     extra = 'when mode is "outlines"'
     trans = _get_trans(trans, fro="head", to="mri")[0]

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -8,7 +8,6 @@ from collections import Counter
 from copy import deepcopy
 
 import numpy as np
-from scipy.ndimage import gaussian_filter1d
 
 from .._fiff.meas_info import create_info
 from .._fiff.pick import (
@@ -202,6 +201,8 @@ def plot_epochs_image(
     |          | list of ch_names           | callable   |                   |
     +----------+----------------------------+------------+-------------------+
     """
+    from scipy.ndimage import gaussian_filter1d
+
     from ..epochs import EpochsArray
 
     _validate_type(group_by, (dict, None), "group_by")

--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 from functools import partial
 
 import numpy as np
-from scipy.interpolate import interp1d
 
 from .._fiff.pick import pick_types
 from ..defaults import DEFAULTS
@@ -252,6 +251,8 @@ class EvokedField:
 
     def _prepare_surf_map(self, surf_map, color, alpha):
         """Compute all the data required to render a fieldlines map."""
+        from scipy.interpolate import interp1d
+
         if surf_map["kind"] == "eeg":
             pick = pick_types(self._evoked.info, meg=False, eeg=True)
         else:

--- a/mne/viz/eyetracking/heatmap.py
+++ b/mne/viz/eyetracking/heatmap.py
@@ -3,7 +3,6 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
-from scipy.ndimage import gaussian_filter
 
 from ..._fiff.constants import FIFF
 from ...utils import _validate_type, fill_doc, logger
@@ -60,6 +59,8 @@ def plot_gaze(
     -----
     .. versionadded:: 1.6
     """
+    from scipy.ndimage import gaussian_filter
+
     from mne import BaseEpochs
     from mne._fiff.pick import _picks_to_idx
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -7,7 +7,6 @@
 import warnings
 
 import numpy as np
-from scipy.stats import gaussian_kde
 
 from .._fiff.meas_info import create_info
 from .._fiff.pick import _picks_to_idx, pick_types
@@ -225,6 +224,7 @@ def _plot_ica_properties(
 ):
     """Plot ICA properties (helper)."""
     from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
+    from scipy.stats import gaussian_kde
 
     topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -15,7 +15,6 @@ from itertools import cycle
 from pathlib import Path
 
 import numpy as np
-from scipy.signal import filtfilt, freqz, group_delay, lfilter, sosfilt, sosfiltfilt
 
 from .._fiff.constants import FIFF
 from .._fiff.pick import (
@@ -1163,6 +1162,7 @@ def plot_filter(
     .. versionadded:: 0.14
     """
     import matplotlib.pyplot as plt
+    from scipy.signal import filtfilt, freqz, group_delay, lfilter, sosfilt, sosfiltfilt
 
     sfreq = float(sfreq)
     _check_option("fscale", fscale, ["log", "linear"])

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -7,7 +7,6 @@
 from copy import deepcopy
 
 import numpy as np
-from scipy.spatial.distance import cdist
 
 from .._fiff._digitization import _get_fid_coords
 from .._fiff.meas_info import create_info
@@ -55,6 +54,7 @@ def plot_montage(
         The figure object.
     """
     import matplotlib.pyplot as plt
+    from scipy.spatial.distance import cdist
 
     from ..channels import DigMontage, make_dig_montage
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -9,7 +9,6 @@ from functools import partial
 from inspect import signature
 
 import numpy as np
-from scipy import ndimage
 
 from .._fiff.pick import _FNIRS_CH_TYPES_SPLIT, _picks_to_idx, channel_type, pick_types
 from ..defaults import _handle_default
@@ -805,6 +804,7 @@ def _erfimage_imshow(
 ):
     """Plot erfimage on sensor topography."""
     import matplotlib.pyplot as plt
+    from scipy import ndimage
 
     this_data = data[:, ch_idx, :]
     if vlim_array is not None:
@@ -861,6 +861,8 @@ def _erfimage_imshow_unified(
     vlim_array=None,
 ):
     """Plot erfimage topography using a single axis."""
+    from scipy import ndimage
+
     _compute_ax_scalings(bn, (tmin, tmax), (0, len(epochs.events)))
     ax = bn.ax
     data_lines = bn.data_lines

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -13,14 +13,6 @@ from numbers import Integral
 import matplotlib.artist
 import matplotlib.patches
 import numpy as np
-from scipy.interpolate import (
-    CloughTocher2DInterpolator,
-    LinearNDInterpolator,
-    NearestNDInterpolator,
-)
-from scipy.sparse import csr_array
-from scipy.spatial import Delaunay, Voronoi
-from scipy.spatial.distance import pdist, squareform
 
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info, _simplify_info
@@ -202,6 +194,8 @@ def _prepare_topomap_plot(inst, ch_type, sphere=None):
 
 def _find_overlaps(info, ch_type, sphere, modality="fnirs"):
     """Find overlapping channels."""
+    from scipy.spatial.distance import pdist, squareform
+
     from ..channels.layout import _find_topomap_coords
 
     if modality == "fnirs":
@@ -844,6 +838,8 @@ def _draw_outlines(ax, outlines):
 
 def _get_extra_points(pos, extrapolate, origin, radii):
     """Get coordinates of additional interpolation points."""
+    from scipy.spatial import Delaunay
+
     radii = np.array(radii, float)
     assert radii.shape == (2,)
     x, y = origin
@@ -981,6 +977,12 @@ class _GridData:
 
     def __init__(self, pos, image_interp, extrapolate, origin, radii, border):
         # in principle this works in N dimensions, not just 2
+        from scipy.interpolate import (
+            CloughTocher2DInterpolator,
+            LinearNDInterpolator,
+            NearestNDInterpolator,
+        )
+
         assert pos.ndim == 2 and pos.shape[1] == 2, pos.shape
         _validate_type(border, ("numeric", str), "border")
 
@@ -1258,6 +1260,8 @@ _VORONOI_CIRCLE_RES = 100
 def _voronoi_topomap(data, pos, outlines, ax, cmap, norm, extent, res):
     """Make a Voronoi diagram on a topomap."""
     # we need an image axis object so first empty image to plot over
+    from scipy.spatial import Voronoi
+
     im = ax.imshow(
         np.zeros((res, res)) * np.nan,
         cmap=cmap,
@@ -4145,6 +4149,7 @@ def plot_ch_adjacency(info, adjacency, ch_names, kind="2d", edit=False):
     """
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+    from scipy.sparse import csr_array
 
     _validate_type(info, Info, "info")
     _validate_type(adjacency, (np.ndarray, csr_array), "adjacency")

--- a/mne/viz/ui_events.py
+++ b/mne/viz/ui_events.py
@@ -19,10 +19,14 @@ import re
 import weakref
 from dataclasses import dataclass
 from functools import partial
-
-from matplotlib.colors import Colormap
+from typing import TYPE_CHECKING
 
 from ..utils import _validate_type, fill_doc, logger, verbose, warn
+
+if TYPE_CHECKING:
+    # matplotlib is ~40 ms to import and this module is on the import path of
+    # mne.viz.utils (see mne/tests/test_import_nesting.py)
+    from matplotlib.colors import Colormap
 
 # Global dict {fig: channel} containing all currently active event channels.
 _event_channels = weakref.WeakKeyDictionary()
@@ -152,7 +156,7 @@ class ColormapRange(UIEvent):
     fmid: float | None = None
     fmax: float | None = None
     alpha: bool | None = None
-    cmap: Colormap | str | None = None
+    cmap: "Colormap | str | None" = None
 
 
 @dataclass

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -18,7 +18,6 @@ from functools import partial
 
 import numpy as np
 from decorator import decorator
-from scipy.signal import argrelmax
 
 from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info
@@ -874,6 +873,8 @@ def _find_peaks(evoked, npeaks):
 
     Returns ``npeaks`` biggest peaks as a list of time points.
     """
+    from scipy.signal import argrelmax
+
     gfp = evoked.data.std(axis=0)
     order = len(evoked.times) // 30
     if order < 1:


### PR DESCRIPTION
Third part of the plan of #14161. Re-nesting `scipy` modules except `linalg`. Also moving `fit_matched_points` to a more natural home. Drafted by Claude Opus 5 and reviewed by me.