### PR TITLE
Speed up evoked time plotting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ jobs:
         default: "false"
     machine:
       <<: *machine_image
-    # large 4 vCPUs 15GB mem
+    # large.gen3 4 vCPUs 16GiB mem -- gen3 is an open beta, and is both faster
+    # and cheaper per minute than gen1 large (14 vs 20 credits/min); revert to
+    # `large` if beta queue times or reliability become a problem
     # https://discuss.circleci.com/t/changes-to-remote-docker-reporting-pricing/47759
-    resource_class: large
+    resource_class: large.gen3
     steps:
       - restore_cache:
           keys:
@@ -431,7 +433,7 @@ jobs:
         default: "false"
     machine:
       <<: *machine_image
-    resource_class: large
+    resource_class: large.gen3
     steps:
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,10 @@ _check_skip: &check_skip
       circleci-agent step halt;
     fi
 
+# gen3 resource classes are only valid with the `current` tag, not a pinned
+# dated tag -- a pinned tag is rejected with "is not a valid resource class"
 _machine_image: &machine_image
-  image: ubuntu-2604:2026.05.1
+  image: ubuntu-2604:current
 
 jobs:
   build_docs:

--- a/doc/changes/dev/14249.newfeature.rst
+++ b/doc/changes/dev/14249.newfeature.rst
@@ -1,0 +1,1 @@
+Sped up various evoked plotting functions by taking advantage of blitting, by `Eric Larson`_

--- a/doc/changes/dev/14249.newfeature.rst
+++ b/doc/changes/dev/14249.newfeature.rst
@@ -1,1 +1,1 @@
-Sped up various evoked plotting functions by taking advantage of blitting, by `Eric Larson`_
+Sped up various evoked plotting functions by taking advantage of blitting, and :class:`mne.Report` image embedding by compressing rendered pixels directly, by `Eric Larson`_

