### PR TITLE
Fix bug with annotation description edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,13 @@ changelog entry instead of a plain name link.
 - Deprecations use the `@mne.utils.deprecated` decorator (functions/classes) or
   `mne.utils.warn(..., FutureWarning)` (parameters); add a test asserting the warning fires, and
   grep for internal call sites to update immediately rather than at end-of-cycle.
+- Workarounds that exist only because of a minimum-version floor (an upstream bug fixed in a
+  newer release, a fallback for an older Python/NumPy/SciPy/...) must be marked with a
+  `# TODO VERSION` comment naming the version at which they can be removed and, when there is
+  one, the upstream issue, e.g.
+  `# TODO VERSION: segfaults on NumPy < 2.2.5 (numpy/numpy#28609)`. These are grepped for
+  when bumping minimum versions, so a workaround without the marker tends to outlive its
+  reason for existing.
 - Prefer the `testing` dataset over `sample`/other large datasets in tests (smaller, faster).
 - Prefer to keep unit tests compact and add to existing tests when possible. The full test suite takes about an hour on CIs, so minimizing test time (for CIs) and test verbosity (for reviewers) is important.
 - When new functionality is added, it is good in general to add it somewhere in an example (`examples/`) or a tutorial (`tutorials/`) to help with discoverability and documentation.

--- a/doc/changes/dev/14186.bugfix.rst
+++ b/doc/changes/dev/14186.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where assigning into :attr:`mne.Annotations.description` (e.g., ``annotations.description[0] = "a_longer_description"``) silently truncated the new value, by storing descriptions using NumPy's variable-width string dtype (``numpy.dtypes.StringDType``) instead of a fixed-width ``"<U"`` dtype, by `Eric Larson`_.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -56,6 +56,11 @@ from .utils import (
 )
 from .utils.check import _soft_import
 
+# Variable-width string dtype used for annotation descriptions. Unlike the fixed-width
+# "<U" dtypes, it does not silently truncate when assigning into an existing array,
+# e.g. ``annotations.description[0] = "a_much_longer_description"``.
+_DESCRIPTION_DTYPE = np.dtypes.StringDType()
+
 # For testing windows_like_datetime, we monkeypatch "datetime" in this module.
 # Keep the true datetime object around for _validate_type use.
 _datetime = datetime
@@ -198,7 +203,7 @@ def _check_duration(duration, n):
 
 def _check_description(description, n):
     """Convert and validate description to a 1D str array of length n."""
-    description = _ensure_1d(description, dtype=str, name="description")
+    description = _ensure_1d(description, dtype=_DESCRIPTION_DTYPE, name="description")
     if description.shape == (1,):
         description = np.repeat(description, n)
     _check_length(description, n, name="description")
@@ -499,7 +504,13 @@ class Annotations:
         -------
         description : array of shape (n_annotations,)
             A string description for each annotation (e.g., event
-            label or condition name).
+            label or condition name). The array uses NumPy's variable-width
+            :obj:`~numpy.dtypes.StringDType`, so assigning a longer string into an
+            existing entry does not truncate it.
+
+            .. versionchanged:: 1.13
+               Previously a fixed-width (``"<U"``) dtype was used, which silently
+               truncated values assigned in place.
 
         See Also
         --------
@@ -974,7 +985,7 @@ class Annotations:
         self._onset = np.array(onsets, float)
         self._duration = np.array(durations, float)
         assert (self._duration >= 0).all()
-        self._description = np.array(descriptions, dtype=str)
+        self._description = np.array(descriptions, dtype=_DESCRIPTION_DTYPE)
         self._ch_names = _ndarray_ch_names(ch_names)
         self._extras = extras
 
@@ -1065,7 +1076,9 @@ class Annotations:
             valid_key_source="data",
             key_description="Annotation description(s)",
         )
-        self.description = np.array([str(mapping.get(d, d)) for d in self.description])
+        self.description = np.array(
+            [str(mapping.get(d, d)) for d in self.description], dtype=_DESCRIPTION_DTYPE
+        )
         return self
 
 
