### PR TITLE
Read BrainVision data in cache-sized blocks

### DIFF
--- a/doc/changes/dev/14241.newfeature.rst
+++ b/doc/changes/dev/14241.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up :func:`mne.io.read_raw_brainvision` by reading binary data in cache-sized blocks, by `Bruno Aristimunha`_.

--- a/mne/_fiff/utils.py
+++ b/mne/_fiff/utils.py
@@ -214,6 +214,7 @@ def _read_segments_file(
     n_channels=None,
     offset=0,
     trigger_ch=None,
+    max_block_bytes=int(100e6),
 ):
     """Read a chunk of raw data."""
     if n_channels is None:
@@ -225,8 +226,12 @@ def _read_segments_file(
     data_offset = n_channels * start * n_bytes + offset
     data_left = (stop - start) * n_channels
 
-    # Read up to 100 MB of data at a time, block_size is in data samples
-    block_size = ((int(100e6) // n_bytes) // n_channels) * n_channels
+    # Read up to max_block_bytes of data at a time; block_size is in data
+    # samples and spans whole channel frames
+    # never below one complete channel frame, or the loop would not advance
+    block_size = max(
+        n_channels, ((max_block_bytes // n_bytes) // n_channels) * n_channels
+    )
     block_size = min(data_left, block_size)
     with open(raw.filenames[fi], "rb", buffering=0) as fid:
         fid.seek(data_offset)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -35,6 +35,9 @@ from ...utils import (
 )
 from ..base import BaseRaw
 
+# read in cache-sized blocks rather than one huge one
+_BLOCK_BYTES = 8 * 1024**2
+
 
 @fill_doc
 class RawBrainVision(BaseRaw):
@@ -191,6 +194,7 @@ class RawBrainVision(BaseRaw):
                 mult,
                 dtype=dtype,
                 n_channels=n_data_ch,
+                max_block_bytes=_BLOCK_BYTES,
             )
         else:
             offsets = self._raw_extras[fi]["offsets"]

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -20,6 +20,7 @@ from mne._fiff.constants import FIFF
 from mne.annotations import events_from_annotations
 from mne.datasets import testing
 from mne.io import read_raw_brainvision, read_raw_fif
+from mne.io.brainvision import brainvision
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import _record_warnings, _stamp_to_dt, object_diff
 
@@ -1163,3 +1164,15 @@ def test_ahdr_format():
     assert raw.info["nchan"] == expected_num_channels
     assert raw.info["highpass"] == expected_hp
     assert raw.info["lowpass"] == expected_lp
+
+
+@pytest.mark.parametrize("block_bytes", (100, 1))  # partial frame, sub-frame
+def test_read_block_size_does_not_change_data(block_bytes, monkeypatch):
+    """Test the size of the read blocks does not change the decoded data."""
+    want = read_raw_brainvision(vhdr_path, preload=True).get_data()
+    # neither budget is a whole number of channel frames, so the read splits
+    # into many blocks whose edges must still land on frame boundaries; a
+    # budget below one frame must still make progress rather than hang
+    monkeypatch.setattr(brainvision, "_BLOCK_BYTES", block_bytes)
+    got = read_raw_brainvision(vhdr_path, preload=True).get_data()
+    assert_array_equal(want, got)


### PR DESCRIPTION
#### Reference issue (if any)

None. Split out of #14237, which was too large to review as one change.

#### What does this implement/fix?

`_read_segments_file` read up to 100 MB of a binary file at a time. Letting a
caller pick a smaller budget, and having BrainVision ask for 8 MiB, keeps the
working set in cache.

Preloading a 101 MB `.eeg` (32 channels, 404 MB decoded, built by repeating the
`test.eeg` payload), warm page cache, min of 5 per process, 3 interleaved A/B
rounds against a pristine `main` worktree on the same machine:

| | main | this PR |
|---|---|---|
| BrainVision preload | 61.5 / 62.7 / 63.4 ms | 54.0 / 54.3 / 55.3 ms |

That is ~1.15x, and the rounds do not overlap.

The default stays `int(100e6)`, so the other eight callers of
`_read_segments_file` (EGI, Curry, Artemis123, Nicolet, Eximia, EEGLAB, FIL,
NSx) read exactly as before — only BrainVision opts in.

`block_size` is also floored at one complete channel frame. A budget smaller
than a frame would otherwise round it to zero and the read loop would not
advance.

#### Correctness

Output is bit-identical to `main` on all 13 BrainVision fixtures in the repo
plus the 101 MB file, compared with `np.array_equal`.

The new test reads the same file twice with very different block budgets and
asserts the data matches. Both budgets are deliberately *not* whole numbers of
channel frames, so a block size that stopped landing on frame boundaries is
caught; the sub-frame case pins the floor described above. Mutation-tested:
making blocks frame-unaligned and adding an off-by-one to the block size are
both caught.

#### Additional information

AI disclosure: I directed the work and reviewed and tested everything; Claude
Code (Claude Opus 5) made the code edits, built the benchmark fixture and ran
the A/B measurements under my direction.
