### PR TITLE
BUG: Accept alternate CTF .hc head-coil descriptors

### DIFF
--- a/doc/changes/dev/14191.bugfix.rst
+++ b/doc/changes/dev/14191.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reading CTF datasets whose ``.hc`` file spells the head coils ``Nasion``/``LPA``/``RPA``, by `Seyed Yahya Shirazi`_.

--- a/mne/io/ctf/hc.py
+++ b/mne/io/ctf/hc.py
@@ -11,10 +11,16 @@ from ...utils import logger
 from .constants import CTF
 from .res4 import _make_ctf_name
 
+# Keys are matched against the lower-cased descriptor line, so entries must be
+# lower case. "lpa"/"rpa" are an alternate spelling seen in the wild alongside
+# a capitalized "Nasion"; CTF's own reader (readCTFds.m) takes the coil name
+# positionally and does not check it against a vocabulary at all.
 _kind_dict = {
     "nasion": CTF.CTFV_COIL_NAS,
     "left ear": CTF.CTFV_COIL_LPA,
     "right ear": CTF.CTFV_COIL_RPA,
+    "lpa": CTF.CTFV_COIL_LPA,
+    "rpa": CTF.CTFV_COIL_RPA,
     "spare": CTF.CTFV_COIL_SPARE,
 }
 
@@ -33,21 +39,24 @@ def _read_one_coil_point(fid):
     if len(one) == 0:
         return None
     one = one.strip().decode("utf-8")
-    if "Unable" in one:
+    # The descriptor is free text written by the acquisition software, and its
+    # capitalization varies between systems, so match it case-insensitively.
+    one_lower = one.lower()
+    if "unable" in one_lower:
         raise RuntimeError("HPI information not available")
 
     # Hopefully this is an unambiguous interpretation
     p = dict()
-    p["valid"] = "measured" in one
+    p["valid"] = "measured" in one_lower
     for key, val in _coord_dict.items():
-        if key in one:
+        if key in one_lower:
             p["coord_frame"] = val
             break
     else:
         p["coord_frame"] = -1
 
     for key, val in _kind_dict.items():
-        if key in one:
+        if key in one_lower:
             p["kind"] = val
             break
     else:

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -704,6 +704,36 @@ def test_missing_res4(tmp_path):
 
 
 @testing.requires_testing_data
+@pytest.mark.parametrize(
+    "names",
+    [
+        pytest.param(("Nasion", "LPA", "RPA"), id="Nasion-LPA-RPA"),
+        pytest.param(("NASION", "Left Ear", "RIGHT EAR"), id="mixed-case"),
+    ],
+)
+def test_hc_coil_name_variants(tmp_path, names):
+    """Test that alternate spellings of the .hc coil descriptors are read."""
+    raw_orig = read_raw_ctf(ctf_dir / ctf_fname_continuous)
+    use_ds = tmp_path / ctf_fname_continuous
+    copytree_rw(ctf_dir / ctf_fname_continuous, use_ds)
+    hc_fname = use_ds / (ctf_fname_continuous[:-2] + "hc")
+    hc = hc_fname.read_text()
+    for old, new in zip(("nasion", "left ear", "right ear"), names):
+        assert old in hc
+        hc = hc.replace(old, new)
+    hc_fname.write_text(hc)
+    raw = read_raw_ctf(use_ds)
+    assert_allclose(
+        raw.info["dev_head_t"]["trans"], raw_orig.info["dev_head_t"]["trans"]
+    )
+    assert len(raw.info["dig"]) == len(raw_orig.info["dig"])
+    for dig, dig_orig in zip(raw.info["dig"], raw_orig.info["dig"]):
+        assert dig["kind"] == dig_orig["kind"]
+        assert dig["ident"] == dig_orig["ident"]
+        assert_allclose(dig["r"], dig_orig["r"])
+
+
+@testing.requires_testing_data
 def test_read_ctf_mag_bad_comp(tmp_path, monkeypatch):
     """Test CTF reader with mag comps and bad comps."""
     path = op.join(ctf_dir, ctf_fname_continuous)


### PR DESCRIPTION
### Reference issue

Fixes #14190.

### What does this implement/fix?

`read_raw_ctf` raises `RuntimeError: Some of the mandatory HPI device-coordinate info was not there.` on CTF datasets whose `.hc` spells the head coils `Nasion`, `LPA`, `RPA` rather than `nasion`, `left ear`, `right ear`. The coordinates are present and correct and every other part of the `.hc` parse succeeds; only the descriptor vocabulary differs, so every point gets `kind = -1` and `_make_ctf_coord_trans_set` finds no LPA/RPA/NAS.

This does two things:

1. Matches the descriptor line case-insensitively. The descriptor is free text emitted by the acquisition software and its capitalization varies.
2. Adds `lpa` and `rpa` as aliases. These are a different vocabulary rather than a casing difference, so lower-casing alone does not fix them.

CTF's own reference reader is more permissive than this on both counts: `readHc` inside `readCTFds.m` reads the coil name positionally and does not check it against a vocabulary at all (`MEGCoilLabel = strvcat('nasion','left ear','right ear')` is declared at line 528 and never used), and it carries an explicit workaround for a `stadard` typo emitted by some Acq releases. I have kept the fixed vocabulary here rather than going positional, since that is a much larger behavioural change; this is the minimum that reads the affected files.

One judgement call worth flagging: I applied the lower-casing to the whole descriptor match, so `measured`, `relative to dewar`/`relative to head` and the `Unable` sentinel are now matched case-insensitively too, not just the coil names. That felt more coherent than leaving one of four lookups case-sensitive, but I am happy to narrow it to `_kind_dict` if you would rather keep the diff tighter.

### Testing

`test_hc_coil_name_variants` copies the CTF testing dataset, rewrites only the three descriptor words in the `.hc`, and asserts that the resulting `dev_head_t` and every digitization point match a read of the untouched original. It is parametrized over `Nasion`/`LPA`/`RPA` and a mixed-case spelling. Both parametrizations fail on `main` with exactly the error from the issue and pass with this change; the rest of `mne/io/ctf/tests/test_ctf.py` is unaffected.

The originating data is OpenNeuro `ds006502` (CC0). The failure is raised before the `.meg4` is opened, so one recording's metadata reproduces it in about 3 MB:

```
aws s3 cp --no-sign-request --recursive --exclude "*.meg4" \
  s3://openneuro.org/ds006502/sub-01/ses-meg1/meg/sub-01_ses-meg1_task-rest_run-1_meg.ds/ \
  sub-01_ses-meg1_task-rest_run-1_meg.ds/
```

With this change that recording's `.hc` parses to `[NAS, LPA, RPA, NAS, LPA, RPA]` across both coordinate frames and the read proceeds to the data stage.
