### PR TITLE
Replace linear channel-name lookups with dictionaries

### DIFF
--- a/doc/changes/dev/14245.newfeature.rst
+++ b/doc/changes/dev/14245.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up channel selection and projector construction by replacing linear channel-name lookups with dictionaries, by `Bruno Aristimunha`_.

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -319,13 +319,17 @@ def pick_channels(ch_names, include, exclude=(), ordered=True, *, verbose=None):
         include = list(ch_names)
     if not isinstance(exclude, list):
         exclude = list(exclude)
+    # ch_names is unique (checked above), so a lookup table is safe here; the
+    # list scans this replaces made the loop quadratic in the channel count
+    name_to_idx = {name: ii for ii, name in enumerate(ch_names)}
+    exclude_set = set(exclude)
     sel, missing = list(), list()
     for name in include:
-        if name in ch_names:
-            if name not in exclude:
-                sel.append(ch_names.index(name))
-        else:
+        idx = name_to_idx.get(name)
+        if idx is None:
             missing.append(name)
+        elif name not in exclude_set:
+            sel.append(idx)
     if len(missing) and ordered:
         raise ValueError(
             f"Missing channels from ch_names required by include:\n{missing}"
@@ -1408,13 +1412,20 @@ def _picks_str_to_idx(
     # second: match all to channel names
     #
 
+    # setdefault keeps the first occurrence, so this matches list.index()
+    # exactly even for duplicate names (which are rejected further down, so
+    # the difference is not reachable today -- it just keeps the swap honest)
+    name_to_idx = {}
+    for ii, name in enumerate(info["ch_names"]):
+        name_to_idx.setdefault(name, ii)
     bad_names = []
     picks_name = list()
     for pick in picks:
-        try:
-            picks_name.append(info["ch_names"].index(pick))
-        except ValueError:
+        idx = name_to_idx.get(pick)
+        if idx is None:
             bad_names.append(pick)
+        else:
+            picks_name.append(idx)
 
     #
     # third: match all to types

--- a/mne/_fiff/proj.py
+++ b/mne/_fiff/proj.py
@@ -889,11 +889,15 @@ def _make_projector(projs, ch_names, bads=(), include_active=True, inplace=False
             # the projection vectors omitting bad channels
             sel = []
             vecsel = []
-            p_set = set(p["data"]["col_names"])  # faster membership access
+            # map name -> position once; .index() here made this loop quadratic
+            # in the channel count (~16x slower at 306 channels, ~47x at 1000)
+            p_idx = {name: i for i, name in enumerate(p["data"]["col_names"])}
             for c, name in enumerate(ch_names):
-                if name not in bads and name in p_set:
-                    sel.append(c)
-                    vecsel.append(p["data"]["col_names"].index(name))
+                if name not in bads:
+                    vi = p_idx.get(name)
+                    if vi is not None:
+                        sel.append(c)
+                        vecsel.append(vi)
 
             # If there is something to pick, pickit
             nrow = p["data"]["nrow"]

--- a/mne/_fiff/tests/test_pick.py
+++ b/mne/_fiff/tests/test_pick.py
@@ -762,3 +762,28 @@ def test_get_channel_types_equiv(meg, eeg, ordered):
     types = np.array(raw.get_channel_types(picks=picks))
     types_iter = np.array([channel_type(raw.info, idx) for idx in picks])
     assert_array_equal(types, types_iter)
+
+
+def test_pick_channels_matches_by_name():
+    """Test picking maps names to positions regardless of the order given."""
+    ch_names = ["a", "b", "c", "d"]
+    # include is out of order, repeats a name, and names one that is excluded
+    sel = pick_channels(ch_names, ["d", "b", "b", "c"], exclude=["c"], ordered=False)
+    assert_array_equal(sel, [1, 3])
+    # with ordered=True the caller's order is kept, duplicates and all
+    sel = pick_channels(ch_names, ["d", "b", "b"], ordered=True)
+    assert_array_equal(sel, [3, 1, 1])
+    # a name that is not present is an error, not a silent skip
+    with pytest.raises(ValueError, match="Missing channels"):
+        pick_channels(ch_names, ["a", "nope"], ordered=True)
+
+
+def test_picks_to_idx_duplicate_names():
+    """Test a repeated channel name resolves to its first position."""
+    with pytest.warns(RuntimeWarning, match="not unique"):
+        info = create_info(["a", "b", "a"], 100.0, "eeg")
+    # "b" is unambiguous; picking it must not be shifted by the duplicate "a"
+    assert_array_equal(_picks_to_idx(info, ["b"]), [1])
+    # an ambiguous name is rejected rather than silently resolved
+    with pytest.raises(ValueError, match="could not be interpreted"):
+        _picks_to_idx(info, ["a"])

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -832,3 +832,18 @@ def test_compute_proj_explained_variance():
             if proj["desc"].split("-")[0] == type_
         ]
         assert n_vector_ <= sum(explained_var)
+
+
+def test_make_projector_matches_by_name():
+    """Test projector columns are matched by channel name, not by position."""
+    ch_names = ["EEG 001", "EEG 002", "EEG 003"]
+    # col_names deliberately permuted, so a positional match gives the wrong
+    # vector: the direction is [2, 3, 1] in ch_names order, not [1, 2, 3]
+    proj = _make_test_proj(["EEG 003", "EEG 001", "EEG 002"], [1.0, 2.0, 3.0], "perm")
+    P, nproj, _ = make_projector([proj], ch_names)
+    assert nproj == 1
+    direction = np.array([2.0, 3.0, 1.0])
+    assert_allclose(P @ direction, 0.0, atol=1e-12)
+    # and a channel the projector does not mention is left untouched
+    P, _, _ = make_projector([proj], ch_names + ["EEG 004"])
+    assert_allclose(P[3], [0, 0, 0, 1], atol=1e-12)


### PR DESCRIPTION
#### Reference issue (if any)

None. Found while profiling a read → pick → filter → epoch → average workflow.

#### What does this implement/fix?

Three places in `mne/_fiff` matched channel names by scanning a list, which is
quadratic in the channel count:

- `_make_projector()` called `col_names.index(name)` inside a loop over
  `ch_names`. A `set` was already used for the membership test, but the lookup
  next to it still scanned.
- `pick_channels()` did three list scans per included channel:
  `name in ch_names`, `name not in exclude`, and `ch_names.index(name)`.
- `_picks_str_to_idx()` called `info["ch_names"].index(pick)` once per pick.

Each becomes a single dict lookup. `ch_names` is already asserted unique in
`pick_channels`, and duplicate `col_names` already raise in `_make_projector`.
In `_picks_str_to_idx` the map is built with `setdefault`, so it keeps
`list.index()`'s first-match semantics exactly, even though ambiguous names are
rejected further down anyway.

Medians of 3 interleaved A/B rounds against a pristine `main` worktree:

| | 128 ch | 306 ch | 1000 ch |
|---|---|---|---|
| `pick_channels` | 2.1x | 3.6x | 10.2x |
| `_picks_to_idx` | 1.4x | 2.3x | 6.4x |
| `_make_projector` | 1.6x | 2.9x | 3.3x |

End to end, `apply_proj()` on a 392-channel raw goes 21.7 → 17.8 ms. The
speedup grows with channel count, so it matters most for whole-head MEG and
high-density EEG.

#### Correctness

- 24/24 projector matrices bit-identical to `main` across six real MEG files,
  with and without bad channels.
- 700 fuzzed `pick_channels` / `_picks_to_idx` cases identical, including
  duplicate names, absent names, `ordered=True/False`, and the exceptions
  raised.
- `pytest mne/_fiff mne/io mne/tests mne/preprocessing mne/channels`:
  3506 passed, 0 failed.

Two tests are added. They pin *name-based* mapping specifically: the projector
test uses `col_names` permuted relative to `ch_names`, so a positional match
annihilates the wrong direction and fails. Mutation-tested — substituting
position for name in either function is caught, as is dropping the `bads`
filter, ignoring `exclude`, and silently skipping missing names.

#### Additional information

AI disclosure: I directed the work and reviewed and tested everything; Claude
Code (Claude Opus 5) did the profiling that found these, made the edits, and
ran the A/B measurements and fuzzing under my direction.
