### PR TITLE
DOC: Explain axial gradiometer channel labels

### DIFF
--- a/doc/_includes/channel_types.rst
+++ b/doc/_includes/channel_types.rst
@@ -22,6 +22,13 @@ types occur in two or more sub-types, the sub-type abbreviations are given in
 parentheses. More information about measurement units is given in the
 :ref:`units` section.
 
+.. note::
+   MNE-Python distinguishes ``mag`` and ``grad`` channels using the measurement
+   unit stored in the data file: teslas for ``mag`` and teslas per meter for
+   ``grad``. Consequently, an axial gradiometer whose data are stored in teslas
+   is reported as ``mag``; the label reflects the data unit rather than the
+   physical sensor geometry.
+
 .. NOTE: To include only the table, here's a different target for :start-after:
    channel-types-begin-table
 


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #9610.

#### What does this implement/fix?

Adds a note to the supported channel-types documentation explaining that MNE-Python distinguishes mag and grad channels by the measurement unit stored in the data file. Therefore, axial gradiometer data stored in teslas are reported as mag even though the physical sensor is a gradiometer.

#### Additional information

Validation: the changed file passes the repository rstcheck and codespell pre-commit hooks and the whitespace check. The documented behavior was also verified directly with channel_type() using an axial-gradiometer coil type whose unit is teslas.

AI assistance disclosure: OpenAI Codex was used to inspect the issue and channel classification implementation, draft the documentation note, and run validation checks.