### PR TITLE
Reuse the MEF session across reads

### DIFF
--- a/doc/changes/dev/14254.newfeature.rst
+++ b/doc/changes/dev/14254.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up windowed reads and epoching of MEF3 files by reusing the session across reads instead of reparsing its metadata each time, by `Bruno Aristimunha`_.

--- a/mne/io/mef/mef.py
+++ b/mne/io/mef/mef.py
@@ -191,6 +191,7 @@ class RawMEF(BaseRaw):
                     "n_channels": len(ch_names),
                     "ch_names": ch_names,
                     "password": password,
+                    "session": session,
                 }
             ],
             orig_units=orig_units,
@@ -235,7 +236,7 @@ class RawMEF(BaseRaw):
         """Read a chunk of raw data."""
         extras = self._raw_extras[fi]
         ch_names = extras["ch_names"]
-        session = _get_session(self._filenames[fi], extras)
+        session = extras["session"]
 
         ch_indices = (
             range(*idx.indices(extras["n_channels"])) if isinstance(idx, slice) else idx
@@ -253,22 +254,6 @@ class RawMEF(BaseRaw):
         block_out = np.zeros((extras["n_channels"], stop - start), dtype=data.dtype)
         block_out[idx] = raw_data
         _mult_cal_one(data, block_out, idx, cals, mult)
-
-
-def _get_session(fname, extras):
-    """Open a MEF session, reusing the one already opened for this file.
-
-    Parsing the session metadata costs ~38 ms on a 194-channel recording and
-    does not depend on the requested range, so opening it per read makes a short
-    window cost as much as reading the whole recording.
-    """
-    session = extras.get("session")
-    if session is None:
-        from pymef.mef_session import MefSession
-
-        session = MefSession(str(fname), extras.get("password", ""))
-        extras["session"] = session
-    return session
 
 
 @verbose

--- a/mne/io/mef/mef.py
+++ b/mne/io/mef/mef.py
@@ -233,11 +233,9 @@ class RawMEF(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        from pymef.mef_session import MefSession
-
         extras = self._raw_extras[fi]
         ch_names = extras["ch_names"]
-        session = MefSession(str(self._filenames[fi]), extras.get("password", ""))
+        session = _get_session(self._filenames[fi], extras)
 
         ch_indices = (
             range(*idx.indices(extras["n_channels"])) if isinstance(idx, slice) else idx
@@ -255,6 +253,22 @@ class RawMEF(BaseRaw):
         block_out = np.zeros((extras["n_channels"], stop - start), dtype=data.dtype)
         block_out[idx] = raw_data
         _mult_cal_one(data, block_out, idx, cals, mult)
+
+
+def _get_session(fname, extras):
+    """Open a MEF session, reusing the one already opened for this file.
+
+    Parsing the session metadata costs ~38 ms on a 194-channel recording and
+    does not depend on the requested range, so opening it per read makes a short
+    window cost as much as reading the whole recording.
+    """
+    session = extras.get("session")
+    if session is None:
+        from pymef.mef_session import MefSession
+
+        session = MefSession(str(fname), extras.get("password", ""))
+        extras["session"] = session
+    return session
 
 
 @verbose

--- a/mne/io/mef/tests/test_mef.py
+++ b/mne/io/mef/tests/test_mef.py
@@ -28,6 +28,7 @@ mef_file_path = (
 def test_mef_reading():
     """Test reading MEF3 file."""
     raw = read_raw_mef(mef_file_path, preload=False)
+    session = raw._raw_extras[0]["session"]
 
     assert raw.info["sfreq"] > 0
     assert len(raw.ch_names) > 0
@@ -36,6 +37,7 @@ def test_mef_reading():
     # Test lazy loading
     data, times = raw[:, :100]
     assert data.shape[1] == 100
+    assert raw._raw_extras[0]["session"] is session
 
     # Test full load
     raw.load_data()


### PR DESCRIPTION
#### What does this implement/fix?

`_read_segment_file` built a fresh `MefSession` on **every call**. Parsing the
session metadata takes ~38 ms on the 194-channel testing recording and does not
depend on the requested range, so a short window cost as much as reading the
whole file:

```
get_data(start=0, stop=100, picks=[one channel])  ->  39.0 ms
   of which  38.0 ms  read_mef_session_metadata
              0.02 ms actual data
```

This caches the session in `_raw_extras`, which `_ReadSegmentFileProtector`
already exposes to readers.

#### Numbers

Median of 3 interleaved process pairs against a pristine `main` worktree:

| request | main | this PR | |
|---|---|---|---|
| full read (194 ch x 98000) | 490.5 ms | 451.5 ms | 1.1x |
| 1000 samples, all channels | 47.2 ms | 7.2 ms | **6.6x** |
| 1000 samples, 4 channels | 39.7 ms | 0.19 ms | **206x** |
| 100 samples, 1 channel | 39.0 ms | 0.07 ms | **590x** |
| **100 epochs of 2 s** | **4895.6 ms** | **914.5 ms** | **5.4x** |

The epoching row is the one that matters in practice — every windowed read paid
the full metadata parse, so epoching, plotting and scrolling were all dominated
by it.

#### Safety

`MefSession` and `RawMef` are both picklable, so caching in `_raw_extras` does
not break `n_jobs`. Checked explicitly, all returning bit-identical data:

- `raw.copy()`, `copy.deepcopy(raw)`, `pickle` round-trip
- `crop()` after a cached read, `preload=True`, repeated reads
- `pytest mne/io/mef mne/io/tests`: 104 passed

#### What this does *not* fix

The remaining 451 ms of a full read is pymef decoding channel by channel
(`read_mef_ts_data`, 194 calls). **pymef does not release the GIL** — I measured
reading the channels across 4, 8 and 14 threads at 0.99x, and with per-thread
sessions it gets worse — so that floor cannot be moved from MNE.

#### Additional information

AI disclosure: I directed the work and reviewed and tested every change; Claude
Code (Claude Opus 5) profiled the reader, measured the GIL behaviour and the
pickling edge cases, and made the edits under my direction.
