### PR TITLE
Fix docstring entries and checking

### DIFF
--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -901,7 +901,6 @@ class ContainsMixin:
             True
             >>> 'seeg' in inst  # doctest: +SKIP
             False
-
         """
         # this method is not supported by Info object. An Info object inherits from a
         # dictionary and the 'key' in Info call is present all across MNE codebase, e.g.
@@ -1001,7 +1000,15 @@ class ValidatedDict(dict):
         super().__setitem__(key, val)
 
     def update(self, other=None, **kwargs):
-        """Update method using __setitem__()."""
+        """Update the instance, validating each key like ``__setitem__``.
+
+        Parameters
+        ----------
+        other : dict | iterable of (key, value) | None
+            The entries to set.
+        **kwargs : dict
+            Additional entries to set, as keyword arguments.
+        """
         iterable = other.items() if isinstance(other, Mapping) else other
         if other is not None:
             for key, val in iterable:

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1004,8 +1004,8 @@ class ValidatedDict(dict):
 
         Parameters
         ----------
-        other : dict | iterable of (key, value) | None
-            The entries to set.
+        other : dict | iterable of pair | None
+            The entries to set, as a mapping or as ``(key, value)`` pairs.
         **kwargs : dict
             Additional entries to set, as keyword arguments.
         """

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -591,7 +591,18 @@ class Annotations:
         return len(self.duration)
 
     def __add__(self, other):
-        """Add (concatencate) two Annotation objects."""
+        """Add (concatenate) two Annotations objects.
+
+        Parameters
+        ----------
+        other : instance of Annotations
+            The annotations to append. Must have the same ``orig_time``.
+
+        Returns
+        -------
+        annotations : instance of Annotations
+            A new instance containing the annotations of both objects.
+        """
         out = self.copy()
         out += other
         return out
@@ -620,7 +631,14 @@ class Annotations:
         )
 
     def __iter__(self):
-        """Iterate over the annotations."""
+        """Iterate over the annotations.
+
+        Yields
+        ------
+        annotation : OrderedDict
+            The keys are ``onset``, ``duration``, ``description``,
+            ``orig_time``, and (if any are set) ``ch_names`` and ``extras``.
+        """
         # Figure this out once ahead of time for consistency and speed (for
         # thousands of annotations)
         with_ch_names = self._any_ch_names()
@@ -628,7 +646,27 @@ class Annotations:
             yield self.__getitem__(idx, with_ch_names=with_ch_names)
 
     def __getitem__(self, key, *, with_ch_names=None, with_extras=True):
