### PR TITLE
DOC: Show how to document deprecated parameters

### DIFF
--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -549,6 +549,19 @@ like this:
     from mne.utils import warn
 
     def my_other_function(new_param=None, old_param=None):
+        """Do something with a parameter.
+
+        Parameters
+        ----------
+        new_param : int | None
+            The parameter to use.
+        old_param : int | None
+            The parameter that is being replaced.
+
+            .. deprecated:: 0.XX
+               Use ``new_param`` instead. ``old_param`` will be removed in
+               version 0.YY.
+        """
         if old_param is not None:
             depr_message = ('old_param is deprecated and will be replaced by '
                             'new_param in 0.XX.')


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #12272.

#### What does this implement/fix?

Extends the contributor-guide example for parameter deprecation with a numpydoc-style function docstring. The deprecated parameter now demonstrates the Sphinx deprecated directive, identifies its replacement, and states its removal version.

This keeps the runtime warning and documentation aspects of a parameter deprecation together in one example.

#### Additional information

Validation: the changed file passes the repository rstcheck and codespell pre-commit hooks, as well as the whitespace check.

AI assistance disclosure: OpenAI Codex was used to inspect the issue and current deprecation conventions, draft the contributor-guide update, and run validation checks.