### PR TITLE
Decode Persyst and Nihon Kohden data in cache-sized blocks

### DIFF
--- a/doc/changes/dev/14251.newfeature.rst
+++ b/doc/changes/dev/14251.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up :func:`mne.io.read_raw_persyst` and :func:`mne.io.read_raw_nihon` by decoding data in cache-sized blocks rather than materializing the whole request, by `Bruno Aristimunha`_.

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -418,6 +418,10 @@ def _map_ch_to_specs(ch_name, chan_labels_upper):
     return out
 
 
+# decode in cache-sized blocks rather than one huge one (1.8x on a 106 MB file)
+_BLOCK_BYTES = 1024**2
+
+
 @fill_doc
 class RawNihon(BaseRaw):
     """Raw object from a Nihon Kohden EEG file.
@@ -566,13 +570,20 @@ class RawNihon(BaseRaw):
                 rel_start = start - ends[start_block - 1]
             start_offset = datastart + rel_start * n_channels * 2
 
+            # Decode a few MB at a time: each step below builds a temporary the
+            # size of the block, so reading the whole request at once pushes
+            # them all out of cache.
+            n_times = stop - start
+            n_block = max(1, _BLOCK_BYTES // 2 // n_channels)
             with open(self.filenames[fi], "rb") as fid:
-                to_read = (stop - start) * n_channels
                 fid.seek(start_offset)
-                block_data = np.fromfile(fid, "<u2", to_read) + 0x8000
-                block_data = block_data.astype(np.int16)
-                block_data = block_data.reshape(n_channels, -1, order="F")
-                block_data = block_data[:-1] * cal  # cast to float64
-                block_data += offsets
-                block_data *= gains
-                _mult_cal_one(data, block_data, idx, cals, mult)
+                for sample_start in range(0, n_times, n_block):
+                    n_read = min(n_block, n_times - sample_start)
+                    block_data = np.fromfile(fid, "<u2", n_read * n_channels) + 0x8000
+                    block_data = block_data.astype(np.int16)
+                    block_data = block_data.reshape(n_channels, -1, order="F")
+                    block_data = block_data[:-1] * cal  # cast to float64
+                    block_data += offsets
+                    block_data *= gains
+                    data_view = data[:, sample_start : sample_start + n_read]
+                    _mult_cal_one(data_view, block_data, idx, cals, mult)

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from ..._fiff.constants import FIFF
 from ..._fiff.meas_info import create_info
-from ..._fiff.utils import _mult_cal_one
+from ..._fiff.utils import _read_segments_file
 from ...annotations import Annotations
 from ...utils import _check_fname, fill_doc, logger, verbose, warn
 from ..base import BaseRaw
@@ -53,6 +53,11 @@ def read_raw_persyst(
     directory as the lay file.
     """
     return RawPersyst(fname, preload, verbose)
+
+
+# read in cache-sized blocks rather than one huge one (2.3x on a 107 MB file);
+# see _read_segments_file() for why a smaller block is faster
+_BLOCK_BYTES = 16 * 1024**2
 
 
 @fill_doc
@@ -267,31 +272,19 @@ class RawPersyst(BaseRaw):
         binary files. In addition, it stores the calibration to convert
         data to uV in the lay file.
         """
-        dtype = self._raw_extras[fi]["dtype"]
-        n_chs = self._raw_extras[fi]["n_chs"]
-        dat_fname = self.filenames[fi]
-
-        # compute samples count based on start and stop
-        time_length_samps = stop - start
-
-        # read data from .dat file into array of correct size, then calibrate
-        # records = recnum rows x inf columns
-        count = time_length_samps * n_chs
-
-        # seek the dat file
-        with open(dat_fname, "rb") as dat_file_ID:
-            # allow offset to occur
-            dat_file_ID.seek(n_chs * dtype.itemsize * start, 1)
-
-            # read in the actual record starting at possibly offset
-            record = np.fromfile(dat_file_ID, dtype=dtype, count=count)
-
-        # chs * rows
-        # cast as float32; more than enough precision
-        record = np.reshape(record, (n_chs, -1), order="F").astype(np.float32)
-
-        # calibrate to convert to V and handle mult
-        _mult_cal_one(data, record, idx, cals, mult)
+        _read_segments_file(
+            self,
+            data,
+            idx,
+            fi,
+            start,
+            stop,
+            cals,
+            mult,
+            dtype=self._raw_extras[fi]["dtype"],
+            n_channels=self._raw_extras[fi]["n_chs"],
+            max_block_bytes=_BLOCK_BYTES,
+        )
 
 
 def _get_subjectinfo(patient_dict):


### PR DESCRIPTION
#### What does this implement/fix?

Two readers materialise the entire requested range before calibrating it, so
every intermediate is as large as the request and none of it stays in cache.

**Persyst** had a hand-rolled copy of `_read_segments_file()` plus one extra
full-size temporary: `np.reshape(record, (n_chs, -1), order="F").astype(np.float32)`.
`_mult_cal_one()` already casts, so that `.astype` was a whole-array copy for
nothing. The method is now a call to the shared helper — a net deletion.

**Nihon Kohden** reads the whole request and then builds four full-size
temporaries over it (`+ 0x8000`, `.astype(int16)`, `* cal` to float64, `+=`/`*=`).
Same work, now a block at a time.

#### Numbers

Median of 5 interleaved process pairs against a pristine `main` worktree:

| case | main | this PR | |
|---|---|---|---|
| Persyst, 107 MB | 88.7 ms | 39.3 ms | **2.26x** |
| Nihon, 106 MB | 267.6 ms | 147.7 ms | **1.81x** |
| Persyst shipped fixture | 0.12 ms | 0.12 ms | 1.05x |
| Nihon shipped fixture | 0.362 ms | 0.364 ms | 0.995x |

Persyst's gain splits cleanly: **1.32x** from dropping the redundant `.astype`
alone (shared helper at its 100 MB default), the rest from the smaller block.

The Nihon shipped-fixture figure is a median of 8 runs x 200 reps — at 0.36 ms a
single-shot comparison is pure noise (an early 7-rep run read 0.86x). That file
is 5800 samples and fits in one 1 MiB block, so it keeps its current code path
exactly.

#### Why the two constants differ

The optimum tracks time points per block, not bytes. Nihon has 25 channels and
builds four temporaries per block; its sweep improves monotonically down to
~256 KiB before falling off a cliff at 64 KiB, so 1 MiB is chosen for margin.
Persyst sits at 16 MiB. This is the same concern I raised on #14246 — a
`max_block_samples=` parameter would express it better than a per-reader byte
budget, and I am happy to go that way instead.

#### One behaviour change worth flagging

Dropping Persyst's `.astype(np.float32)` changes results for a 32-bit `.dat`
whose raw counts exceed `2**24`, where float32 was silently rounding them. That
is a precision fix rather than a regression, and 16-bit files (and the shipped
32-bit fixture, whose counts are well inside the range) are unaffected.

#### Correctness

- Bit-identical to `main` across every readable Persyst and Nihon Kohden
  fixture, including the synthesised large ones (`np.array_equal`, data and
  annotations).
- `pytest mne/io/persyst mne/io/nihon mne/_fiff`: 164 passed.

Large files were synthesised by tiling — Persyst derives its sample count from
the `.dat` file size, and Nihon's single data block was tiled with
`record_duration` patched. No shipped fixture is big enough to show the effect,
so CI cannot demonstrate it.

#### Additional information

AI disclosure: I directed the work and reviewed and tested every change; Claude
Code (Claude Opus 5) profiled the readers, ran the A/B measurements and made the
edits under my direction.
