### PR TITLE
DOC: Enable related example recommendations

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -526,6 +526,7 @@ sphinx_gallery_conf = {
         "mne_doc_utils.reset_modules",
     ),  # called w/each script
     "reset_modules_order": "both",
+    "recommender": {"enable": True},
     "image_scrapers": scrapers,
     "show_memory": sys.platform == "linux" and sphinx_gallery_parallel == 1,
     "line_numbers": False,  # messes with style


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #13864.

#### What does this implement/fix?

Enables the built-in Sphinx-Gallery recommender for the MNE-Python tutorials and examples. Sphinx-Gallery will use the text content of each gallery to display related examples at the bottom of generated pages, using its default recommendation settings.

#### Additional information

The configuration was validated with the minimum supported Sphinx-Gallery version, 0.16. Syntax compilation, Ruff, and whitespace checks also pass. NumPy, which the recommender requires, is already a core MNE-Python dependency.

AI assistance disclosure: OpenAI Codex was used to inspect the issue and Sphinx-Gallery compatibility, draft the configuration change, and run the validation checks.