### PR TITLE
DOC: Correct Brain colormap input types

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1936,12 +1936,11 @@ class Brain:
         %(thresh)s
         %(center)s
         %(transparent)s
-        colormap : str, list of color, or array
-            Name of matplotlib colormap to use, a list of matplotlib colors,
-            or a custom look up table (an n x 4 array coded with RBGA values
-            between 0 and 255), the default "auto" chooses a default divergent
-            colormap, if "center" is given (currently "icefire"), otherwise a
-            default sequential colormap (currently "rocket").
+        colormap : str | matplotlib.colors.Colormap
+            Matplotlib colormap name or instance. The default ``"auto"`` chooses
+            a default divergent colormap if ``center`` is given (currently
+            ``"icefire"``), otherwise a default sequential colormap (currently
+            ``"rocket"``).
         alpha : float in [0, 1] | array, shape (n_vertices,)
             Alpha level to control opacity of the overlay. A scalar applies
             globally, while a 1D array applies per-vertex opacity.


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #9974.

#### What does this implement/fix?

Corrects the Brain.add_data() colormap documentation so it matches the implementation. The method accepts a Matplotlib colormap name or Colormap instance; the previously documented list-of-colors and lookup-table inputs are not accepted by the colormap normalization path.

The description of the automatic divergent or sequential colormap choice is retained and reformatted using the current documentation conventions.

#### Additional information

Validation: mne/tests/test_docstring_parameters.py completed with 18 tests passing and one unrelated optional-dependency skip. The diff also passes the whitespace check.

AI assistance disclosure: OpenAI Codex was used to inspect the issue and colormap implementation, draft the documentation correction, and run validation checks.