--- a/mne/gui/tests/test_dipolefit.py
+++ b/mne/gui/tests/test_dipolefit.py
@@ -173,7 +173,7 @@ def test_dipolefit_gui_basic(
     assert g._time_text.get_position()[0] == 0.09
     # both move with the time, so they are drawn on top of a cached background
     # rather than triggering a full redraw of the traces plot
-    blit_artists = g._renderer._mplcanvas._blit_artists
+    blit_artists = g._renderer._mplcanvas._blit._artists
     assert blit_artists == [g._time_line, g._time_text]
 
     g.fit_dipole()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -419,7 +419,7 @@ def _compress_img(img, image_format, dpi):
         # 20 rather than 50 encodes ~1.5x faster for a few percent more bytes
         pil_kwargs.update(lossless=True, quality=20)
     else:
-        assert image_format == "png", image_format
+        assert image_format == "png", image_format  # _fig_to_img checks this
         pil_kwargs.update(optimize=True, compress_level=9)
     background = Image.new("RGBA", img.size, (255, 255, 255))
     img = Image.alpha_composite(background, img).convert("RGB")
@@ -441,6 +441,12 @@ def _fig_to_img(
     # fig can be ndarray, mpl Figure, PyVista Figure
     import matplotlib.pyplot as plt
     from matplotlib.figure import Figure
+
+    # Report validates its own image_format, but add_figure and friends pass whatever
+    # they are given straight through, and e.g. "PNG" is used in the docs
+    _validate_type(image_format, str, "image_format")
+    image_format = image_format.lower()
+    _check_option("image_format", image_format, _ALLOWED_IMAGE_FORMATS + ("ndarray",))
 
     if isinstance(fig, np.ndarray):
         # In this case, we are creating the fig, so we might as well

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -408,6 +408,26 @@ def _constrain_fig_resolution(fig, *, max_width, max_res):
         fig.set_dpi(dpi)
 
 
+def _compress_img(img, image_format, dpi):
+    """Drop the alpha channel and compress, for space and to avoid rendering issues."""
+    from PIL import Image
+
+    # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
+    pil_kwargs = dict()
+    if image_format == "webp":
+        # Here quality means speed/size tradeoff (either way the result is lossless);
+        # 20 rather than 50 encodes ~1.5x faster for a few percent more bytes
+        pil_kwargs.update(lossless=True, quality=20)
+    else:
+        assert image_format == "png", image_format
+        pil_kwargs.update(optimize=True, compress_level=9)
+    background = Image.new("RGBA", img.size, (255, 255, 255))
+    img = Image.alpha_composite(background, img).convert("RGB")
+    output = BytesIO()
+    img.save(output, format=image_format, dpi=(dpi, dpi), **pil_kwargs)
+    return output
+
+
 def _fig_to_img(
     fig,
     *,
@@ -425,10 +445,22 @@ def _fig_to_img(
     if isinstance(fig, np.ndarray):
         # In this case, we are creating the fig, so we might as well
         # auto-close in all cases
-        fig = _ndarray_to_fig(fig)
+        img, fig = fig, _ndarray_to_fig(fig)
+        dpi = fig.get_dpi()
         if own_figure:
             _constrain_fig_resolution(fig, max_width=max_width, max_res=max_res)
         own_figure = True  # close the figure we just created
+        if fig.get_dpi() == dpi and image_format in ("png", "webp"):
+            # Nothing rescaled the pixels, so compress them as they are rather than
+            # rendering them back through the figure only to read them out again
+            from PIL import Image
+
+            plt.close(fig)
+            if img.dtype.kind == "f":  # float in [0, 1], as _fig_to_img returns
+                img = np.clip(img, 0, 1) * 255
+            img = Image.fromarray(img.astype(np.uint8)).convert("RGBA")
+            output = _compress_img(img, image_format, dpi)
+            return base64.b64encode(output.getvalue()).decode("ascii")
     elif isinstance(fig, Figure):
         if own_figure:
             _constrain_fig_resolution(fig, max_width=max_width, max_res=max_res)
@@ -484,20 +516,10 @@ def _fig_to_img(
     if image_format not in ("svg", "ndarray"):
         from PIL import Image
 
-        # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
-        pil_kwargs = dict()
-        if image_format == "webp":
-            # Here quality means speed/size tradeoff (either way the result is lossless)
-            pil_kwargs.update(lossless=True, quality=50)
-        elif image_format == "png":
-            pil_kwargs.update(optimize=True, compress_level=9)
         output.seek(0)
         orig = Image.open(output)
         if orig.mode == "RGBA":
-            background = Image.new("RGBA", orig.size, (255, 255, 255))
-            new = Image.alpha_composite(background, orig).convert("RGB")
-            output = BytesIO()
-            new.save(output, format=image_format, dpi=(dpi, dpi), **pil_kwargs)
+            output = _compress_img(orig, image_format, dpi)
 
     if image_format == "ndarray":
         # float in [0, 1], like the PNG this used to go through

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -496,17 +496,19 @@ def _fig_to_img(
     logger.debug(
         f"Saving figure with dimension {fig.get_size_inches()} inches with {dpi} dpi"
     )
-    if image_format == "ndarray":
-        # Raw RGBA: the caller wants the rendered pixels, so encoding them as PNG
-        # only to decode them again below is pure overhead.
+    if image_format == "svg":
+        mpl_format = "svg"
+    elif image_format != "ndarray" and "bbox_inches" in mpl_kwargs:
+        # bbox_inches changes the rendered size, so the raw buffer could no longer be
+        # reshaped from the figure's own bbox
+        mpl_format = "png"
+    else:
+        # Raw RGBA: the pixels are all that is wanted below, so encoding them as PNG
+        # only to decode them again is pure overhead.
         mpl_format = "rgba"
         # Agg truncates the figure size to whole pixels (`RendererAgg.__init__`),
         # so rounding here would mis-shape the buffer at fractional DPI
         shape = (int(fig.bbox.size[1]), int(fig.bbox.size[0]), 4)
-    elif image_format == "svg":
-        mpl_format = "svg"
-    else:
-        mpl_format = "png"
     fig.savefig(output, format=mpl_format, dpi=dpi, **mpl_kwargs)
 
     if own_figure:
@@ -516,8 +518,13 @@ def _fig_to_img(
     if image_format not in ("svg", "ndarray"):
         from PIL import Image
 
-        output.seek(0)
-        orig = Image.open(output)
+        if mpl_format == "rgba":
+            orig = Image.frombuffer(
+                "RGBA", shape[1::-1], output.getbuffer(), "raw", "RGBA", 0, 1
+            )
+        else:
+            output.seek(0)
+            orig = Image.open(output)
         if orig.mode == "RGBA":
             output = _compress_img(orig, image_format, dpi)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -230,7 +230,7 @@ def _html_slider_element(
         tags=tags,
         title=title,
         start_idx=start_idx,
-        image_format=image_format,
+        image_format=_mime_format(image_format),
         klass=klass,
         show="show" if show else "",
     )
@@ -255,7 +255,7 @@ def _html_image_element(
         caption=caption,
         tags=tags,
         title=title,
-        image_format=image_format,
+        image_format=_mime_format(image_format),
         div_klass=div_klass,
         img_klass=img_klass,
         embedded=embedded,
@@ -418,6 +418,9 @@ def _compress_img(img, image_format, dpi):
         # Here quality means speed/size tradeoff (either way the result is lossless);
         # 20 rather than 50 encodes ~1.5x faster for a few percent more bytes
         pil_kwargs.update(lossless=True, quality=20)
+    elif image_format == "webp-lossy":
+        # ~as cheap to encode as PNG and ~3x smaller, at the cost of exactness
+        pil_kwargs.update(lossless=False, quality=90)
     else:
         assert image_format == "png", image_format  # _fig_to_img checks this
         # optimize=True forces maximum effort regardless of compress_level and
@@ -426,7 +429,7 @@ def _compress_img(img, image_format, dpi):
     background = Image.new("RGBA", img.size, (255, 255, 255))
     img = Image.alpha_composite(background, img).convert("RGB")
     output = BytesIO()
-    img.save(output, format=image_format, dpi=(dpi, dpi), **pil_kwargs)
+    img.save(output, format=_mime_format(image_format), dpi=(dpi, dpi), **pil_kwargs)
     return output
 
 
@@ -458,7 +461,7 @@ def _fig_to_img(
         if own_figure:
             _constrain_fig_resolution(fig, max_width=max_width, max_res=max_res)
         own_figure = True  # close the figure we just created
-        if fig.get_dpi() == dpi and image_format in ("png", "webp"):
+        if fig.get_dpi() == dpi and image_format not in ("svg", "ndarray"):
             # Nothing rescaled the pixels, so compress them as they are rather than
             # rendering them back through the figure only to read them out again
             from PIL import Image
@@ -797,7 +800,12 @@ def open_report(fname, **params):
 mne_logo_path = Path(__file__).parents[1] / "icons" / "mne_icon-cropped.png"
 mne_logo = base64.b64encode(mne_logo_path.read_bytes()).decode("ascii")
 
-_ALLOWED_IMAGE_FORMATS = ("png", "svg", "webp")
+_ALLOWED_IMAGE_FORMATS = ("png", "svg", "webp", "webp-lossy")
+
+
+def _mime_format(image_format):
+    """Strip our lossy/lossless qualifier to get the PIL/MIME name."""
+    return image_format.split("-")[0]
 
 
 def _check_image_format(rep, image_format):
@@ -830,16 +838,20 @@ class Report:
         Name of the file containing the noise covariance.
     %(baseline_report)s
         Defaults to ``None``, i.e. no baseline correction.
-    image_format : 'png' | 'svg' | 'webp' | 'auto'
+    image_format : 'png' | 'svg' | 'webp' | 'webp-lossy' | 'auto'
         Default image format to use (default is ``'auto'``, which will use
         ``'webp'`` if available and ``'png'`` otherwise).
         ``'svg'`` uses vector graphics, so fidelity is higher but can increase
         file size and browser image rendering time as well.
+        ``'webp-lossy'`` gives much smaller files than the (lossless) ``'webp'``
+        at a comparable encoding cost, at the price of exact pixel fidelity.
 
         .. versionadded:: 0.15
         .. versionchanged:: 1.3
            Added support for ``'webp'`` format, removed support for GIF, and
            set the default to ``'auto'``.
+        .. versionchanged:: 1.13
+           Added support for ``'webp-lossy'`` format.
     raw_psd : bool | dict
         If True, include PSD plots for raw files. Can be False (default) to
         omit, True to plot, or a dict to pass as ``kwargs`` to

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -23,7 +23,6 @@ from shutil import copyfile
 
 import matplotlib
 import numpy as np
-from matplotlib.animation import AbstractMovieWriter
 
 from .. import __version__ as MNE_VERSION
 from .._fiff.meas_info import Info, read_info
@@ -85,7 +84,7 @@ from ..viz import (
 from ..viz._brain.view import views_dicts
 from ..viz._scraper import _mne_qt_browser_screenshot
 from ..viz.misc import _get_bem_plotting_surfaces, _plot_mri_contours
-from ..viz.utils import _ndarray_to_fig
+from ..viz.utils import _BlitManager, _ndarray_to_fig
 
 _BEM_VIEWS = ("axial", "sagittal", "coronal")
 
@@ -369,27 +368,6 @@ def _check_tags(tags) -> tuple[str]:
 # PLOTTING FUNCTIONS
 
 
-class _NdArrayCapture(AbstractMovieWriter):
-    def __init__(self, frames: list):
-        super().__init__(fps=1, metadata={}, bitrate=0)
-        self.frames = frames
-
-    def grab_frame(self, **savefig_kwargs):
-        img = _fig_to_img(
-            fig=self.fig, image_format="ndarray", pad_inches=0, **savefig_kwargs
-        )
-        self.frames.append(img)
-
-    def save(self, filename, *args, **kwargs):
-        pass
-
-    def finish(self):
-        pass
-
-    def setup(self, fig, outfile, dpi=None):
-        self.fig = fig
-
-
 def _use_agg(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -486,7 +464,17 @@ def _fig_to_img(
     logger.debug(
         f"Saving figure with dimension {fig.get_size_inches()} inches with {dpi} dpi"
     )
-    mpl_format = "svg" if image_format == "svg" else "png"
+    if image_format == "ndarray":
+        # Raw RGBA: the caller wants the rendered pixels, so encoding them as PNG
+        # only to decode them again below is pure overhead.
+        mpl_format = "rgba"
+        # Agg truncates the figure size to whole pixels (`RendererAgg.__init__`),
+        # so rounding here would mis-shape the buffer at fractional DPI
+        shape = (int(fig.bbox.size[1]), int(fig.bbox.size[0]), 4)
+    elif image_format == "svg":
+        mpl_format = "svg"
+    else:
+        mpl_format = "png"
     fig.savefig(output, format=mpl_format, dpi=dpi, **mpl_kwargs)
 
     if own_figure:
@@ -512,8 +500,9 @@ def _fig_to_img(
             new.save(output, format=image_format, dpi=(dpi, dpi), **pil_kwargs)
 
     if image_format == "ndarray":
-        output.seek(0)
-        output = plt.imread(output, format="png")
+        # float in [0, 1], like the PNG this used to go through
+        output = np.frombuffer(output.getbuffer(), np.uint8).reshape(shape)
+        output = output.astype(np.float32) / 255
     else:
         output = output.getvalue()
         if image_format == "svg":
@@ -3893,8 +3882,6 @@ class Report:
             fig.delaxes(axes[1, 1])
             axes = axes.ravel()[:3]
             axes[0].set_title(ch_type)
-            frames[ch_type] = list()
-            this_writer = _NdArrayCapture(frames[ch_type])
             _, ch_anim = evoked.animate_topomap(
                 times=times,
                 ch_type=ch_type,
@@ -3903,10 +3890,22 @@ class Report:
                 show=False,
                 time_format="",  # we impose our own in HTML
                 butterfly=True,
+                blit=False,  # we do our own, `Animation.save` cannot blit at all
                 **topomap_kwargs,
             )
+            _constrain_fig_resolution(fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES)
+            fig.canvas.draw()  # the animation does its initial draw here
             ch_anim.pause()
-            ch_anim.save("", writer=this_writer)
+            # Only the topomap image, its contours and the butterfly cursor change
+            # from one frame to the next, so blit those onto a cached picture of the
+            # rest of the figure and read the pixels straight out of the canvas.
+            blit = _BlitManager(fig)
+            frames[ch_type] = list()
+            for frame in range(len(times)):
+                blit.update(ch_anim.mne_frame_func(frame))
+                frames[ch_type].append(
+                    np.asarray(fig.canvas.buffer_rgba(), dtype=np.float32) / 255
+                )
             plt.close(fig)
             del (
                 fig,

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -514,8 +514,6 @@ def _fig_to_img(
         # reshaped from the figure's own bbox
         mpl_format = "png"
     else:
-        # Raw RGBA: the pixels are all that is wanted below, so encoding them as PNG
-        # only to decode them again is pure overhead.
         mpl_format = "rgba"
         # Agg truncates the figure size to whole pixels (`RendererAgg.__init__`),
         # so rounding here would mis-shape the buffer at fractional DPI
@@ -530,6 +528,7 @@ def _fig_to_img(
         from PIL import Image
 
         if mpl_format == "rgba":
+            # Raw RGBA: the pixels can be decoded directly
             orig = Image.frombuffer(
                 "RGBA", shape[1::-1], output.getbuffer(), "raw", "RGBA", 0, 1
             )

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -420,7 +420,9 @@ def _compress_img(img, image_format, dpi):
         pil_kwargs.update(lossless=True, quality=20)
     else:
         assert image_format == "png", image_format  # _fig_to_img checks this
-        pil_kwargs.update(optimize=True, compress_level=9)
+        # optimize=True forces maximum effort regardless of compress_level and
+        # encodes ~3x slower for ~1% fewer bytes, so favor speed here
+        pil_kwargs.update(compress_level=6)
     background = Image.new("RGBA", img.size, (255, 255, 255))
     img = Image.alpha_composite(background, img).convert("RGB")
     output = BytesIO()

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -33,6 +33,7 @@ from mne.report import report as report_mod
 from mne.report.report import (
     _ALLOWED_IMAGE_FORMATS,
     CONTENT_ORDER,
+    _fig_to_img,
 )
 from mne.utils import Bunch, _record_warnings
 from mne.utils._testing import assert_object_equal
@@ -207,6 +208,9 @@ def test_render_report(renderer_pyvistaqt, tmp_path, invisible_fig):
 
     # ndarray support smoke test
     report.add_figure(fig=np.zeros((2, 3, 3)), title="title")
+    # ... and the reverse: a figure whose size is not a whole number of pixels
+    fig = plt.figure(figsize=(2.8, 2.8), dpi=89.6)
+    assert _fig_to_img(fig, image_format="ndarray").shape == (250, 250, 4)
 
     with pytest.raises(TypeError, match="It seems you passed a path"):
         report.add_figure(fig="foo", title="title")

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -1394,7 +1394,8 @@ def test_image_format(image_format):
     r = Report(image_format=image_format)
     fig1, _ = _get_example_figures()
     r.add_figure(fig1, "fig1")
-    assert image_format in r.html[0]
+    assert image_format.removesuffix("-lossy") in r.html[0]
+    assert "-lossy" not in r.html[0]  # not a MIME type
 
 
 def test_gif(tmp_path):

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -211,6 +211,10 @@ def test_render_report(renderer_pyvistaqt, tmp_path, invisible_fig):
     # ... and the reverse: a figure whose size is not a whole number of pixels
     fig = plt.figure(figsize=(2.8, 2.8), dpi=89.6)
     assert _fig_to_img(fig, image_format="ndarray").shape == (250, 250, 4)
+    # add_figure does not validate image_format, so _fig_to_img normalizes and checks
+    report.add_figure(fig=fig, title="upper", image_format="PNG")  # used in the docs
+    with pytest.raises(ValueError, match="Invalid value for the 'image_format'"):
+        report.add_figure(fig=fig, title="bad", image_format="jpeg")
 
     with pytest.raises(TypeError, match="It seems you passed a path"):
         report.add_figure(fig="foo", title="title")

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -1682,29 +1682,26 @@ def test_brain_time_line_blitting(renderer_interactive_pyvistaqt, brain_gc):
     brain = _create_testing_brain(hemi="lh", show_traces=True, initial_time=0)
     canvas = brain.mpl_canvas
     assert canvas.canvas.supports_blit
-    assert brain.time_line in canvas._blit_artists
-    assert brain.time_line.get_animated()
+    assert brain.time_line in canvas._blit._artists
 
     n_draws = list()
     canvas.canvas.mpl_connect("draw_event", lambda event: n_draws.append(event))
-    canvas.update_plot()  # a full redraw caches the background ...
-    assert canvas._blit_background is not None
-    assert len(n_draws) == 1
-
-    brain.set_time(brain._times[-1])  # ... so moving the time line only blits
+    brain.set_time(brain._times[-1])  # one redraw caches the background ...
     assert brain.time_line.get_xdata()[0] == brain._times[-1]
+    assert canvas._blit._background is not None
     assert len(n_draws) == 1
 
-    # adding a trace still redraws in full, and anything can be blitted
+    brain.set_time(brain._times[len(brain._times) // 2])  # ... then it only blits
+    assert len(n_draws) == 1
+
+    # a full redraw invalidates the background, and anything can be blitted
     text = canvas.axes.text(0, 0, "hello")
     canvas.add_blit_artist(text)
-    assert text.get_animated()
-    canvas.update_blit_artists()  # background was dropped, so this redraws
+    canvas.update_blit_artists()  # the background was dropped, so this redraws
     assert len(n_draws) == 2
 
     canvas.remove_blit_artist(text)
-    assert not text.get_animated()
-    assert text not in canvas._blit_artists
+    assert text not in canvas._blit._artists
     assert len(n_draws) == 3  # restored to the background by a full redraw
     brain.close()
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -8,6 +8,7 @@ import warnings
 from abc import ABC, abstractmethod
 
 from ..ui_events import TimeChange, publish
+from ..utils import _BlitManager
 
 
 class Figure3D(ABC):
@@ -1429,12 +1430,7 @@ class _AbstractMplCanvas(ABC):
         self.axes = self.fig.add_subplot(111)
         self.axes.set(xlabel="Time (s)", ylabel="Activation (AU)")
         self.manager = None
-        # Artists that are redrawn on their own (see `add_blit_artist`), the
-        # background they are drawn onto, and the draw_event callback id that
-        # keeps that background up to date.
-        self._blit_artists = list()
-        self._blit_background = None
-        self._blit_cid = None
+        self._blit = _BlitManager(self.fig, draw=self.update_plot)
 
     def _connect(self):
         for event in ("button_press", "motion_notify") + self._extra_events:
@@ -1458,36 +1454,19 @@ class _AbstractMplCanvas(ABC):
     def add_blit_artist(self, artist):
         """Mark an artist as fast-updating, to be drawn by :meth:`update_blit_artists`.
 
-        Such an artist is excluded from the canvas background, so that moving it
-        (e.g. the time line, or a label that travels with it) costs a blit of the
-        cached background rather than a full redraw of the figure.
-
         Parameters
         ----------
         artist : instance of matplotlib.artist.Artist
-            The artist to draw separately. Must live in this canvas's axes: an
-            artist added to the figure itself would be left out of saved images,
-            because Matplotlib only exempts *Axes* children from the rule that
-            animated artists are not drawn (see ``_AxesBase.draw``).
+            The artist to draw separately. Must live in this canvas's axes, and be
+            drawn on top of the curves, as blitting draws it over a cached picture
+            of the rest of the figure.
         """
-        if not self.canvas.supports_blit:  # e.g. ipympl in a notebook
-            return
         if artist.axes is not self.axes:
             raise RuntimeError(
                 f"{artist!r} must be an artist of this canvas's axes to be drawn "
                 "separately, got one in " + repr(artist.axes)
             )
-        if artist in self._blit_artists:
-            return
-        artist.set_animated(True)
-        self._blit_artists.append(artist)
-        # the cached background may already contain this artist, so drop it and
-        # let the next update redraw (and re-cache) the figure without it
-        self._blit_background = None
-        if self._blit_cid is None:
-            # Grab a fresh background after every full redraw, whatever caused it
-            # (update_plot, draw_idle, a resize, a DPI change, ...).
-            self._blit_cid = self.canvas.mpl_connect("draw_event", self._on_draw)
+        self._blit.add(artist)
 
     def remove_blit_artist(self, artist):
         """Stop drawing an artist separately, putting it back in the background.
@@ -1498,11 +1477,7 @@ class _AbstractMplCanvas(ABC):
             The artist to stop drawing separately. Artists that were never added
             are ignored.
         """
-        if artist not in self._blit_artists:
-            return
-        self._blit_artists.remove(artist)
-        artist.set_animated(False)
-        self.update_plot()  # redraw so the artist becomes part of the background
+        self._blit.remove(artist)
 
     def update_blit_artists(self):
         """Redraw only the artists added with :meth:`add_blit_artist`.
@@ -1510,24 +1485,7 @@ class _AbstractMplCanvas(ABC):
         This is the fast path taken while the time line moves; any other change
         to the figure needs :meth:`update_plot` instead.
         """
-        if self._blit_background is None or not self._blit_artists:
-            self.update_plot()  # nothing cached yet (or nothing to draw fast)
-            return
-        self.canvas.restore_region(self._blit_background)
-        self._draw_blit_artists()
-        self.canvas.blit(self.fig.bbox)
-
-    def _draw_blit_artists(self):
-        for artist in self._blit_artists:
-            self.fig.draw_artist(artist)
-
-    def _on_draw(self, event=None):
-        """Cache the background after a full redraw (draw_event callback)."""
-        self._blit_background = self.canvas.copy_from_bbox(self.fig.bbox)
-        if not self.canvas.is_saving():
-            # When saving, Matplotlib draws animated artists itself; drawing them
-            # again here would just double up their antialiasing.
-            self._draw_blit_artists()
+        self._blit.update()
 
     def update_plot(self):
         """Update the plot."""
@@ -1584,11 +1542,7 @@ class _AbstractMplCanvas(ABC):
     def clear(self):
         """Clear internal variables."""
         self.close()
-        if self._blit_cid is not None:
-            self.canvas.mpl_disconnect(self._blit_cid)
-            self._blit_cid = None
-        self._blit_artists.clear()  # the artists go away with the figure below
-        self._blit_background = None
+        self._blit.close()
         self.axes.clear()
         self.fig.clear()
         self.canvas = None

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -49,6 +49,7 @@ from .topomap import (
 from .ui_events import TimeChange, publish, subscribe
 from .utils import (
     DraggableColorbar,
+    _BlitManager,
     _check_cov,
     _check_delayed_ssp,
     _check_option,
@@ -587,6 +588,10 @@ def _plot_lines(
     sphere = _check_sphere(sphere, info)
     path_effects = [patheffects.withStroke(linewidth=2, foreground="w", alpha=0.75)]
     gfp_path_effects = [patheffects.withStroke(linewidth=5, foreground="w", alpha=0.75)]
+    # The time cursors and the hover label are the only artists that move, so draw
+    # them on top of a cached background rather than redrawing every channel's trace.
+    blit_manager = _BlitManager(fig)
+
     if selectable:
         selectables = np.ones(len(ch_types_used), dtype=bool)
         for type_idx, this_type in enumerate(ch_types_used):
@@ -632,22 +637,29 @@ def _plot_lines(
                 else:
                     text.set_alpha(0.0)
                     text.set_path_effects([])
+                blit_manager.add(text)
 
             # vertical line to indicate time point
             for ax in axes:
                 line = getattr(ax, "_cursorline", None)
                 if line is None:
-                    ax._cursorline = ax.axvline(event.xdata, color="black", alpha=0.2)
+                    # zorder: blitting draws the cursor over a cached picture of the
+                    # rest of the figure, so it has to be on top of the traces for
+                    # the blitted figure to match a full redraw
+                    line = ax._cursorline = ax.axvline(
+                        event.xdata, color="black", alpha=0.2, zorder=len(ax.lines)
+                    )
+                    blit_manager.add(line)
                 else:
                     line.set_xdata([event.xdata, event.xdata])
-            ax.figure.canvas.draw_idle()
+                    line.set_visible(True)
+            blit_manager.update()
 
         def _rm_cursor(event):
             for ax in axes:
                 if getattr(ax, "_cursorline", None) is not None:
-                    ax._cursorline.remove()
-                    ax._cursorline = None
-            ax.figure.canvas.draw_idle()
+                    ax._cursorline.set_visible(False)
+            blit_manager.update()
 
         def _select_time(event):
             for ax in axes:
@@ -886,10 +898,13 @@ def _plot_lines(
         for ax in axes:
             line = getattr(ax, "_selectline", None)
             if line is None:
-                ax._selectline = ax.axvline(event.time, color="black", alpha=1)
+                ax._selectline = ax.axvline(
+                    event.time, color="black", alpha=1, zorder=len(ax.lines)
+                )
+                blit_manager.add(ax._selectline)
             else:
                 line.set_xdata([event.time, event.time])
-        ax.figure.canvas.draw()
+        blit_manager.update()
 
     subscribe(fig, "time_change", on_time_change)
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -184,6 +184,17 @@ def test_plot_topomap_animation(capsys, tmp_path):
     assert "extrapolation mode local to mean" in out
     assert fig.axes[0].images[0].get_cmap().name == "viridis"
 
+    # everything drawn on top of the topomap image must be returned by the animation
+    # function, otherwise blitting leaves it frozen at the first frame (gh-14242)
+    items = anim.mne_frame_func(1)  # has to be tested separately on the 'Agg' backend
+    ax = fig.axes[0]
+    zorder = ax.images[0].get_zorder()
+    on_top = [
+        a for a in ax.lines + ax.collections + ax.texts if a.get_zorder() > zorder
+    ]
+    assert len(on_top) > 2  # at least the time label, head outlines and sensors
+    assert set(on_top).issubset(items)
+
     # saving
     PIL = pytest.importorskip("PIL")
     gif_path = tmp_path / "test.gif"
@@ -222,7 +233,7 @@ def test_plot_topomap_animation_csd(capsys):
     _, anim = evoked_csd.animate_topomap(
         ch_type="csd", times=[0, 0.1], butterfly=False, time_unit="s", verbose="debug"
     )
-    anim._func(1)  # _animate has to be tested separately on 'Agg' backend.
+    anim.mne_frame_func(1)  # has to be tested separately on the 'Agg' backend
     out, _ = capsys.readouterr()
     assert "extrapolation mode head to mean" in out
 
@@ -964,7 +975,7 @@ def test_plot_projs_topomap_opm(triaxial_evoked):
 def test_animate_topomap_opm(triaxial_evoked):
     """Test animate_topomap does not crash on colocated OPM channels (gh-13866)."""
     fig, anim = triaxial_evoked.animate_topomap(ch_type="mag", times=[0.0], show=False)
-    anim._func(0)
+    anim.mne_frame_func(0)
     assert len(fig.axes) >= 1
 
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -17,6 +17,7 @@ from .ui_events import ChannelsSelect, TimeChange, link, publish, subscribe
 from .utils import (
     DraggableColorbar,
     SelectFromCollection,
+    _BlitManager,
     _check_cov,
     _check_delayed_ssp,
     _draw_proj_checkbox,
@@ -1172,7 +1173,7 @@ def _plot_evoked_topo(
 
     setattr(fig, "_current_time", None)
 
-    def _on_time_change(event, fig, tmin, tmax):
+    def _on_time_change(event, fig, blit, tmin, tmax):
         """Respond to a time change UI event."""
         fig._current_time = event.time
 
@@ -1188,11 +1189,14 @@ def _plot_evoked_topo(
                     color=font_color,
                     linewidth=0.5,
                 )
+                blit.add(subax.time_cursor)
             else:
                 subax.time_cursor.set_xdata([time, time])
             # Hide the vertical line when the time is out of bounds.
             subax.time_cursor.set_visible(tmin <= event.time <= tmax)
-        fig.canvas.draw()
+        # the cursors are the only thing that moves, so blit them onto a cached
+        # background instead of redrawing every channel's traces
+        blit.update()
 
     subscribe(
         fig,
@@ -1200,6 +1204,7 @@ def _plot_evoked_topo(
         partial(
             _on_time_change,
             fig=fig,
+            blit=_BlitManager(fig),
             tmin=np.min([t[0] for t in times]),
             tmax=np.max([t[-1] for t in times]),
         ),

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -434,7 +434,7 @@ class _NoOpAxes(matplotlib.axes.Axes):
     but :func:`_update_contours` only wants the geometry it computes.
     """
 
-    def add_collection(self, collection, autolim=True):
+    def add_collection(self, collection, *args, **kwargs):
         return collection
 
     def update_datalim(self, *args, **kwargs):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -7,10 +7,13 @@
 import copy
 import itertools
 import warnings
-from functools import partial
+from functools import cache, partial
 from numbers import Integral
 
 import matplotlib.artist
+import matplotlib.axes
+import matplotlib.contour
+import matplotlib.figure
 import matplotlib.patches
 import numpy as np
 
@@ -419,24 +422,44 @@ def _plot_update_evoked_topomap(params, bools):
     ):
         Zi = interp.set_values(d)()
         im.set_data(Zi)
-        new_contours.append(_update_contours(cont, ax, Xi, Yi, Zi, params["contours"]))
+        new_contours.append(_update_contours(cont, Xi, Yi, Zi, params["contours"]))
     params["contours_"][:] = new_contours
     params["fig"].canvas.draw()
 
 
-def _update_contours(cont, ax, Xi, Yi, Zi, contours):
+class _NoOpAxes(matplotlib.axes.Axes):
+    """Axes that throws away whatever is drawn on it.
+
+    `~matplotlib.contour.QuadContourSet` attaches itself to an Axes on construction,
+    but :func:`_update_contours` only wants the geometry it computes.
+    """
+
+    def add_collection(self, collection, autolim=True):
+        return collection
+
+    def update_datalim(self, *args, **kwargs):
+        pass
+
+    def autoscale_view(self, *args, **kwargs):
+        pass
+
+
+@cache
+def _no_op_axes():
+    """Get the one throwaway Axes used to compute contour geometry."""
+    return _NoOpAxes(matplotlib.figure.Figure(), [0, 0, 1, 1])
+
+
+def _update_contours(cont, Xi, Yi, Zi, contours):
     if cont is None:
         return cont
-    lw = cont.get_linewidth()
-    visible = cont.get_visible()
-    patch_ = cont.get_clip_path()
-    color = cont.get_edgecolors()
-    zorder = _TOPOMAP_ZORDER["contours"]
-    if cont in ax.collections:
-        cont.remove()
-    cont = ax.contour(Xi, Yi, Zi, contours, colors=color, linewidths=lw, zorder=zorder)
-    cont.set_visible(visible)
-    cont.set_clip_path(patch_)
+    # Swap the new geometry into the existing artist rather than replacing it: adding
+    # an artist marks the figure stale, and an interactive backend then services that
+    # pending draw from inside ``canvas.blit()`` -- a full redraw, which omits every
+    # animated artist and so undoes the blit. Keeping the artist also keeps its color,
+    # linewidth, zorder and clip path, which used to have to be copied over.
+    new = matplotlib.contour.QuadContourSet(_no_op_axes(), Xi, Yi, Zi, levels=contours)
+    cont.set_paths(new.get_paths())
     return cont
 
 
@@ -3644,9 +3667,21 @@ def _topomap_animation(
     if butterfly:
         ax_line.plot(all_times, all_data.T, color="k", lw=0.5, alpha=0.5)
         ax_line.set_xlim(all_times[0], all_times[-1])
-        butterfly_vline = ax_line.axvline(used_times[0], color="r")
+        # zorder: above the axes spines, otherwise drawing the cursor on top of a
+        # cached background (blitting) does not match a full redraw
+        butterfly_vline = ax_line.axvline(used_times[0], color="r", zorder=3)
 
     params = dict(frame=0, frames=list(range(len(used_times))), pause=False, cont=cont)
+    # Blitting draws only the artists that ``animate`` returns, on top of a cached
+    # background, so everything sitting on top of the topomap image (time label, head
+    # outlines, sensor markers, channel names, ...) has to be redrawn along with it.
+    overdrawn = [
+        artist
+        for artist in ax.lines + ax.collections + ax.texts
+        if artist.get_zorder() > im.get_zorder() and artist is not cont
+    ]
+    if butterfly:
+        overdrawn.append(butterfly_vline)
     del cont
 
     def animate(frame):
@@ -3655,10 +3690,12 @@ def _topomap_animation(
         im.set_data(Zi)
         if time_format:
             text.set_text(time_format % (used_times[frame] * scaling_time))
-        params["cont"] = _update_contours(params["cont"], ax, Xi, Yi, Zi, contours)
-        items = [im]
+        params["cont"] = _update_contours(params["cont"], Xi, Yi, Zi, contours)
         if butterfly:
             butterfly_vline.set_xdata([used_times[frame]])
+        items = [im] + overdrawn
+        if params["cont"] is not None:
+            items.append(params["cont"])
         return _validate_artists(items)
 
     interval = 1000 / frame_rate  # interval is in ms
@@ -3696,6 +3733,9 @@ def _topomap_animation(
     fig.canvas.mpl_connect("key_press_event", key_press)
 
     fig.mne_animation = anim  # to make sure anim is not garbage collected
+    # Matplotlib only keeps the frame function privately (as ``anim._func``), and
+    # drawing a single frame without the timer is useful (e.g. in Report)
+    anim.mne_frame_func = animate
     plt_show(show, block=False)
 
     return fig, anim

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -676,6 +676,137 @@ def _key_press(event):
         plt.close(event.canvas.figure)
 
 
+class _BlitManager:
+    """Redraw a few fast-changing artists without redrawing the whole figure.
+
+    Artists added with :meth:`add` are left out of the cached figure background, so
+    that moving them (a time cursor, a label that travels with it, ...) costs a blit
+    of that background rather than a full redraw of the figure. They are drawn on top
+    of that background, so they should be the topmost artists of their axes for the
+    blitted figure to match a full redraw.
+
+    Parameters
+    ----------
+    fig : instance of matplotlib.figure.Figure
+        The figure to blit.
+    draw : callable | None
+        What to call for a full, *synchronous* redraw of the figure. Defaults to the
+        figure canvas' ``draw``.
+    """
+
+    def __init__(self, fig, draw=None):
+        self._fig = fig
+        self._draw = fig.canvas.draw if draw is None else draw
+        self._artists = list()
+        self._background = None
+        self._capturing = False
+        self._cid = None
+        # Connect as early as possible: Matplotlib's blitting widgets redraw the
+        # figure from inside their own draw_event callback (see
+        # `SpanSelector.update_background`), so a manager connected after one of
+        # those would see a canvas they had already drawn on.
+        self._connect()
+
+    def add(self, artist):
+        """Mark an artist as fast-updating, to be drawn by :meth:`update`.
+
+        Parameters
+        ----------
+        artist : instance of matplotlib.artist.Artist
+            The artist to draw separately.
+        """
+        self._connect()
+        if not self._fig.canvas.supports_blit:  # e.g. ipympl in a notebook
+            return
+        if artist in self._artists:
+            return
+        self._artists.append(artist)
+        self._background = None  # the cached background may contain this artist
+
+    def remove(self, artist):
+        """Stop drawing an artist separately, putting it back in the background.
+
+        Parameters
+        ----------
+        artist : instance of matplotlib.artist.Artist
+            The artist to stop drawing separately. Artists that were never added
+            are ignored.
+        """
+        if artist not in self._artists:
+            return
+        self._artists.remove(artist)
+        self._background = None
+        self._draw()
+
+    def update(self, artists=None):
+        """Redraw only the artists added with :meth:`add`.
+
+        This is the fast path taken while the artists move; any other change to the
+        figure needs a full redraw instead.
+
+        Parameters
+        ----------
+        artists : list of matplotlib.artist.Artist | None
+            Artists to draw instead of the ones added so far, for callers that
+            rebuild some of them for every frame (e.g. a contour set, which
+            Matplotlib cannot update in place). The cached background stays valid,
+            as it never contained any of them.
+        """
+        if artists is not None and self._fig.canvas.supports_blit:
+            self._artists = list(artists)
+        if not self._artists:  # nothing to draw fast (e.g. blitting unsupported)
+            self._draw()
+            return
+        if self._background is None:
+            self._capture()
+        self._fig.canvas.restore_region(self._background)
+        self._draw_artists()
+        self._fig.canvas.blit(self._fig.bbox)
+
+    def close(self):
+        """Forget the artists and stop tracking the figure background."""
+        if self._cid is not None:
+            self._fig.canvas.mpl_disconnect(self._cid)
+            self._cid = None
+        self._artists.clear()  # the artists go away with the figure
+        self._background = None
+
+    def _connect(self):
+        # Drop the cached background after every full redraw, whatever caused it (an
+        # explicit draw, a resize, a DPI change, ...). The canvas can still be missing
+        # when the manager is built alongside its figure, hence the retry from
+        # :meth:`add`.
+        if self._cid is None and self._fig.canvas is not None:
+            self._cid = self._fig.canvas.mpl_connect("draw_event", self._on_draw)
+
+    def _capture(self):
+        """Cache a picture of the figure without the fast-updating artists."""
+        # Hiding the artists for one redraw is how Matplotlib's own blitting widgets
+        # keep themselves out of their background, see `SpanSelector.update_background`.
+        # Marking them ``animated`` instead would keep them out of *every* redraw,
+        # which costs those same widgets a full redraw of the figure per draw event.
+        visible = [artist.get_visible() for artist in self._artists]
+        self._capturing = True
+        try:
+            for artist in self._artists:
+                artist.set_visible(False)
+            self._draw()
+            self._background = self._fig.canvas.copy_from_bbox(self._fig.bbox)
+        finally:
+            for artist, was_visible in zip(self._artists, visible):
+                artist.set_visible(was_visible)
+            self._capturing = False
+
+    def _draw_artists(self):
+        for artist in sorted(self._artists, key=lambda artist: artist.get_zorder()):
+            self._fig.draw_artist(artist)
+
+    def _on_draw(self, event=None):
+        """Drop the cached background after a full redraw (draw_event callback)."""
+        if not self._capturing:  # ... except the one :meth:`_capture` just asked for
+            self._background = None
+
+
 class ClickableImage:
     """Display an image so you can click on it and store x/y positions.
 

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -70,7 +70,7 @@ python -m pip install $STD_ARGS \
 	git+https://github.com/the-siesta-group/edfio \
 	trame trame-vtk "trame-vuetify!=3.2.3" trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
 	openmeeg imageio-ffmpeg xlrd mffpy traitlets pybv eeglabio defusedxml antio curryreader \
-	filelock
+	jamica filelock
 echo "::endgroup::"
 
 echo "::group::Make sure we're on a NumPy 2.0 variant"

--- a/tools/vulture_allowlist.py
+++ b/tools/vulture_allowlist.py
@@ -192,3 +192,6 @@ _.extra_public_methods
 
 # Accessed through an attribute-path string by the _qt_safe_window decorator
 _._init_renderer
+
+# Called by Matplotlib on the _NoOpAxes a ContourSet attaches itself to
+_.update_datalim

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -156,11 +156,10 @@ report.save("report_evoked.html", overwrite=True)
 # Adding `~mne.Covariance`
 # ^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# (Noise) covariance objects can be added via
-# :meth:`mne.Report.add_covariance`. The method accepts `~mne.Covariance`
-# objects and the path to a file on disk. It also expects us to pass an
-# `~mne.Info` object or the path to a file to read the measurement info from,
-# as well as a title.
+# (Noise) covariance objects can be added via :meth:`mne.Report.add_covariance`. The
+# method accepts `~mne.Covariance` objects and the path to a file on disk. It also
+# expects us to pass an `~mne.Info` object or the path to a file to read the measurement
+# info from, as well as a title.
 
 cov_path = sample_dir / "sample_audvis-cov.fif"
 


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/14242

@wmvanvliet I generalized our blit code. Looks like it's actually pretty clean, steps:

1. Generalize our `brain` blit code to a more general version `_BlitManager`
2. Use that version in 3D plotting
3. Use that version in `evoked.plot` and `evoked.plot_topo`
4. Use that version in our animate_topomap code
5. Speed up animate_topomap by actually blitting properly (working around a matplotilb issue where the figure would silently invalidate and draw nothing if you tried to use the correct blit path)

Minor changes to evoked.plot and evoked.topo are that the time `axvline` will stay on top now, but I think that's reasonable (and expected).

(5) was a pain to discover -- turns out to be caused by the modification of the contours, which removes and re-adds the set to the axes, which invalidates the draw, causing a full redraw (with nothing left to draw, so you get a blank plot). The workaround I came up with is to add a dummy no-op `ax` class pass to the `contour` call, and then pull the contours from it. I'm going to work on upstreaming a warning about this and a less-hacky way to get the contours... but it might be a bit to land etc. In the meantime I think the no-op class is workable, and has a big performance boost.

(5) speeds up `report.add_evoked` from about 8s to 5s by dropping the timepoint code from over 3s to under 1s.

I then also sped up how images are embedded in reports to cut down another second off that 5s `add_evokeds`.

I used Claude Opus 5 to investigate (iterating / reviewing multiple versions).