### PR TITLE
Fix volumetric MIP

### DIFF
--- a/doc/changes/dev/14187.bugfix.rst
+++ b/doc/changes/dev/14187.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where volumetric source estimates plotted with signed dataand the default MIP mapping (``volume_options=dict(blending="mip")``) rendered the negative half on top of the positive half from every viewing angle, by `Eric Larson`_.

--- a/doc/changes/dev/14187.bugfix.rst
+++ b/doc/changes/dev/14187.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a bug where volumetric source estimates plotted with signed dataand the default MIP mapping (``volume_options=dict(blending="mip")``) rendered the negative half on top of the positive half from every viewing angle, by `Eric Larson`_.
+Fixed a bug where volumetric source estimates plotted with signed data and the default MIP mapping (``volume_options=dict(blending="mip")``) rendered the negative half on top of the positive half from every viewing angle, by `Eric Larson`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -4165,6 +4165,9 @@ class Brain:
                         fill = 0 if active["center"] is not None else rng[0]
                         grid.point_data["values"].fill(fill)
                         grid.point_data["values"][vertices] = values
+                        self._renderer._update_volume_rgba(
+                            grid, self._data["ctable"], rng
+                        )
                         # This can be useful for debugging fsaverage-5 source space by
                         # making the value at (0, -5, 5) high
                         # if 21334 in vertices:

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -1465,16 +1465,18 @@ something
         assert_allclose(img.shape[0], screenshot_all.shape[0], atol=1)
 
 
-def test_brain_traces_colormap(renderer_interactive_pyvistaqt, brain_gc):
+@pytest.mark.parametrize("src", ("surface", "volume"))
+def test_brain_traces_colormap(renderer_interactive_pyvistaqt, brain_gc, src):
     """Test colormap selection."""
     brain = _create_testing_brain(
         hemi="lh",
         surf="white",
-        src="surface",
+        src=src,
         show_traces=0.5,
         initial_time=0,
         n_time=5,
         diverging=True,
+        volume_options=dict(resolution=None),  # for speed, don't upsample
         add_data_kwargs=dict(colorbar_kwargs=dict(n_labels=3)),
     )
     # mne_analyze should be chosen