@@ -1924,7 +1937,7 @@ def _write_annotations_txt(fname, annot):
                 )
             data.append([val if val is not None else "" for val in values])
     content += "\n"
-    data = np.array(data, dtype=str).T
+    data = np.array(data, dtype=_DESCRIPTION_DTYPE).T
     assert data.ndim == 2
     assert data.shape[0] == len(annot.onset)
     assert data.shape[1] == n_cols

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -725,6 +725,19 @@ class Annotations:
         """
         return deepcopy(self)
 
+    def __getstate__(self):
+        """Get the state for pickling and copying."""
+        state = self.__dict__.copy()
+        # Store the descriptions as a list: copy.deepcopy of a StringDType array
+        # TODO VERSION: segfaults on NumPy < 2.2.5 (numpy/numpy#28609)
+        state["_description"] = self._description.tolist()
+        return state
+
+    def __setstate__(self, state):
+        """Set the state from pickling and copying."""
+        self.__dict__.update(state)
+        self._description = np.array(self._description, dtype=_DESCRIPTION_DTYPE)
+
     def delete(self, idx):
         """Remove an annotation. Operates inplace.
 
@@ -1294,7 +1307,7 @@ class HEDAnnotations(Annotations):
             _orig_time=self._orig_time,
             onset=self.onset,
             duration=self.duration,
-            description=self.description,
+            description=self.description.tolist(),  # see Annotations.__getstate__
             ch_names=self.ch_names,
             _extras=self.extras,
             hed_string=list(self.hed_string),

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -56,11 +56,6 @@ from .utils import (
 )
 from .utils.check import _soft_import
 
-# Variable-width string dtype used for annotation descriptions. Unlike the fixed-width
-# "<U" dtypes, it does not silently truncate when assigning into an existing array,
-# e.g. ``annotations.description[0] = "a_much_longer_description"``.
-_DESCRIPTION_DTYPE = np.dtypes.StringDType()
-
 # For testing windows_like_datetime, we monkeypatch "datetime" in this module.
 # Keep the true datetime object around for _validate_type use.
 _datetime = datetime
@@ -203,7 +198,9 @@ def _check_duration(duration, n):
 
 def _check_description(description, n):
     """Convert and validate description to a 1D str array of length n."""
-    description = _ensure_1d(description, dtype=_DESCRIPTION_DTYPE, name="description")
+    description = _ensure_1d(
+        description, dtype=np.dtypes.StringDType, name="description"
+    )
     if description.shape == (1,):
         description = np.repeat(description, n)
     _check_length(description, n, name="description")
@@ -508,10 +505,6 @@ class Annotations:
             :obj:`~numpy.dtypes.StringDType`, so assigning a longer string into an
             existing entry does not truncate it.
 
-            .. versionchanged:: 1.13
-               Previously a fixed-width (``"<U"``) dtype was used, which silently
-               truncated values assigned in place.
-
         See Also
         --------
         :attr:`~mne.Annotations.onset`
@@ -736,7 +729,7 @@ class Annotations:
     def __setstate__(self, state):
         """Set the state from pickling and copying."""
         self.__dict__.update(state)
