### PR TITLE
Read KIT data in cache-sized blocks

### DIFF
--- a/doc/changes/dev/14255.newfeature.rst
+++ b/doc/changes/dev/14255.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up reading large KIT files by reading them in cache-sized blocks, by `Bruno Aristimunha`_.

--- a/mne/_fiff/utils.py
+++ b/mne/_fiff/utils.py
@@ -226,7 +226,7 @@ def _read_segments_file(
     n_channels=None,
     offset=0,
     trigger_ch=None,
-    max_block_bytes=int(100e6),
+    max_block_samples=None,
 ):
     """Read a chunk of raw data."""
     if n_channels is None:
@@ -238,12 +238,10 @@ def _read_segments_file(
     data_offset = n_channels * start * n_bytes + offset
     data_left = (stop - start) * n_channels
 
-    # Read up to max_block_bytes of data at a time; block_size is in data
-    # samples and spans whole channel frames
-    # never below one complete channel frame, or the loop would not advance
-    block_size = max(
-        n_channels, ((max_block_bytes // n_bytes) // n_channels) * n_channels
-    )
+    if max_block_samples is None:
+        max_block_samples = int(100e6) // n_bytes // n_channels
+    # block_size counts channel values and must span whole channel frames
+    block_size = max(1, max_block_samples) * n_channels
     block_size = min(data_left, block_size)
     with open(raw.filenames[fi], "rb", buffering=0) as fid:
         fid.seek(data_offset)

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -19,10 +19,6 @@ from ...utils import _check_fname, logger, verbose, warn
 from ..base import BaseRaw
 from .utils import _load_mne_locs, _read_pos
 
-# read in cache-sized blocks rather than one huge one (1.5x on a 176 MB file); see
-# _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 16 * 1024**2
-
 
 @verbose
 def read_raw_artemis123(
@@ -366,6 +362,8 @@ class RawArtemis123(BaseRaw):
             raise RuntimeError(f"{input_fname} - Not Found")
 
         info, header_info = _get_artemis123_info(input_fname, pos_fname=pos_fname)
+        # Cache-sized blocks are 1.5x faster on a 176 MB file.
+        header_info["max_block_samples"] = max(1, 16 * 1024**2 // 4 // info["nchan"])
 
         last_samps = [header_info.get("num_samples", 1) - 1]
 
@@ -550,5 +548,5 @@ class RawArtemis123(BaseRaw):
             cals,
             mult,
             dtype=">f4",
-            max_block_bytes=_BLOCK_BYTES,
+            max_block_samples=self._raw_extras[fi]["max_block_samples"],
         )

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -35,9 +35,6 @@ from ...utils import (
 )
 from ..base import BaseRaw
 
-# read in cache-sized blocks rather than one huge one
-_BLOCK_BYTES = 8 * 1024**2
-
 
 @fill_doc
 class RawBrainVision(BaseRaw):
@@ -147,6 +144,11 @@ class RawBrainVision(BaseRaw):
 
         orig_format = "single" if isinstance(fmt, dict) else fmt
         raw_extras = dict(offsets=offsets, fmt=fmt, order=order, n_samples=n_samples)
+        if not isinstance(fmt, dict):
+            # Read in cache-sized blocks rather than one huge one.
+            raw_extras["max_block_samples"] = max(
+                1, 8 * 1024**2 // dtype_bytes // n_data_ch
+            )
         super().__init__(
             info,
             last_samps=[n_samples - 1],
@@ -194,7 +196,7 @@ class RawBrainVision(BaseRaw):
                 mult,
                 dtype=dtype,
                 n_channels=n_data_ch,
-                max_block_bytes=_BLOCK_BYTES,
+                max_block_samples=self._raw_extras[fi]["max_block_samples"],
             )
         else:
             offsets = self._raw_extras[fi]["offsets"]

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -20,7 +20,6 @@ from mne._fiff.constants import FIFF
 from mne.annotations import events_from_annotations
 from mne.datasets import testing
 from mne.io import read_raw_brainvision, read_raw_fif
-from mne.io.brainvision import brainvision
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import _record_warnings, _stamp_to_dt, object_diff
 
@@ -1166,13 +1165,21 @@ def test_ahdr_format():
     assert raw.info["lowpass"] == expected_lp
 
 
-@pytest.mark.parametrize("block_bytes", (100, 1))  # partial frame, sub-frame
-def test_read_block_size_does_not_change_data(block_bytes, monkeypatch):
+@pytest.mark.parametrize("max_block_samples", (2, 1))
+def test_read_block_size_does_not_change_data(max_block_samples, monkeypatch):
     """Test the size of the read blocks does not change the decoded data."""
     want = read_raw_brainvision(vhdr_path, preload=True).get_data()
-    # neither budget is a whole number of channel frames, so the read splits
-    # into many blocks whose edges must still land on frame boundaries; a
-    # budget below one frame must still make progress rather than hang
-    monkeypatch.setattr(brainvision, "_BLOCK_BYTES", block_bytes)
-    got = read_raw_brainvision(vhdr_path, preload=True).get_data()
+    raw = read_raw_brainvision(vhdr_path, preload=False)
+    raw._raw_extras[0]["max_block_samples"] = max_block_samples
+    n_channels = raw._raw_extras[0]["orig_nchan"]
+    counts = []
+    fromfile = np.fromfile
+
+    def _fromfile(fid, dtype, count):
+        counts.append(count)
+        return fromfile(fid, dtype, count)
+
+    monkeypatch.setattr(np, "fromfile", _fromfile)
+    got = raw.load_data().get_data()
+    assert max(counts) == max_block_samples * n_channels
     assert_array_equal(want, got)

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -209,11 +209,6 @@ def _get_curry_recording_type(fname):
             return "evoked"
 
 
-# read in cache-sized blocks rather than one huge one (1.5x on a 107 MB file); see
-# _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 16 * 1024**2
-
-
 def _get_curry_epoch_info(fname):
     _soft_import("curryreader", "read epoch info")
     _soft_import("pandas", "dataframe integration")
@@ -795,7 +790,11 @@ class RawCurry(BaseRaw):
 
         # create raw object
         last_samps = [n_samples - 1]
-        raw_extras = dict(is_ascii=is_ascii)
+        # Cache-sized blocks are 1.5x faster on a 107 MB file.
+        raw_extras = dict(
+            is_ascii=is_ascii,
+            max_block_samples=max(1, 16 * 1024**2 // 4 // info["nchan"]),
+        )
         super().__init__(
             info,
             preload=False,
@@ -879,7 +878,7 @@ class RawCurry(BaseRaw):
                 cals,
                 mult,
                 dtype="<f4",
-                max_block_bytes=_BLOCK_BYTES,
+                max_block_samples=self._raw_extras[fi]["max_block_samples"],
             )
 
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -216,11 +216,6 @@ def _get_montage_information(eeg, get_pos, *, montage_units):
     return ch_names, ch_types, montage
 
 
-# read in cache-sized blocks rather than one huge one (2.1x on a 102 MB file); see
-# _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 4 * 1024**2
-
-
 def _get_info(eeg, *, eog, montage_units):
     """Get measurement info."""
     # add the ch_names and info['chs'][idx]['loc']
@@ -480,6 +475,8 @@ class RawEEGLAB(BaseRaw):
                         "is_embedded": is_embedded,
                         "input_fname": input_fname,
                         "uint16_codec": uint16_codec,
+                        # Cache-sized blocks are 2.1x faster on a 102 MB file.
+                        "max_block_samples": max(1, 4 * 1024**2 // 4 // info["nchan"]),
                     }
                 ],
             )
@@ -561,7 +558,7 @@ class RawEEGLAB(BaseRaw):
             cals,
             mult,
             dtype="<f4",
-            max_block_bytes=_BLOCK_BYTES,
+            max_block_samples=raw_extra["max_block_samples"],
         )
 
 

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -10,10 +10,6 @@ from ..._fiff.utils import _file_size, _read_segments_file
 from ...utils import _check_fname, fill_doc, logger, verbose, warn
 from ..base import BaseRaw
 
-# read in cache-sized blocks rather than one huge one (2.4x on a 102 MB file); see
-# _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 2 * 1024**2
-
 
 @fill_doc
 def read_raw_eximia(
@@ -105,6 +101,10 @@ class RawEximia(BaseRaw):
             last_samps=(n_samples - 1,),
             filenames=[fname],
             orig_format="short",
+            raw_extras=[
+                # Cache-sized blocks are 2.4x faster on a 102 MB file.
+                {"max_block_samples": max(1, 2 * 1024**2 // 2 // info["nchan"])}
+            ],
         )
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
@@ -119,5 +119,5 @@ class RawEximia(BaseRaw):
             cals,
             mult,
             dtype="<i2",
-            max_block_bytes=_BLOCK_BYTES,
+            max_block_samples=self._raw_extras[fi]["max_block_samples"],
         )

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -99,6 +99,9 @@ class RawFIL(BaseRaw):
         nchans = len(chans["name"])
         nsamples = _determine_nsamples(files["bin"], nchans, precision) - 1
         sample_info["nsamples"] = nsamples
+        # 16 MiB avoids regressing the 9.8 MB fixture while remaining 1.9x
+        # faster on a 197 MB file.
+        sample_info["max_block_samples"] = max(1, 16 * 1024**2 // dt.itemsize // nchans)
 
         raw_extras = list()
         raw_extras.append(sample_info)
@@ -193,15 +196,8 @@ class RawFIL(BaseRaw):
             cals,
             mult,
             dtype=si["dt"],
-            max_block_bytes=_BLOCK_BYTES,
+            max_block_samples=si["max_block_samples"],
         )
-
-
-# read in cache-sized blocks rather than one huge one (1.9x on a 197 MB file); see
-# _read_segments_file() for why a smaller block is faster. 4 MiB is faster still
-# (2.5x) but measurably regresses the 9.8 MB shipped fixture, which fits in one
-# 16 MiB block and so keeps its current code path exactly.
-_BLOCK_BYTES = 16 * 1024**2
 
 
 def _convert_channel_info(chans):

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -82,11 +82,6 @@ class UnsupportedKITFormat(ValueError):
         ValueError.__init__(self, *args, **kwargs)
 
 
-# read in cache-sized blocks rather than one huge one (1.8x on a 136 MB file);
-# each block is cast to float64 and scaled, so a smaller one stays in cache
-_BLOCK_BYTES = 2 * 1024**2
-
-
 @fill_doc
 class RawKIT(BaseRaw):
     r"""Raw object from KIT SQD file.
@@ -154,6 +149,10 @@ class RawKIT(BaseRaw):
         )
         kit_info["slope"] = slope
         kit_info["stimthresh"] = stimthresh
+        # Each block is cast to float64 and scaled, so a smaller one stays in cache
+        kit_info["max_block_samples"] = max(
+            1, 2 * 1024**2 // kit_info["dtype"].itemsize // kit_info["nchan"]
+        )
         if kit_info["acq_type"] != KIT.CONTINUOUS:
             raise TypeError("SQD file contains epochs, not raw data. Wrong reader.")
         logger.info("Creating Info structure...")
@@ -214,7 +213,7 @@ class RawKIT(BaseRaw):
 
         n_bytes = sqd["dtype"].itemsize
         assert n_bytes in (2, 4)
-        blk_size = min(data_left, (_BLOCK_BYTES // n_bytes // nchan) * nchan)
+        blk_size = min(data_left, sqd["max_block_samples"] * nchan)
         with open(self.filenames[fi], "rb", buffering=0) as fid:
             # extract data
             pointer = start * nchan * n_bytes

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -82,6 +82,11 @@ class UnsupportedKITFormat(ValueError):
         ValueError.__init__(self, *args, **kwargs)
 
 
+# read in cache-sized blocks rather than one huge one (1.8x on a 136 MB file);
+# each block is cast to float64 and scaled, so a smaller one stays in cache
+_BLOCK_BYTES = 2 * 1024**2
+
+
 @fill_doc
 class RawKIT(BaseRaw):
     r"""Raw object from KIT SQD file.
@@ -209,8 +214,7 @@ class RawKIT(BaseRaw):
 
         n_bytes = sqd["dtype"].itemsize
         assert n_bytes in (2, 4)
-        # Read up to 100 MB of data at a time.
-        blk_size = min(data_left, (100000000 // n_bytes // nchan) * nchan)
+        blk_size = min(data_left, (_BLOCK_BYTES // n_bytes // nchan) * nchan)
         with open(self.filenames[fi], "rb", buffering=0) as fid:
             # extract data
             pointer = start * nchan * n_bytes

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -58,6 +58,26 @@ ricoh_systems_paths += [
 berlin_path = data_path / "KIT" / "data_berlin.con"
 
 
+def test_block_size_in_raw_extras(monkeypatch):
+    """Test that the per-file block size controls binary reads."""
+    raw = read_raw_kit(sqd_path, preload=False)
+    assert raw._raw_extras[0]["max_block_samples"] == 5461
+    want = raw.get_data(start=0, stop=7)
+    raw._raw_extras[0]["max_block_samples"] = 3
+    counts = []
+    fromfile = np.fromfile
+
+    def _fromfile(fid, dtype, count):
+        counts.append(count)
+        return fromfile(fid, dtype, count)
+
+    monkeypatch.setattr(np, "fromfile", _fromfile)
+    got = raw.get_data(start=0, stop=7)
+
+    assert counts == [576, 576, 192]
+    assert_array_equal(got, want)
+
+
 @requires_testing_data
 def test_data(tmp_path):
     """Test reading raw kit files."""

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -418,10 +418,6 @@ def _map_ch_to_specs(ch_name, chan_labels_upper):
     return out
 
 
-# decode in cache-sized blocks rather than one huge one (1.8x on a 106 MB file)
-_BLOCK_BYTES = 1024**2
-
-
 @fill_doc
 class RawNihon(BaseRaw):
     """Raw object from a Nihon Kohden EEG file.
@@ -477,6 +473,11 @@ class RawNihon(BaseRaw):
         ]
 
         raw_extras = dict(cal=cal, offsets=offsets, gains=gains, header=header)
+        # Cache-sized blocks are 1.8x faster on a 106 MB file.
+        for datablock in header["controlblocks"][0]["datablocks"]:
+            datablock["max_block_samples"] = max(
+                1, 1024**2 // 2 // (datablock["n_channels"] + 1)
+            )
         for i_ch, ch_name in enumerate(info["ch_names"]):
             t_range = chs[ch_name]["phys_max"] - chs[ch_name]["phys_min"]
             info["chs"][i_ch]["range"] = t_range
@@ -574,7 +575,7 @@ class RawNihon(BaseRaw):
             # size of the block, so reading the whole request at once pushes
             # them all out of cache.
             n_times = stop - start
-            n_block = max(1, _BLOCK_BYTES // 2 // n_channels)
+            n_block = datablock["max_block_samples"]
             with open(self.filenames[fi], "rb") as fid:
                 fid.seek(start_offset)
                 for sample_start in range(0, n_times, n_block):

--- a/mne/io/nsx/nsx.py
+++ b/mne/io/nsx/nsx.py
@@ -146,11 +146,6 @@ def read_raw_nsx(
     )
 
 
-# read in cache-sized blocks rather than one huge one (2.3x on a 102 MB file); see
-# _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 4 * 1024**2
-
-
 @fill_doc
 class RawNSX(BaseRaw):
     """Raw object from NSx file from Blackrock Microsystems.
@@ -206,6 +201,10 @@ class RawNSX(BaseRaw):
             orig_units,
         ) = _get_hdr_info(input_fname, stim_channel=stim_channel, eog=eog, misc=misc)
         raw_extras["orig_format"] = orig_format
+        # Cache-sized blocks are 2.3x faster on a 102 MB file.
+        raw_extras["max_block_samples"] = max(
+            1, 4 * 1024**2 // np.dtype(orig_format).itemsize // info["nchan"]
+        )
         first_samps = (raw_extras["timestamp"][0],)
         super().__init__(
             info,
@@ -261,7 +260,7 @@ class RawNSX(BaseRaw):
                 n_channels=None,
                 offset=offset,
                 trigger_ch=None,
-                max_block_bytes=_BLOCK_BYTES,
+                max_block_samples=self._raw_extras[fi]["max_block_samples"],
             )
 
 

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -55,11 +55,6 @@ def read_raw_persyst(
     return RawPersyst(fname, preload, verbose)
 
 
-# read in cache-sized blocks rather than one huge one (2.3x on a 107 MB file);
-# see _read_segments_file() for why a smaller block is faster
-_BLOCK_BYTES = 16 * 1024**2
-
-
 @fill_doc
 class RawPersyst(BaseRaw):
     """Raw object from a Persyst file.
@@ -235,7 +230,11 @@ class RawPersyst(BaseRaw):
 
             logger.debug(f"Loaded {n_samples} samples for {n_chs} channels.")
 
+        # Cache-sized blocks are 2.3x faster on a 107 MB file.
         raw_extras = {"dtype": dtype, "n_chs": n_chs, "n_samples": n_samples}
+        raw_extras["max_block_samples"] = max(
+            1, 16 * 1024**2 // dtype.itemsize // n_chs
+        )
         # create Raw object
         super().__init__(
             info,
@@ -283,7 +282,7 @@ class RawPersyst(BaseRaw):
             mult,
             dtype=self._raw_extras[fi]["dtype"],
             n_channels=self._raw_extras[fi]["n_chs"],
-            max_block_bytes=_BLOCK_BYTES,
+            max_block_samples=self._raw_extras[fi]["max_block_samples"],
         )
 
 


### PR DESCRIPTION
#### What does this implement/fix?

The reader asked for up to 100 MB per block, then cast the whole block to
float64 and scaled it in place (`.astype(float)` then `block *= conv_factor`), so
the working set ran to several hundred MB and none of it stayed in cache.

Same treatment as #14241 and #14246.

#### Numbers

Median of 5 interleaved process pairs against a pristine `main` worktree:

| file | main | this PR | |
|---|---|---|---|
| 136 MB (161 ch x 425000) | 258.5 ms | 145.6 ms | **1.78x** |

A sweep puts the optimum at 2 MiB — 32 MiB is only 1.14x, 8 MiB 1.38x,
4 MiB 1.66x, 1 MiB 1.60x.

No shipped fixture regresses, and two improve because they were already being
split differently:

| fixture | main | this PR | |
|---|---|---|---|
| `ArtificalSignalData_Yokogawa_1khz.con` | 2.87 ms | 2.26 ms | 1.27x |
| `ArtificalSignalData_RICOH_1khz.con` | 3.06 ms | 2.77 ms | 1.10x |
| `Example_PQA160C_1001-export.con` | 1.05 ms | 1.07 ms | 0.99x |
| `010409_Motor_task_coregist-export.con` | 1.22 ms | 1.24 ms | 0.98x |

#### Correctness

- Output bit-identical to `main` on every readable KIT fixture (`np.array_equal`).
- `pytest mne/io/kit`: 15 passed.

#### Caveats

The constant differs from the other readers (2 MiB here, 8 MiB BrainVision,
2–16 MiB in #14246) because the optimum tracks time points per block, so it
moves with the channel count. As on #14246, I think a `max_block_samples=`
parameter would express this better than a per-reader byte budget, and I am
happy to go that way instead.

No fixture in the testing dataset is large enough to show the effect, so CI
cannot demonstrate it. The large file was synthesised by tiling the raw-data
section of `data_berlin.con` — verified to be the last section in the file — and
patching `n_samples` in the acquisition header.

#### Additional information

AI disclosure: I directed the work and reviewed and tested every change; Claude
Code (Claude Opus 5) ran the block-size sweep and the A/B measurements and made
the edits under my direction.
