### PR TITLE
Speed up cluster index list construction in permutation cluster tests

### DIFF
--- a/doc/changes/dev/14217.newfeature.rst
+++ b/doc/changes/dev/14217.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up the permutation cluster tests (e.g., :func:`mne.stats.spatio_temporal_cluster_1samp_test`), especially with TFCE, by grouping cluster indices with a single sort instead of one pass over the data per cluster, by :newcontrib:`Luca Kaemmer`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -253,6 +253,7 @@
 .. _Lorenzo Alfine: https://github.com/lorrandal
 .. _Lorenzo Desantis: https://github.com/lorenzo-desantis/
 .. _Louis Thibault: https://github.com/lthibault
+.. _Luca Kaemmer: https://github.com/Lucakaemmer
 .. _Lukas Breuer: https://www.researchgate.net/profile/Lukas-Breuer-2
 .. _Lukas Gemein: https://github.com/gemeinl
 .. _Lukas Hecker: https://github.com/LukeTheHecker

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -87,12 +87,23 @@ def _get_labels_st(x_in, adjacency, max_step):
     return active, labels
 
 
+def _labels_to_clusters(active, labels):
+    """Group active indices by component label into a list of index arrays."""
+    # A stable sort keeps clusters in ascending label order and indices in
+    # ascending order within each cluster, i.e., the same output as masking
+    # once per label, but without the O(n_active * n_clusters) cost.
+    order = np.argsort(labels, kind="stable")
+    active = active[order]
+    labels = labels[order]
+    return np.split(active, np.flatnonzero(np.diff(labels)) + 1)
+
+
 def _get_clusters_st(x_in, adjacency, max_step=1):
     """Find spatio-temporal clusters via SciPy connected components."""
     active, labels = _get_labels_st(x_in, adjacency, max_step)
     if labels is None:
         return []
-    return [active[labels == id_] for id_ in np.unique(labels)]
+    return _labels_to_clusters(active, labels)
 
 
 def _get_cluster_sums_st(x, x_in, adjacency, max_step, t_power):
@@ -142,7 +153,7 @@ def _get_components(x_in, adjacency):
     active, labels = _get_labels(x_in, adjacency)
     if labels is None:
         return []
-    return [active[labels == id_] for id_ in np.unique(labels)]
+    return _labels_to_clusters(active, labels)
 
 
 def _get_cluster_sums(x, x_in, adjacency, t_power):

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -19,6 +19,7 @@ from mne import MixedSourceEstimate, SourceEstimate, SourceSpaces, VolSourceEsti
 from mne.stats import combine_adjacency, ttest_ind_no_p
 from mne.stats.cluster_level import (
     _find_clusters,
+    _labels_to_clusters,
     _TTestReordered,
     f_oneway,
     permutation_cluster_1samp_test,
@@ -732,6 +733,22 @@ def test_find_clusters_sums_only(kind, t_power):
     clusters_none, sums_only = _find_clusters(x, sums_only=True, **kwargs)
     assert clusters_none is None
     assert_allclose(sorted(sums_only), sorted(sums_full))
+
+
+def test_labels_to_clusters():
+    """Test grouping of active indices by component label."""
+    rng = np.random.default_rng(0)
+    active = np.sort(rng.choice(500, 200, replace=False))
+    labels = rng.integers(0, 30, size=200)
+    got = _labels_to_clusters(active, labels)
+    want = [active[labels == label] for label in np.unique(labels)]
+    assert len(got) == len(want) == len(np.unique(labels))
+    for a, b in zip(got, want):
+        assert_array_equal(a, b)
+    # a single cluster
+    got = _labels_to_clusters(active, np.zeros(200, int))
+    assert len(got) == 1
+    assert_array_equal(got[0], active)
 
 
 def test_spatio_temporal_cluster_adjacency(numba_conditional):


### PR DESCRIPTION
#### Reference issue (if any)

Follow-up to #13731 and #14057.

#### What does this implement/fix?

Since #13731/#14057, `_get_clusters_st` and `_get_components` build the list of cluster index arrays with

    [active[labels == id_] for id_ in np.unique(labels)]

which goes through `labels` once per cluster. With many clusters this is the main cost of a permutation, especially for TFCE, where it happens at every threshold. This PR replaces it with a stable argsort followed by `np.split`, in a small helper used by both functions. The result is the same list (same clusters, same order), just built in one pass. A small test for the helper is included.

Timings on a 12 x 143 x 143 lattice (245,388 points, 12 "subjects" of Gaussian noise, `tail=1`; Apple M3, numpy 2.5.2, scipy 1.18.1, numba 0.67.0):

| | main | this PR |
|---|---|---|
| `_find_clusters`, TFCE (`start=0, step=0.2`), global adjacency | 2.03 s | 0.50 s |
| `_find_clusters`, TFCE, spatial adjacency with `max_step=1` | 1.91 s | 0.40 s |
| `_find_clusters`, `threshold=0.5` (14,788 clusters) | 0.28 s | 0.03 s |
| `permutation_cluster_1samp_test`, TFCE, 20 permutations | 57 s | 12 s |

Cluster indices, cluster sums, TFCE scores, `T_obs`, `H0` and p-values are identical between `main` and this branch on these inputs.

#### Additional information

Drafted and tested the initial implementation with Claude Fable 5.