-        self._description = np.array(self._description, dtype=_DESCRIPTION_DTYPE)
+        self._description = np.array(self._description, dtype=np.dtypes.StringDType)
 
     def delete(self, idx):
         """Remove an annotation. Operates inplace.
@@ -998,7 +991,7 @@ class Annotations:
         self._onset = np.array(onsets, float)
         self._duration = np.array(durations, float)
         assert (self._duration >= 0).all()
-        self._description = np.array(descriptions, dtype=_DESCRIPTION_DTYPE)
+        self._description = np.array(descriptions, dtype=np.dtypes.StringDType)
         self._ch_names = _ndarray_ch_names(ch_names)
         self._extras = extras
 
@@ -1090,7 +1083,8 @@ class Annotations:
             key_description="Annotation description(s)",
         )
         self.description = np.array(
-            [str(mapping.get(d, d)) for d in self.description], dtype=_DESCRIPTION_DTYPE
+            [str(mapping.get(d, d)) for d in self.description],
+            dtype=np.dtypes.StringDType,
         )
         return self
 
@@ -1950,7 +1944,7 @@ def _write_annotations_txt(fname, annot):
                 )
             data.append([val if val is not None else "" for val in values])
     content += "\n"
-    data = np.array(data, dtype=_DESCRIPTION_DTYPE).T
+    data = np.array(data, dtype=np.dtypes.StringDType).T
     assert data.ndim == 2
     assert data.shape[0] == len(annot.onset)
     assert data.shape[1] == n_cols

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -29,7 +29,8 @@ def _export_raw(fname, raw):
 
     if raw.annotations:
         annotations = [
-            raw.annotations.description,
+            # eeglabio builds a structured array, which does not support StringDType
+            raw.annotations.description.tolist(),
             # subtract raw.first_time because EEGLAB marks events starting from
             # the first available data point and ignores raw.first_time
             _sync_onset(raw, raw.annotations.onset, inverse=False),
@@ -59,7 +60,8 @@ def _export_epochs(fname, epochs):
 
     if epochs.annotations:
         annot = [
-            epochs.annotations.description,
+            # eeglabio builds a structured array, which does not support StringDType
+            epochs.annotations.description.tolist(),
             epochs.annotations.onset,
             epochs.annotations.duration,
         ]

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -747,7 +747,7 @@ def test_eeglab_drop_nan_annotations(tmp_path):
     sfreq = raw.info["sfreq"]
     ch_names = raw.ch_names
     anno = [
-        raw.annotations.description,
+        raw.annotations.description.tolist(),
         raw.annotations.onset,
         raw.annotations.duration,
     ]

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1296,7 +1296,7 @@ def test_read_annotation_txt_empty(tmp_path):
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, str)  # str, not np.str_
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 
@@ -1732,6 +1732,43 @@ def test_annotation_rename():
     a = mne.annotations_from_events(a, 256)
     a.rename({"1": "A", "11": "B", "111": "C"})
     assert_array_equal(a.description, ["B", "A", "C"])
+
+
+def _assert_no_truncation(annot):
+    """Check that in-place description assignment keeps the whole string."""
+    assert annot.description.dtype == np.dtypes.StringDType()
+    long_description = "a_very_much_longer_description"
+    annot.description[-1] = long_description
+    assert annot.description[-1] == long_description
+
+
+@pytest.mark.parametrize("fmt", ("fif", "csv", "txt"))
+def test_description_assignment_not_truncated(tmp_path, fmt):
+    """Test that assigning into description does not truncate strings."""
+    annot = Annotations([1.0, 2.0], [1.0, 1.0], ["short", "b"], extras=[dict(a=1)] * 2)
+    _assert_no_truncation(annot.copy())
+    annot.append(3.0, 1.0, "c", extras=[dict(a=1)])
+    annot.rename({"b": "b_renamed"})
+    other = annot.copy()
+    other.onset += 10.0
+    cropped, deleted = annot.copy(), annot.copy()
+    cropped.crop(0.0, 100.0)
+    deleted.delete(0)
+    for modified in (annot.copy(), annot + other, cropped, deleted):
+        _assert_no_truncation(modified)
+    # round-trip through disk (Annotations.save and raw.save)
+    annot_fname = tmp_path / f"test-annot.{fmt}"
+    annot.save(annot_fname)
+    round_tripped = [read_annotations(annot_fname)]
+    if fmt == "fif":
+        raw = RawArray(np.zeros((1, 2000)), create_info(1, 100.0, "eeg"))
+        raw.set_annotations(annot)
+        raw_fname = tmp_path / "test_raw.fif"
+        raw.save(raw_fname)
+        round_tripped.append(read_raw_fif(raw_fname).annotations)
+    for got in round_tripped:
+        assert_array_equal(got.description, annot.description)
+        _assert_no_truncation(got)
 
 
 def test_annotation_duration_setting():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -4,6 +4,7 @@
 
 import sys
 from collections import OrderedDict
+from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from itertools import repeat
 from pathlib import Path
@@ -1745,8 +1746,14 @@ def _assert_no_truncation(annot):
 @pytest.mark.parametrize("fmt", ("fif", "csv", "txt"))
 def test_description_assignment_not_truncated(tmp_path, fmt):
     """Test that assigning into description does not truncate strings."""
+    if fmt != "fif":
+        pytest.importorskip("pandas")
     annot = Annotations([1.0, 2.0], [1.0, 1.0], ["short", "b"], extras=[dict(a=1)] * 2)
     _assert_no_truncation(annot.copy())
+    # the copy must be independent (and not crash: numpy/numpy#28609)
+    annot_copy = deepcopy(annot)
+    annot_copy.description[0] = "changed"
+    assert annot.description[0] == "short"
     annot.append(3.0, 1.0, "c", extras=[dict(a=1)])
     annot.rename({"b": "b_renamed"})
     other = annot.copy()

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -657,7 +657,12 @@ def object_hash(x, h=None):
         x = np.asarray(x)
         h.update(str(x.shape).encode("utf-8"))
         h.update(str(x.dtype).encode("utf-8"))
-        h.update(x.tobytes())
+        if x.dtype.kind == "T":
+            # variable-width strings store a pointer to the heap, so tobytes() does
+            # not contain the actual string data
+            h.update(repr(x.tolist()).encode("utf-8"))
+        else:
+            h.update(x.tobytes())
     elif isinstance(x, datetime):
         object_hash(_dt_to_stamp(x))
     elif sparse.issparse(x):

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -367,6 +367,15 @@ def test_hash():
     d1["d"][0] = 0
     assert object_hash(d0) != object_hash(d1)
 
+    # variable-width strings (hashing must look at the data, not the pointers)
+    d1 = deepcopy(d0)
+    d1["f"] = np.array(["a" * 40], dtype=np.dtypes.StringDType())
+    d2 = deepcopy(d1)
+    assert object_hash(d1) == object_hash(d2)
+    d2["f"][0] = "b" * 40
+    assert len(object_diff(d1, d2)) > 0
+    assert object_hash(d1) != object_hash(d2)
+
     d1 = deepcopy(d0)
     assert object_hash(d0) == object_hash(d1)
     d1["a"]["a"] = 0.11

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -370,7 +370,9 @@ def test_hash():
     # variable-width strings (hashing must look at the data, not the pointers)
     d1 = deepcopy(d0)
     d1["f"] = np.array(["a" * 40], dtype=np.dtypes.StringDType())
-    d2 = deepcopy(d1)
+    d2 = deepcopy(d0)
+    # TODO VERSION: deepcopy segfaults on NumPy < 2.2.5 (numpy/numpy#28609)
+    d2["f"] = d1["f"].copy()
     assert object_hash(d1) == object_hash(d2)
     d2["f"][0] = "b" * 40
     assert len(object_diff(d1, d2)) > 0

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -54,7 +54,7 @@ echo "::endgroup::"
 echo "::group::Everything else"
 python -m pip install $STD_ARGS \
 	"pyvista @ https://github.com/pyvista/pyvista/archive/refs/heads/main.zip" \
-	"pyvistaqt @ https://github.com/larsoner/pyvistaqt/archive/refs/heads/qvtk-opengl-widget.zip" \
+	"pyvistaqt @ https://github.com/pyvista/pyvistaqt/archive/refs/heads/main.zip" \
 	"git+https://github.com/nilearn/nilearn" \
 	"git+https://github.com/pierreablin/picard" \
 	"git+https://github.com/the-siesta-group/edfio" \


### PR DESCRIPTION
In `main`, creating `Annotations` and then editing a description to be longer than the longest-width string silently truncates:
```
>>> import mne
>>> annot = mne.Annotations([0, 1], 1, ['a', 'bb'])
>>> annot.description[0] = 'aaa'
>>> annot.description[0]
np.str_('aa')
```
By switching to NumPy 2.0's varible-width string dtype, on this branch it works:
```
i>>> import mne
>>> annot = mne.Annotations([0, 1], 1, ['a', 'bb'])
>>> annot.description[0] = 'aaa'
>>> annot.description[0]
'aaa'
```

Changes drafted by Claude Opus 5 and reviewed / understood by me.