### PR TITLE
DOC: Clarify Epochs drop reasons

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3609,13 +3609,14 @@ class Epochs(BaseEpochs):
         A tuple of the same length as the event array used to initialize the
         Epochs object. If the i-th original event is still part of the
         selection, drop_log[i] will be an empty tuple; otherwise it will be
-        a tuple of the reasons the event is not longer in the selection, e.g.:
+        a tuple of the reasons the event is no longer in the selection, e.g.:
 
         - 'IGNORED'
             If it isn't part of the current subset defined by the user
-        - 'NO_DATA' or 'TOO_SHORT'
-            If epoch didn't contain enough data names of channels that exceeded
-            the amplitude threshold
+        - 'NO_DATA'
+            If the epoch would start before the beginning of the recording.
+        - 'TOO_SHORT'
+            If the epoch would end after the end of the recording.
         - 'EQUALIZED_COUNTS'
             See :meth:`~mne.Epochs.equalize_event_counts`
         - 'USER'


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #12683.

#### What does this implement/fix?

Clarifies the Epochs.drop_log documentation by documenting the two recording-boundary rejection reasons separately:

- NO_DATA means that an epoch would start before the beginning of the recording.
- TOO_SHORT means that an epoch would end after the end of the recording.

It also fixes a nearby grammar error.

#### Additional information

Validation: mne/tests/test_docstring_parameters.py completed with 18 tests passing and one unrelated optional-dependency skip. The diff also passes the whitespace check.

AI assistance disclosure: OpenAI Codex was used to inspect the issue and implementation, draft the documentation change, and run the validation checks.