### PR TITLE
Add title for RawArray

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -16,6 +16,7 @@ from ..utils import (
     _get_stim_channel,
     _validate_type,
     legacy,
+    sizeof_fmt,
     verbose,
 )
 from ..utils.spectrum import _split_psd_kwargs
@@ -137,8 +138,9 @@ def plot_raw(
     show_options : bool
         If True, a dialog for options related to projection is shown.
     title : str | None
-        The title of the window. If None, and either the filename of the
-        raw object or '<unknown>' will be displayed as title.
+        The title of the window. If None, the filename of the raw object is
+        used; for in-memory instances without a filename (e.g.,
+        `~mne.io.RawArray`), the class name and approximate size are used.
     show : bool
         Show figure if True.
     block : bool
@@ -369,16 +371,18 @@ def plot_raw(
     start += first_time
     event_id_rev = {v: k for k, v in (event_id or {}).items()}
 
-    # generate window title; allow instances without a filename (e.g., ICA)
+    # generate window title; allow instances without a filename (e.g., RawArray)
     if title is None:
-        title = "<unknown>"
-        fnames = list(tuple(raw.filenames))  # get a list of a copy of the filenames
+        # in-memory instances (e.g., RawArray) have filenames of (None,)
+        fnames = [fname for fname in raw.filenames if fname is not None]
         if len(fnames):
             title = fnames.pop(0)
             extra = f" ... (+ {len(fnames)} more)" if len(fnames) else ""
             title = f"{title}{extra}"
             if len(title) > 60:
                 title = _shorten_path_from_middle(title)
+        else:  # give at least a hint about the data being shown
+            title = f"{type(raw).__name__} (~{sizeof_fmt(raw._size)})"
     elif not isinstance(title, str):
         raise TypeError(f"title must be None or a string, got a {type(title)}")
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -4,6 +4,7 @@
 
 import itertools
 import os
+import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -747,6 +748,13 @@ def test_plot_raw_traces(raw, events, browser_backend):
         raw.plot(order="foo")
     with pytest.raises(TypeError, match="title must be None or a string, got"):
         raw.plot(title=1)
+    # in-memory raw has filenames == (None,); title should fall back to class + size
+    fig = RawArray(raw.get_data(), raw.info).plot()
+    if browser_backend.name == "matplotlib":
+        title = fig.canvas.manager.get_window_title()
+    else:
+        title = fig.windowTitle()
+    assert re.match(r"RawArray \(~[\d.]+ (bytes|[KMGT]iB)\)", title), title
     raw.plot(show_options=True)
     browser_backend._close_all()
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -750,11 +750,14 @@ def test_plot_raw_traces(raw, events, browser_backend):
         raw.plot(title=1)
     # in-memory raw has filenames == (None,); title should fall back to class + size
     fig = RawArray(raw.get_data(), raw.info).plot()
-    if browser_backend.name == "matplotlib":
-        title = fig.canvas.manager.get_window_title()
-    else:
+    if browser_backend.name != "matplotlib":
         title = fig.windowTitle()
-    assert re.match(r"RawArray \(~[\d.]+ (bytes|[KMGT]iB)\)", title), title
+    elif check_version("matplotlib", "3.10.3"):
+        title = fig.canvas.manager.get_window_title()
+    else:  # matplotlib < 3.10.3 hard-codes "image" for non-GUI window titles
+        title = None
+    if title is not None:
+        assert re.match(r"RawArray \(~[\d.]+ (bytes|[KMGT]iB)\)", title), title
     raw.plot(show_options=True)
     browser_backend._close_all()
 


### PR DESCRIPTION
I was working with plotting a `RawArray` and the title was just `None`, because there are no associated filenames. Instead, let's do `RawArray (2.1 GiB)` or similar.

No changelog entry needed I think since it's so minor. Changes drafted with Claude Opus 5 and reviewed/iterated by me.