### PR TITLE
Fix hemis generation in test_vertex_to_mni_fs_nibabel to cover both

### DIFF
--- a/mne/tests/test_freesurfer.py
+++ b/mne/tests/test_freesurfer.py
@@ -114,7 +114,7 @@ def test_vertex_to_mni_fs_nibabel(monkeypatch):
     n_check = 1000
     subject = "sample"
     vertices = rng.integers(0, 100000, n_check)
-    hemis = rng.integers(0, 1, n_check)
+    hemis = rng.integers(0, 2, n_check)
     coords = vertex_to_mni(vertices, hemis, subject, subjects_dir)
     read_mri = mne._freesurfer._read_mri_info
     monkeypatch.setattr(


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
and the [detailed contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

If you used AI to help prepare this pull request, please pay special attention to
our **Policy on AI Assistance in Contributions** in
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md).
Here are some examples of what we expect for "tool, manner, and scope" disclosure:

- "I implemented the code changes myself, and Claude Sonnet 4.6 wrote the test."
- "I prompted Gemini 3.1 Pro to get a first draft implementation, then refined it
  manually until I was satisfied."
- "I wrote the code and asked Kimi K2.5 to write the docstring for me."
- "I fed GPT 5.4 the paper where the algorithm is described, and asked it to implement
  it for me. Then I had it write an example script using the `sample` dataset, and I
  wrote the narrative text of the tutorial myself."

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

I wasn't able to find an existing issue for this bug.

#### What does this implement/fix?

This fixes `test_vertex_to_mni_fs_nibabel` so that it covers both hemispheres.

`rng.integers(0, 1)` always returns 0 (exclusive upper bound), so `hemis` was all zeros and the test only compared left-hemisphere coordinates. Changed to `rng.integers(0, 2)` so the right hemisphere is exercised too.

Test-only change; the seeded RNG keeps it deterministic.

#### Additional information

**AI Disclosure:** I didn't actually use AI to write any code or comments here, but I technically found this bug during an AI-assisted static analysis project that I've been working on. The AI assisting me was OpenAI Codex gpt-5.6-sol (xhigh). Just stating that for transparency; maintainers, just yell if this disclosure is too pedantic.
