### PR TITLE
Read EGI simple-binary event channels in blocks

### DIFF
--- a/doc/changes/dev/14250.newfeature.rst
+++ b/doc/changes/dev/14250.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up :func:`mne.io.read_raw_egi` on simple-binary files by reading the event channels in blocks instead of one sample at a time, by `Bruno Aristimunha`_.

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -79,15 +79,27 @@ def _read_header(fid):
     return info
 
 
+# read whole frames a few MB at a time rather than the whole recording at once
+_EVENT_BLOCK_BYTES = 4 * 1024**2
+
+
 def _read_events(fid, info):
     """Read events."""
-    events = np.zeros([info["n_events"], info["n_segments"] * info["n_samples"]])
+    n_samples = info["n_samples"]
+    # Each sample is one frame of n_channels data values followed by n_events
+    # event values, so read whole frames and keep the event rows. Seeking past
+    # the data channels instead costs a seek and a read per sample, which
+    # dominates the time to open a long recording.
+    n_rows = info["n_channels"] + info["n_events"]
+    events = np.zeros([info["n_events"], info["n_segments"] * n_samples])
     fid.seek(36 + info["n_events"] * 4, 0)  # skip header
-    for si in range(info["n_samples"]):
-        # skip data channels
-        fid.seek(info["n_channels"] * info["dtype"].itemsize, 1)
-        # read event channels
-        events[:, si] = np.fromfile(fid, info["dtype"], info["n_events"])
+    n_block = max(1, _EVENT_BLOCK_BYTES // (n_rows * info["dtype"].itemsize))
+    for start in range(0, n_samples, n_block):
+        n_read = min(n_block, n_samples - start)
+        frames = np.fromfile(fid, info["dtype"], n_read * n_rows)
+        events[:, start : start + n_read] = frames.reshape(n_read, n_rows).T[
+            info["n_channels"] :
+        ]
     return events
 
 


### PR DESCRIPTION
#### What does this implement/fix?

`_read_events()` walks a simple-binary EGI file **one time sample at a time**:
for every sample it seeks past the data channels and issues a separate
`np.fromfile` for that sample's event values. Opening a file therefore costs two
Python-level I/O calls per sample.

Samples are stored as interleaved frames — `n_channels` data values followed by
`n_events` event values — so the same bytes can be read a few MB at a time and
the event rows sliced out. Same reads, ~4000x fewer calls.

#### Numbers

Median of 5 interleaved process pairs against a pristine `main` worktree:

| file | main | this PR | |
|---|---|---|---|
| 32 MB, 30800 samples, 256 ch | 170.3 ms | 10.8 ms | **15.7x** |
| shipped `test_egi.raw` (79 KB) | 1.96 ms | 1.53 ms | 1.28x |

Beforehand `cProfile` put `_read_events` at **89% of `read_raw_egi`** (0.194 s of
0.219 s, 30821 `np.fromfile` calls). The cost is linear in recording length, so
it grows with the file — the fixture above is only ~2 minutes of data.

#### Correctness

- Bit-identical to `main`: data arrays **and annotations** compared with
  `np.array_equal` (the annotations matter here — they are built from exactly
  these event channels).
- Memory stays bounded: the loop reads 4 MiB at a time rather than slurping the
  whole recording, so the seeks are not traded for a large allocation.
- `pytest mne/io/egi`: 26 passed.

#### Caveats

No fixture in the testing dataset is long enough to show this, so CI cannot
demonstrate it. The large file was synthesised by tiling the shipped fixture's
data section and patching `n_samples` in the header; I verified the header
layout matches the file exactly before tiling.

#### Additional information

AI disclosure: I directed the work and reviewed and tested every change; Claude
Code (Claude Opus 5) profiled the reader, ran the A/B measurements and made the
edits under my direction.