-        """Propagate indexing and slicing to the underlying numpy structure."""
+        """Propagate indexing and slicing to the underlying numpy structure.
+
+        Parameters
+        ----------
+        key : int | slice | array-like
+            The annotation(s) to select.
+        with_ch_names : bool | None
+            Whether to include the ``ch_names`` key when returning a single
+            annotation. If ``None``, include it only if any annotation has
+            channel names.
+        with_extras : bool
+            Whether to include the ``extras`` key when returning a single
+            annotation.
+
+        Returns
+        -------
+        annotation : OrderedDict | instance of Annotations
+            A single annotation (as a dict) if ``key`` is an integer, otherwise
+            a new :class:`~mne.Annotations` instance with the selected
+            annotations.
+        """
         if isinstance(key, int_like):  # ty: ignore[invalid-argument-type]  # __instancecheck__
             out_keys = ("onset", "duration", "description", "orig_time")
             out_vals = (
@@ -1254,7 +1292,27 @@ class HEDAnnotations(Annotations):
         return f"<{s}>"
 
     def __getitem__(self, key, *, with_ch_names=None, with_extras=True):
-        """Propagate indexing and slicing to the underlying structure."""
+        """Propagate indexing and slicing to the underlying structure.
+
+        Parameters
+        ----------
+        key : int | slice | array-like
+            The annotation(s) to select.
+        with_ch_names : bool | None
+            Whether to include the ``ch_names`` key when returning a single
+            annotation. If ``None``, include it only if any annotation has
+            channel names.
+        with_extras : bool
+            Whether to include the ``extras`` key when returning a single
+            annotation.
+
+        Returns
+        -------
+        annotation : OrderedDict | instance of HEDAnnotations
+            A single annotation (as a dict, including ``hed_string``) if
+            ``key`` is an integer, otherwise a new
+            :class:`~mne.HEDAnnotations` instance with the selected annotations.
+        """
         result = super().__getitem__(
             key, with_ch_names=with_ch_names, with_extras=with_extras
         )

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -102,7 +102,13 @@ class ConductorModel(dict):
         return f"<ConductorModel | {extra}>"
 
     def copy(self):
-        """Return copy of ConductorModel instance."""
+        """Return copy of ConductorModel instance.
+
+        Returns
+        -------
+        bem : instance of ConductorModel
+            The copied conductor model.
+        """
         return deepcopy(self)
 
     @property

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -553,7 +553,18 @@ class DigMontage:
         return deepcopy(self)
 
     def __add__(self, other):
-        """Add two DigMontages."""
+        """Add two DigMontages.
+
+        Parameters
+        ----------
+        other : instance of DigMontage
+            The montage to add.
+
+        Returns
+        -------
+        montage : instance of DigMontage
+            A new montage containing the points of both montages.
+        """
         out = self.copy()
         out += other
         return out

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -273,7 +273,18 @@ class Covariance(dict):
         return s
 
     def __add__(self, cov):
-        """Add Covariance taking into account number of degrees of freedom."""
+        """Add Covariance taking into account number of degrees of freedom.
+
+        Parameters
+        ----------
+        cov : instance of Covariance
+            The covariance to add.
+
+        Returns
+        -------
+        cov : instance of Covariance
+            A new covariance, weighted by the degrees of freedom of each input.
+        """
         _check_covs_algebra(self, cov)
         this_cov = cov.copy()
         this_cov["data"] = (

--- a/mne/event.py
+++ b/mne/event.py
@@ -1250,7 +1250,6 @@ class AcqParserFIF:
                 manual for details. Currently the class does not offer any
                 facility for computing subaverages, but it can be done manually
                 by the user after collecting the epochs.
-
         """
         if isinstance(item, str):
             item = [item]

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -161,7 +161,13 @@ class Forward(dict):
     """
 
     def copy(self):
-        """Copy the Forward instance."""
+        """Copy the Forward instance.
+
+        Returns
+        -------
+        fwd : instance of Forward
+            The copied forward solution.
+        """
         return Forward(deepcopy(self))
 
     @verbose

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -911,7 +911,6 @@ class BaseRaw(
             >>> picks = mne.pick_types(raw.info, meg=True, exclude='bads')  # doctest: +SKIP
             >>> t_idx = raw.time_as_index([10., 20.])  # doctest: +SKIP
             >>> data, times = raw[picks, t_idx[0]:t_idx[1]]  # doctest: +SKIP
-
         """  # noqa: E501
         return self._getitem(item)
 

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -178,15 +178,15 @@ class RawKIT(BaseRaw):
     def read_stim_ch(self, buffer_size=1e5):
         """Read events from data.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         buffer_size : int
             The size of chunk to by which the data are scanned.
 
         Returns
         -------
-        events : array, [samples]
-           The event vector (1 x samples).
+        events : array, shape (n_samples,)
+            The event vector.
         """
         buffer_size = int(buffer_size)
         start = int(self.first_samp)

--- a/mne/label.py
+++ b/mne/label.py
@@ -324,7 +324,19 @@ class Label:
         return len(self.vertices)
 
     def __add__(self, other):
-        """Add Labels."""
+        """Add labels.
+
+        Parameters
+        ----------
+        other : instance of Label | instance of BiHemiLabel
+            The label to add.
+
+        Returns
+        -------
+        label : instance of Label | instance of BiHemiLabel
+            The union of the two labels (a :class:`~mne.BiHemiLabel` if the
+            hemispheres differ).
+        """
         _validate_type(other, (Label, BiHemiLabel), "other")
         if isinstance(other, BiHemiLabel):
             return other + self
@@ -394,7 +406,18 @@ class Label:
         return label
 
     def __sub__(self, other):
-        """Subtract Labels."""
+        """Subtract labels.
+
+        Parameters
+        ----------
+        other : instance of Label | instance of BiHemiLabel
+            The label to subtract.
+
+        Returns
+        -------
+        label : instance of Label
+            The vertices of this label that are not in ``other``.
+        """
         _validate_type(other, (Label, BiHemiLabel), "other")
         if isinstance(other, BiHemiLabel):
             if self.hemi == "lh":
@@ -1046,7 +1069,18 @@ class BiHemiLabel:
         return len(self.lh) + len(self.rh)
 
     def __add__(self, other):
-        """Add labels."""
+        """Add labels.
+
+        Parameters
+        ----------
+        other : instance of Label | instance of BiHemiLabel
+            The label to add.
+
+        Returns
+        -------
+        label : instance of BiHemiLabel
+            The union of the two labels.
+        """
         if isinstance(other, Label):
             if other.hemi == "lh":
                 lh = self.lh + other
@@ -1065,7 +1099,19 @@ class BiHemiLabel:
         return BiHemiLabel(lh, rh, name, color)
 
     def __sub__(self, other):
-        """Subtract labels."""
+        """Subtract labels.
+
+        Parameters
+        ----------
+        other : instance of Label | instance of BiHemiLabel
+            The label to subtract.
+
+        Returns
+        -------
+        label : instance of Label | instance of BiHemiLabel
+            The vertices of this label that are not in ``other`` (a
+            :class:`~mne.Label` if only one hemisphere remains).
+        """
         _validate_type(other, (Label, BiHemiLabel), "other")
         if isinstance(other, Label):
             if other.hemi == "lh":

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -85,7 +85,13 @@ class InverseOperator(dict):
     """InverseOperator class to represent info from inverse operator."""
 
     def copy(self):
-        """Return a copy of the InverseOperator."""
+        """Return a copy of the InverseOperator.
+
+        Returns
+        -------
+        inv : instance of InverseOperator
+            The copied inverse operator.
+        """
         return InverseOperator(deepcopy(self))
 
     @property

--- a/mne/preprocessing/nirs/_scalp_coupling_index.py
+++ b/mne/preprocessing/nirs/_scalp_coupling_index.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from ...io import BaseRaw
-from ...utils import _validate_type, verbose
+from ...utils import _validate_type, _verbose_safe_false, verbose
 from ..nirs import _channel_frequencies, _validate_nirs_info
 
 
@@ -16,7 +16,7 @@ def scalp_coupling_index(
     h_freq=1.5,
     l_trans_bandwidth=0.3,
     h_trans_bandwidth=0.3,
-    verbose=False,
+    verbose=None,
 ):
     r"""Calculate scalp coupling index.
 
@@ -53,7 +53,7 @@ def scalp_coupling_index(
         h_freq,
         l_trans_bandwidth=l_trans_bandwidth,
         h_trans_bandwidth=h_trans_bandwidth,
-        verbose=verbose,
+        verbose=_verbose_safe_false(),
     ).get_data()
 
     # Determine number of wavelengths per source-detector pair

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -576,7 +576,15 @@ class SourceSimulator:
         return stc
 
     def __iter__(self):
-        """Iterate over 1 second STCs."""
+        """Iterate over 1 second STCs.
+
+        Yields
+        ------
+        stc : instance of SourceEstimate
+            The source estimate for the next chunk of data.
+        stim : ndarray, shape (n_samples,)
+            The stim channel for the same chunk.
+        """
         # Arbitrary chunk size, can be modified later to something else.
         # Loop over chunks of 1 second - or, maximum sample size.
         # Can be modified to a different value.

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1003,7 +1003,19 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
         self._times.flags.writeable = False
 
     def __add__(self, a):
-        """Add source estimates."""
+        """Add source estimates.
+
+        Parameters
+        ----------
+        a : instance of SourceEstimate | float
+            The source estimate (with matching vertices) or scalar to
+            add.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            A new source estimate with the sum as data.
+        """
         stc = self.copy()
         stc += a
         return stc
@@ -1051,7 +1063,19 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
         return sum_stc
 
     def __sub__(self, a):
-        """Subtract source estimates."""
+        """Subtract source estimates.
+
+        Parameters
+        ----------
+        a : instance of SourceEstimate | float
+            The source estimate (with matching vertices) or scalar to
+            subtract.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            A new source estimate with the difference as data.
+        """
         stc = self.copy()
         stc -= a
         return stc
@@ -1068,8 +1092,20 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
     def __truediv__(self, a):  # noqa: D105
         return self.__div__(a)
 
-    def __div__(self, a):  # noqa: D105
-        """Divide source estimates."""
+    def __div__(self, a):
+        """Divide source estimates.
+
+        Parameters
+        ----------
+        a : instance of SourceEstimate | float
+            The source estimate (with matching vertices) or scalar to
+            divide by.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            A new source estimate with the quotient as data.
+        """
         stc = self.copy()
         stc /= a
         return stc
@@ -1087,7 +1123,19 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
         return self
 
     def __mul__(self, a):
-        """Multiply source estimates."""
+        """Multiply source estimates.
+
+        Parameters
+        ----------
+        a : instance of SourceEstimate | float
+            The source estimate (with matching vertices) or scalar to
+            multiply by.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            A new source estimate with the product as data.
+        """
         stc = self.copy()
         stc *= a
         return stc
@@ -1123,8 +1171,14 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
     def __rdiv__(self, a):  # noqa: D105
         return self / a
 
-    def __neg__(self):  # noqa: D105
-        """Negate the source estimate."""
+    def __neg__(self):
+        """Negate the source estimate.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            A new source estimate with negated data.
+        """
         stc = self.copy()
         stc._remove_kernel_sens_data_()
         stc.data *= -1

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -437,9 +437,21 @@ class SourceSpaces(list):
             fig=fig,
         )
 
-    def __getitem__(self, *args, **kwargs):
-        """Get an item."""
-        out = super().__getitem__(*args, **kwargs)
+    def __getitem__(self, key):
+        """Get one or more source spaces.
+
+        Parameters
+        ----------
+        key : int | slice
+            The source space(s) to get.
+
+        Returns
+        -------
+        src : dict | instance of SourceSpaces
+            A single source space if ``key`` is an integer, otherwise a new
+            :class:`~mne.SourceSpaces` instance.
+        """
+        out = super().__getitem__(key)
         if isinstance(out, list):
             out = SourceSpaces(out)
         return out
@@ -474,7 +486,18 @@ class SourceSpaces(list):
         return self[0].get("subject_his_id", None) if len(self) else None
 
     def __add__(self, other):
-        """Combine source spaces."""
+        """Combine source spaces.
+
+        Parameters
+        ----------
+        other : instance of SourceSpaces
+            The source spaces to append.
+
+        Returns
+        -------
+        src : instance of SourceSpaces
+            A new instance containing the source spaces of both objects.
+        """
         out = self.copy()
         out += other
         return SourceSpaces(out)

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -242,7 +242,14 @@ def _public_api_objects():
     from numpydoc.docscrape import ClassDoc
 
     seen = set()
-    candidates = [(dotted, _resolve_dotted(dotted)) for dotted in _documented_names()]
+    candidates = list()
+    for dotted in _documented_names():
+        try:
+            candidates.append((dotted, _resolve_dotted(dotted)))
+        except ModuleNotFoundError as exc:  # e.g., mne.decoding but no sklearn
+            if "'sklearn'" in str(exc):
+                continue
+            raise
     candidates += [(where, obj) for where, _, obj in _public_module_members()]
     for where, obj in candidates:
         if id(obj) in seen:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -301,14 +301,6 @@ def test_tabs():
             )
 
 
-def _is_private(dotted):
-    """Return True if any component is private (dunders are public)."""
-    return any(
-        part.startswith("_") and not (part.startswith("__") and part.endswith("__"))
-        for part in dotted.split(".")
-    )
-
-
 # Use ``np.random.default_rng(seed)`` and its modern methods. The global RNG
 # (``np.random.seed``/``np.random.randn``/...) makes tests order-dependent and
 # flaky, and the legacy ``RandomState`` methods below don't exist on a

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -3,6 +3,7 @@
 # Copyright the MNE-Python contributors.
 
 import ast
+import functools
 import importlib
 import inspect
 import re
@@ -17,6 +18,7 @@ import pytest
 import mne
 from mne.utils import _pl, _record_warnings
 from mne.utils._typing import Color, FileLike
+from mne.utils.docs import _doc_special_members
 
 public_modules = [
     # the list of modules users need to access for all functionality
@@ -104,26 +106,6 @@ bad_docstring_type = re.compile(
     r"(?<!['\"])\b(?:optional|defaults?)\b(?!['\"])",
     re.IGNORECASE,
 )
-subclass_name_ignores = (
-    (
-        dict,
-        {
-            "values",
-            "setdefault",
-            "popitems",
-            "keys",
-            "pop",
-            "update",
-            "copy",
-            "popitem",
-            "get",
-            "items",
-            "fromkeys",
-            "clear",
-        },
-    ),
-    (list, {"append", "count", "extend", "index", "insert", "pop", "remove", "sort"}),
-)
 
 
 @pytest.mark.parametrize(
@@ -183,10 +165,9 @@ def check_parameters_match(func, *, cls=None, where):
     )
     if skip:
         return list()
-    if cls is not None:
-        for subclass, ignores in subclass_name_ignores:
-            if issubclass(cls, subclass) and name.split(".")[-1] in ignores:
-                return list()
+    # e.g. dict.keys / list.__getitem__ inherited by our dict/list subclasses
+    if not inspect.isclass(func) and not inspect.isfunction(inspect.unwrap(func)):
+        return list()
     incorrect = [
         f"{where} : {name} : {err[0]} : {err[1]}"
         for err in validate(name)["errors"]
@@ -230,49 +211,67 @@ def check_parameters_match(func, *, cls=None, where):
     return incorrect
 
 
-@pytest.mark.slowtest
-def test_docstring_parameters():
-    """Test module docstring formatting."""
-    npd = pytest.importorskip("numpydoc")
-    incorrect = []
+def _public_module_members():
+    """Yield ``(module_name, member_name, obj)`` for public module members."""
     for name in public_modules:
         # Assert that by default we import all public names with `import mne`
         if name not in ("mne", "mne.gui"):
-            extra = name.split(".")[1]
-            assert hasattr(mne, extra)
+            assert hasattr(mne, name.split(".")[1])
         with _record_warnings():  # traits warnings
-            module = __import__(name, globals())
-        for submod in name.split(".")[1:]:
-            module = getattr(module, submod)
+            module = importlib.import_module(name)
         try:
-            classes = inspect.getmembers(module, inspect.isclass)
+            members = inspect.getmembers(module, inspect.isclass)
+            members += inspect.getmembers(module, inspect.isfunction)
         except ModuleNotFoundError as exc:  # e.g., mne.decoding but no sklearn
             if "'sklearn'" in str(exc):
                 continue
             raise
-        for cname, cls in classes:
-            if cname.startswith("_"):
-                continue
-            incorrect += check_parameters_match(cls, where=name)
-            cdoc = npd.docscrape.ClassDoc(cls)
-            for method_name in cdoc.methods:
-                method = getattr(cls, method_name)
-                incorrect += check_parameters_match(method, cls=cls, where=name)
+        for member_name, obj in members:
+            if not member_name.startswith("_"):
+                yield name, member_name, obj
+
+
+def _public_api_objects():
+    """Yield ``(obj, cls, where)`` for everything whose docstring we check.
+
+    This is the union of what is documented in ``doc/api/*.rst`` and what is
+    public in ``public_modules``; ``where`` is the documented dotted name or the
+    public module name, for error messages. Classes yield their public methods
+    (and ``__call__``) too.
+    """
+    from numpydoc.docscrape import ClassDoc
+
+    seen = set()
+    candidates = [(dotted, _resolve_dotted(dotted)) for dotted in _documented_names()]
+    candidates += [(where, obj) for where, _, obj in _public_module_members()]
+    for where, obj in candidates:
+        if id(obj) in seen:
+            continue
+        seen.add(id(obj))
+        if inspect.isclass(obj):
+            yield obj, None, where
+            class_doc = ClassDoc(obj)
+            # the same dunders that doc/conf.py renders in the API docs
+            class_doc.extra_public_methods = _doc_special_members
+            for method_name in class_doc.methods:
+                yield getattr(obj, method_name), obj, where
             if (
-                hasattr(cls, "__call__")
-                and "of type object" not in str(cls.__call__)
-                and "of ABCMeta object" not in str(cls.__call__)
+                hasattr(obj, "__call__")
+                and "of type object" not in str(obj.__call__)
+                and "of ABCMeta object" not in str(obj.__call__)
             ):
-                incorrect += check_parameters_match(
-                    cls.__call__,
-                    cls=cls,
-                    where=name,
-                )
-        functions = inspect.getmembers(module, inspect.isfunction)
-        for fname, func in functions:
-            if fname.startswith("_"):
-                continue
-            incorrect += check_parameters_match(func, where=name)
+                yield obj.__call__, obj, where
+        elif inspect.isroutine(obj):
+            yield obj, None, where
+
+
+@pytest.mark.slowtest
+def test_docstring_parameters():
+    """Test module docstring formatting."""
+    pytest.importorskip("numpydoc")
+    incorrect = []
+    for obj, cls, where in _public_api_objects():
+        incorrect += check_parameters_match(obj, cls=cls, where=where)
     incorrect = sorted(list(set(incorrect)))
     if len(incorrect) > 0:
         raise AssertionError(
@@ -293,6 +292,14 @@ def test_tabs():
             assert "\t" not in source, (
                 f'"{modname}" has tabs, please remove them or add it to the ignore list'
             )
+
+
+def _is_private(dotted):
+    """Return True if any component is private (dunders are public)."""
+    return any(
+        part.startswith("_") and not (part.startswith("__") and part.endswith("__"))
+        for part in dotted.split(".")
+    )
 
 
 # Use ``np.random.default_rng(seed)`` and its modern methods. The global RNG
@@ -417,85 +424,36 @@ write_info
 
 def test_documented():
     """Test that public functions and classes are documented."""
-    doc_dir = (Path(__file__).parents[2] / "doc" / "api").absolute()
-    doc_file = doc_dir / "python_reference.rst"
-    if not doc_file.is_file():
-        pytest.skip(f"Documentation file not found: {doc_file}")
-    api_files = (
-        "covariance",
-        "creating_from_arrays",
-        "datasets",
-        "decoding",
-        "events",
-        "file_io",
-        "forward",
-        "inverse",
-        "logging",
-        "most_used_classes",
-        "mri",
-        "preprocessing",
-        "reading_raw_data",
-        "realtime",
-        "report",
-        "sensor_space",
-        "simulation",
-        "source_space",
-        "statistics",
-        "time_frequency",
-        "visualization",
-        "export",
-    )
-    known_names = list()
-    for api_file in api_files:
-        with open(doc_dir / f"{api_file}.rst", "rb") as fid:
-            for line in fid:
-                line = line.decode("utf-8")
-                if not line.startswith("  "):  # at least two spaces
-                    continue
-                line = line.split()
-                if len(line) == 1 and line[0] != ":":
-                    known_names.append(line[0].split(".")[-1])
-    known_names = set(known_names)
-
+    pytest.importorskip("sphinx")
+    known_names = {name.split(".")[-1] for name in _documented_names()}
     missing = []
-    for name in public_modules:
-        with _record_warnings():  # traits warnings
-            module = __import__(name, globals())
-        for submod in name.split(".")[1:]:
-            module = getattr(module, submod)
-        try:
-            classes = inspect.getmembers(module, inspect.isclass)
-        except ModuleNotFoundError as exc:  # e.g., mne.decoding but no sklearn
-            if "'sklearn'" in str(exc):
-                continue
-            raise
-        functions = inspect.getmembers(module, inspect.isfunction)
-        checks = list(classes) + list(functions)
-        for this_name, cf in checks:
-            if not this_name.startswith("_") and this_name not in known_names:
-                from_mod = inspect.getmodule(cf).__name__
-                if (
-                    from_mod.startswith("mne")
-                    and not any(from_mod.startswith(x) for x in documented_ignored_mods)
-                    and this_name not in documented_ignored_names
-                    and not hasattr(cf, "_deprecated_original")
-                ):
-                    missing.append(f"{name} : {from_mod}.{this_name}")
+    for where, this_name, cf in _public_module_members():
+        if this_name in known_names:
+            continue
+        from_mod = inspect.getmodule(cf).__name__
+        if (
+            from_mod.startswith("mne")
+            and not any(from_mod.startswith(x) for x in documented_ignored_mods)
+            and this_name not in documented_ignored_names
+            and not hasattr(cf, "_deprecated_original")
+        ):
+            missing.append(f"{where} : {from_mod}.{this_name}")
     missing = sorted(set(missing))
     if len(missing) > 0:
         raise AssertionError(
             f"{len(missing)} new public member{_pl(missing)} missing from "
-            "doc/python_reference.rst:\n" + "\n".join(missing)
+            "doc/api/*.rst:\n" + "\n".join(missing)
         )
 
 
-def _documented_public_names():
+@functools.cache
+def _documented_names():
     """Return the names documented in ``doc/api/*.rst`` autosummary blocks."""
     from sphinx.ext.autosummary.generate import find_autosummary_in_files
 
     api_dir = Path(__file__).parents[2] / "doc" / "api"
     files = [str(path) for path in sorted(api_dir.glob("*.rst"))]
-    return {entry.name for entry in find_autosummary_in_files(files)}
+    return tuple(sorted({entry.name for entry in find_autosummary_in_files(files)}))
 
 
 def _resolve_dotted(name):
@@ -514,23 +472,12 @@ def _in_typed_module(obj):
 
 
 def _documented_callables():
-    """Yield ``(callable, cls)`` for documented public API in typed modules."""
-    seen = set()
-    for dotted in sorted(_documented_public_names()):
-        obj = _resolve_dotted(dotted)
-        if not _in_typed_module(obj):
-            continue
-        if inspect.isclass(obj):
-            yield obj, None  # constructor signature vs class docstring
-            for mname, method in inspect.getmembers(obj, inspect.isfunction):
-                if mname.startswith("_") or not _in_typed_module(method):
-                    continue
-                if method not in seen:
-                    seen.add(method)
-                    yield method, obj
-        elif inspect.isfunction(obj) and obj not in seen:
-            seen.add(obj)
-            yield obj, None
+    """Yield ``(callable, cls)`` for public API in typed modules."""
+    for obj, cls, _ in _public_api_objects():
+        if cls is not None and obj.__name__.startswith("_"):
+            continue  # dunders like __call__ are not type-hint checked
+        if (inspect.isclass(obj) or inspect.isfunction(obj)) and _in_typed_module(obj):
+            yield obj, cls
 
 
 def _annotation_to_str(ann):

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1225,6 +1225,7 @@ class Spectrum(BaseSpectrum):
         # save memory
         del self.inst
 
+    @fill_doc
     def __getitem__(self, item):
         """Get Spectrum data.
 
@@ -1500,6 +1501,7 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
         # save memory
         del self.inst
 
+    @fill_doc
     def __getitem__(self, item):
         """Subselect epochs from an EpochsSpectrum.
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -3840,6 +3840,7 @@ class RawTFR(BaseTFR):
         state["dims"] += ("freq", "time")
         super().__setstate__(state)
 
+    @fill_doc
     def __getitem__(self, item):
         """Get RawTFR data.
 

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -135,8 +135,8 @@ class Transform(dict):
     def __eq__(self, other, rtol=0.0, atol=0.0):
         """Check for equality.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         other : instance of Transform
             The other transform.
         rtol : float
@@ -159,8 +159,8 @@ class Transform(dict):
     def __ne__(self, other, rtol=0.0, atol=0.0):
         """Check for inequality.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         other : instance of Transform
             The other transform.
         rtol : float
@@ -200,7 +200,13 @@ class Transform(dict):
         write_trans(fname, self, overwrite=overwrite, verbose=verbose)
 
     def copy(self):
-        """Make a copy of the transform."""
+        """Make a copy of the transform.
+
+        Returns
+        -------
+        trans : instance of Transform
+            The copied transform.
+        """
         return deepcopy(self)
 
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -69,25 +69,20 @@ tfr_arithmetics_return_template = """
 Returns
 -------
 tfr : instance of RawTFR | instance of EpochsTFR | instance of AverageTFR
-    {}
-"""
+    {}"""
 
-tfr_add_sub_template = """
-Parameters
+tfr_add_sub_template = """Parameters
 ----------
 other : instance of RawTFR | instance of EpochsTFR | instance of AverageTFR
     The TFR instance to {}. Must have the same type as ``self``, and matching
     ``.times`` and ``.freqs`` attributes.
-
 {}
 """
 
-tfr_mul_truediv_template = """
-Parameters
+tfr_mul_truediv_template = """Parameters
 ----------
 num : int | float
     The number to {} by.
-
 {}
 """
 

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -362,6 +362,11 @@ class GetEpochsMixin:
 
         This method resets the object iteration state to the first epoch.
 
+        Returns
+        -------
+        epochs : instance of Epochs
+            The instance itself, to iterate over with :meth:`~mne.Epochs.next`.
+
         Notes
         -----
         This enables the use of this Python pattern::

--- a/mne/utils/progressbar.py
+++ b/mne/utils/progressbar.py
@@ -139,7 +139,13 @@ class ProgressBar:
             pass
 
     def __iter__(self):
-        """Iterate to auto-increment the pbar with 1."""
+        """Iterate to auto-increment the pbar with 1.
+
+        Yields
+        ------
+        item : object
+            The next item of the wrapped iterable.
+        """
         yield from self._tqdm
 
     def subset(self, idx):

--- a/tools/vulture_allowlist.py
+++ b/tools/vulture_allowlist.py
@@ -178,3 +178,6 @@ _show_help_fig
 # Called by Qt, or only from a subprocess (mne/viz/backends/tests/test_utils.py)
 eventFilter
 _sigint_impl
+
+# Read by numpydoc's ClassDoc (also set in doc/conf.py)
+_.extra_public_methods


### PR DESCRIPTION
We were deciding "which docstrings do we need to make sure are correct" three different ways in `test_docstring_parameters.py`. This unifies them, and expands them slightly by checking dunders that we render in our public API doc (previously we just checked `__call__`). This identified several issues, plus there was a `verbose=False` that should have been `verbose=None`.

The `__getitem__` docstring changes are a bit odd, but they are more true now about how these instances can be used.

Changes drafted by Claude Fable 5 and reviewed by me.