### PR TITLE
Update CSS to allow newlines in docstrings

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -123,8 +123,7 @@ div.versionadded {
     margin-left: 0.5rem;
     display: inline-block;
 }
-/* when FF supports :has(), change to →  dd > p:has(+div.versionadded) */
-dd>p {
+dd>p:has(+div.versionadded) {
     display: inline;
 }
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2750,7 +2750,7 @@ class FilterMixin:
                     ``envelope=False`` and compute the envelope after the
                     inverse solution has been obtained.
 
-        If envelope=False, more memory is required since the original raw data
+        If ``envelope=False``, more memory is required since the original raw data
         as well as the analytic signal have temporarily to be stored in memory.
         If n_jobs > 1, more memory is required as ``len(picks) * n_times``
         additional time points need to be temporarily stored in memory.


### PR DESCRIPTION
Fixes #14176

Current main branch docs missing newlines in docstrings, e.g., `apply_hilbert`:
<img width="897" height="491" alt="image" src="https://github.com/user-attachments/assets/9931ec78-5862-4c86-8032-22261b03d876" />

What the docs from this PR should look like:
<img width="897" height="712" alt="image" src="https://github.com/user-attachments/assets/b10b448c-9b06-43a9-a9da-8b1b757a69a9" />

`versionadded` directives should remain shrunk and inline, e.g., in `Epochs.average`:
<img width="855" height="138" alt="image" src="https://github.com/user-attachments/assets/424c2cb7-d588-4575-9033-2d0f0cb8b460" />