@@ -1482,6 +1484,26 @@ def test_brain_traces_colormap(renderer_interactive_pyvistaqt, brain_gc):
     assert_array_equal(ctab[0], [0, 255, 255, 255])  # opaque cyan
     assert_array_equal(ctab[-1], [255, 255, 0, 255])  # opaque yellow
     assert_allclose(ctab[len(ctab) // 2], [128, 128, 128, 0], atol=3)
+    if src == "volume":
+        # A divergent MIP is one volume with the colors baked into the data, not
+        # a MIP plus a MinIP: VTK does no depth intermixing between volume
+        # actors, so a pair of them composites in the order they were added and
+        # the negative half would hide the positive half from every angle.
+        vol = brain._data["vol"]
+        assert vol["grid_volume_neg"] is None
+        grid = vol["grid"]
+        values = np.asarray(grid.point_data["values"])
+        rgba = np.asarray(grid.point_data["rgba"])
+        # component 3 is the magnitude that the projection maximizes over, so
+        # the larger |value| wins regardless of which one is nearer the camera
+        fmax = brain._cmap_range[1]
+        want = np.clip(np.abs(values) / fmax * 255, 0, 255)
+        assert_allclose(rgba[:, 3], want, atol=1)
+        # components 0-2 are literal color: warm for positive, cool for negative
+        assert values.min() < 0 < values.max()
+        pos, neg = rgba[np.argmax(values)], rgba[np.argmin(values)]
+        assert pos[0] > pos[2]  # yellow end
+        assert neg[2] > neg[0]  # cyan end
     brain.close()
 
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1175,7 +1175,7 @@ def _bake_volume_rgba(values, ctable, rng):
     idx = np.clip((values - lo) / (hi - lo) * (n_colors - 1), 0, n_colors - 1)
     rgba = ctable[idx.astype(np.int64)].copy()
     # magnitude, not mapped opacity (saturates at fmax -> ties); from the table
-    # center, where a divergent colormap changes sign (rng may be asymmetric)
+    # center, where a divergent colormap changes sign (`rng` may be asymmetric)
     half = (n_colors - 1) / 2.0
     rgba[:, 3] = np.round(np.abs(idx - half) / half * 255).astype(np.uint8)
     return rgba

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1088,10 +1088,10 @@ class _PyVistaRenderer(_AbstractRenderer):
         # so do a divergent MIP in one volume with baked colors instead of two
         signed_mip = center is not None and blending == "mip"
         if signed_mip:
-            grid.point_data[_RGBA_NAME] = np.zeros((grid.n_points, 4), np.uint8)
+            grid.point_data["rgba"] = np.zeros((grid.n_points, 4), np.uint8)
             # the reslicer and mapper both act on the active scalars; "values"
             # stays under its own name for picking
-            grid.point_data.active_scalars_name = _RGBA_NAME
+            grid.point_data.active_scalars_name = "rgba"
 
         mapper = vtkSmartVolumeMapper()
         interp_map_meth = "SetInterpolationModeTo"
@@ -1160,9 +1160,6 @@ class _PyVistaRenderer(_AbstractRenderer):
         return actor
 
 
-_RGBA_NAME = "rgba"
-
-
 def _bake_volume_rgba(values, ctable, rng):
     """Encode signed scalars as dependent-component RGBA for a signed MIP.
 
@@ -1183,9 +1180,9 @@ def _bake_volume_rgba(values, ctable, rng):
 
 def _update_volume_rgba(grid, ctable, rng):
     """Re-bake the color array of a signed-MIP volume, if the grid has one."""
-    if _RGBA_NAME not in grid.point_data:
+    if "rgba" not in grid.point_data:
         return
-    grid.point_data[_RGBA_NAME][:] = _bake_volume_rgba(
+    grid.point_data["rgba"][:] = _bake_volume_rgba(
         np.asarray(grid.point_data["values"]), ctable, rng
     )
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1003,16 +1003,28 @@ class _PyVistaRenderer(_AbstractRenderer):
                 scalar_bar.SetLabelFormat(fmt)
 
     def _set_volume_range(self, volume, ctable, alpha, scalar_bar, rng, fmt=None):
-        color_tf = vtkColorTransferFunction()
-        opacity_tf = vtkPiecewiseFunction()
-        for loc, color in zip(np.linspace(*rng, num=len(ctable)), ctable):
-            color_tf.AddRGBPoint(loc, *(color[:-1] / 255.0))
-            opacity_tf.AddPoint(loc, color[-1] * alpha / 255.0)
-        color_tf.ClampingOn()
-        opacity_tf.ClampingOn()
         prop = volume.GetProperty()
-        prop.SetColor(color_tf)
-        prop.SetScalarOpacity(opacity_tf)
+        if not prop.GetIndependentComponents():
+            # signed MIP: color is baked into the data, so re-bake it here and
+            # keep only magnitude -> opacity in a transfer function
+            opacity_tf = vtkPiecewiseFunction()
+            for loc, opacity in zip(*_volume_rgba_opacity(ctable, alpha)):
+                opacity_tf.AddPoint(float(loc), float(opacity))
+            opacity_tf.ClampingOn()
+            prop.SetScalarOpacity(opacity_tf)
+            grid = getattr(volume, "_mne_grid", None)
+            if grid is not None:
+                _update_volume_rgba(grid, ctable, rng)
+        else:
+            color_tf = vtkColorTransferFunction()
+            opacity_tf = vtkPiecewiseFunction()
+            for loc, color in zip(np.linspace(*rng, num=len(ctable)), ctable):
+                color_tf.AddRGBPoint(loc, *(color[:-1] / 255.0))
+                opacity_tf.AddPoint(loc, color[-1] * alpha / 255.0)
+            color_tf.ClampingOn()
+            opacity_tf.ClampingOn()
+            prop.SetColor(color_tf)
+            prop.SetScalarOpacity(opacity_tf)
         if scalar_bar is not None:
             lut = vtkLookupTable()
             lut.SetRange(*rng)
@@ -1020,6 +1032,9 @@ class _PyVistaRenderer(_AbstractRenderer):
             scalar_bar.SetLookupTable(lut)
             if fmt is not None:
                 scalar_bar.SetLabelFormat(fmt)
+
+    def _update_volume_rgba(self, grid, ctable, rng):
+        _update_volume_rgba(grid, ctable, rng)
 
     def _sphere(self, center, color, radius):
         mesh = pyvista.Sphere(
@@ -1041,7 +1056,7 @@ class _PyVistaRenderer(_AbstractRenderer):
         interpolation="linear",
     ):
         # Note: this method is used by mne-gui-addons, so we should be mindful of
-        # backwards compatibility when changing it.
+        # backwards compatibility when changing it. volume_neg is always None now.
 
         # Now we can actually construct the visualization
         grid = pyvista.ImageData(
@@ -1069,6 +1084,15 @@ class _PyVistaRenderer(_AbstractRenderer):
         else:
             grid_mesh = None
 
+        # VTK composites overlapping volume actors in add order, not by depth,
+        # so do a divergent MIP in one volume with baked colors instead of two
+        signed_mip = center is not None and blending == "mip"
+        if signed_mip:
+            grid.point_data[_RGBA_NAME] = np.zeros((grid.n_points, 4), np.uint8)
+            # the reslicer and mapper both act on the active scalars; "values"
+            # stays under its own name for picking
+            grid.point_data.active_scalars_name = _RGBA_NAME
+
         mapper = vtkSmartVolumeMapper()
         interp_map_meth = "SetInterpolationModeTo"
         interp_map_meth += dict(nearest="NearestNeighbor", linear="Linear")[
@@ -1076,6 +1100,9 @@ class _PyVistaRenderer(_AbstractRenderer):
         ]
         interp_prop_meth = "SetInterpolationTypeTo"
         interp_prop_meth += dict(nearest="Nearest", linear="Linear")[interpolation]
+        # shading needs a gradient: VTK ignores it for MIP, and with nearest
+        # the gradient is a spike at each voxel face (bright lattice)
+        shade = blending == "composite" and interpolation == "linear"
         del interpolation
         if resolution is None:  # native
             mapper.SetScalarModeToUsePointData()
@@ -1097,25 +1124,15 @@ class _PyVistaRenderer(_AbstractRenderer):
         dist = grid.length / np.mean(grid.dimensions)
         volume_pos_prop = volume_pos.GetProperty()
         volume_pos_prop.SetScalarOpacityUnitDistance(dist)
-        volume_pos_prop.ShadeOn()
+        volume_pos_prop.SetShade(shade)
         getattr(volume_pos_prop, interp_prop_meth)()
-        if center is not None and blending == "mip":
-            # We need to create a minimum intensity projection for the neg half
-            mapper_neg = vtkSmartVolumeMapper()
-            if resolution is None:  # native
-                mapper_neg.SetScalarModeToUsePointData()
-                mapper_neg.SetInputDataObject(grid)
-            else:
-                mapper_neg.SetInputConnection(upsampler.GetOutputPort())
-            mapper_neg.SetBlendModeToMinimumIntensity()
-            volume_neg = vtkVolume()
-            volume_neg.SetMapper(mapper_neg)
-            volume_neg_prop = volume_neg.GetProperty()
-            volume_neg_prop.SetScalarOpacityUnitDistance(dist)
-            volume_neg_prop.ShadeOn()
-            getattr(volume_neg_prop, interp_prop_meth)()
-        else:
-            volume_neg = None
+        if signed_mip:
+            # components 0-2 are color, component 3 is the maximized magnitude
+            volume_pos_prop.IndependentComponentsOff()
+            # stashed (not passed) so _set_volume_range() can re-bake without a
+            # signature change, which mne-gui-addons relies on
+            volume_pos._mne_grid = grid
+        volume_neg = None  # kept only for backward compatibility
         return grid, grid_mesh, volume_pos, volume_neg
 
     def _silhouette(self, mesh, color=None, line_width=None, alpha=None, decimate=None):
@@ -1141,6 +1158,51 @@ class _PyVistaRenderer(_AbstractRenderer):
             prop.SetLineWidth(line_width)
         _hide_testing_actor(actor)
         return actor
+
+
+_RGBA_NAME = "rgba"
+
+
+def _bake_volume_rgba(values, ctable, rng):
+    """Encode signed scalars as dependent-component RGBA for a signed MIP.
+
+    VTK maximizes over component 3, so putting the magnitude there makes MIP a
+    maximum *absolute* intensity projection: largest ``|value|`` along the ray
+    wins, ties go to the nearest sample.
+    """
+    n_colors = len(ctable)
+    lo, hi = float(rng[0]), float(rng[1])
+    idx = np.clip((values - lo) / (hi - lo) * (n_colors - 1), 0, n_colors - 1)
+    rgba = ctable[idx.astype(np.int64)].copy()
+    # magnitude, not mapped opacity (saturates at fmax -> ties); from the table
+    # center, where a divergent colormap changes sign (rng may be asymmetric)
+    half = (n_colors - 1) / 2.0
+    rgba[:, 3] = np.round(np.abs(idx - half) / half * 255).astype(np.uint8)
+    return rgba
+
+
+def _update_volume_rgba(grid, ctable, rng):
+    """Re-bake the color array of a signed-MIP volume, if the grid has one."""
+    if _RGBA_NAME not in grid.point_data:
+        return
+    grid.point_data[_RGBA_NAME][:] = _bake_volume_rgba(
+        np.asarray(grid.point_data["values"]), ctable, rng
+    )
+
+
+def _volume_rgba_opacity(ctable, alpha):
+    """Map magnitude (component 3, 0-255) to opacity using the colormap alpha."""
+    # magnitude is a distance from the table center, so walk outward both ways;
+    # halves agree for the center-symmetric tables calculate_lut() emits
+    n_colors = len(ctable)
+    half = (n_colors - 1) / 2.0
+    mag = np.arange(256)
+    offset = mag / 255.0 * half
+    opacity = np.maximum(
+        ctable[np.round(half + offset).astype(np.int64), 3],
+        ctable[np.round(half - offset).astype(np.int64), 3],
+    )
+    return mag, opacity * alpha / 255.0
 
 
 def _compute_normals(mesh):


### PR DESCRIPTION
For volumetric viz and two-sided data in MIP mode, we currently create two volumes: one MIP and one MinIP. This is problematic because of how multiple MIP/MinIP volumes are rendered -- there is no depth sorting / resolution, so which is shown depends on actor addition order.

Turns out there is a way around this: create a single volume and use the `A` component of `RGBA` to map to absolute intensity (and map the actual desired voxel alpha elsewhere), as VTK evaluates the `A` channel to decide "what is maximal" in the volume. There is in principle a slightly better way to do this (that wouldn't require re-baking values) -- "independent component" mode -- but it's broken for MIP. The other possible solution, `vtkMultiVolume` is broken for MIP.

Comparison, main (blue always wins) by simplifying the LCMV example:

<img width="880" height="528" alt="before" src="https://github.com/user-attachments/assets/d7288ed0-824d-43ba-82b5-ffc8a08d77ce" />


PR (highest voxel along view ray wins):

<img width="880" height="528" alt="after" src="https://github.com/user-attachments/assets/c7a37bc8-bfb8-4cf6-84e6-41b09808adae" />

Also fixes a minor bug with `blending="composite", interpolation="nearest"` where setting `ShadeOn` would give a grid outline artifact:

<img width="880" height="528" alt="composite_before" src="https://github.com/user-attachments/assets/e52b85f6-2ea2-44d4-bc18-185ffa070824" />


Now fixed:

<img width="880" height="528" alt="composite_after" src="https://github.com/user-attachments/assets/0055e5f7-e585-46aa-b273-eeb1cbcef07e" />

Changes drafted with Opus 5 and reviewed and iterated on by me.