### PR TITLE
Fix for parallel callers of data_path

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -136,7 +136,7 @@ def _get_path(path, key, name):
     if not path.is_dir():
         logger.info(f"Creating {path}")
         try:
-            path.mkdir()
+            path.mkdir(exist_ok=True)  # exist_ok for parallel calls
         except OSError:
             raise OSError(
                 "User does not have write permissions "


### PR DESCRIPTION
The failure [here](https://github.com/mne-tools/mne-bids/actions/runs/32171847300/job/95824740590?pr=1642) is from two xdist runners making the same call. I saw it earlier today in mne-connectivity, too. Fix it by allowing the path to have been created between when it wasn't found, and when creation is attempted.