### PR TITLE
Interactive dipole fitting: add STC mesh controls

### DIFF
--- a/mne/gui/_dipolefit.py
+++ b/mne/gui/_dipolefit.py
@@ -537,7 +537,12 @@ class DipoleFitUI:
         self._set_status("Setting up controls...")
         r = self._renderer
 
+        # Add some controls for the STC viewer, but not all of them.
+        if self._stc_brain is not None:
+            self._stc_brain._configure_dock_colormap_widget(name="STC Color Limits")
+
         # Visibility and opacity controls for the various meshes, one row per mesh.
+        r._dock_add_stretch()
         layout = r._dock_add_group_box("Meshes", collapse=True)
         grid = r._layout_create("grid")
         r._layout_add_widget(layout, grid)
@@ -633,6 +638,7 @@ class DipoleFitUI:
         )
         self._save_button.set_enabled(False)
         r._dock_add_stretch()
+        r._dock_finalize()
 
     def toggle_mesh(self, name, show=None):
         """Toggle a mesh on or off.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -557,7 +557,6 @@ class Brain:
             raise ValueError("No data to visualize. See ``add_data``.")
         self.time_viewer = time_viewer
         self.orientation = list(_lh_views_dict.keys())
-        self.default_smoothing_range = [-1, 15]
 
         # Default configuration
         self.visibility = False
@@ -1012,7 +1011,7 @@ class Brain:
         self.widgets["smoothing"] = self._renderer._dock_add_spin_box(
             name="Smoothing",
             value=self._data["smoothing_steps"],
-            rng=self.default_smoothing_range,
+            rng=[-1, 15],
             callback=self.set_data_smoothing,
             double=False,
             layout=layout,

--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -438,11 +438,12 @@ class EvokedField:
         """Configure the widgets shown in the dock on the left."""
         r = self._renderer
 
-        if not hasattr(r, "_dock"):
+        existing_dock = hasattr(r, "_dock")
+        if not existing_dock:
             r._dock_initialize()
 
         # Fieldline configuration
-        layout = r._dock_add_group_box("Fieldlines", collapse=True)
+        layout = r._dock_add_group_box("Fieldlines", collapse=False)
 
         r._dock_add_label(value="max value", align=True, layout=layout)
 
@@ -514,7 +515,7 @@ class EvokedField:
         self._widgets["contour_line_width"] = r._dock_add_slider(
             name="Thickness",
             value=self._contour_line_width,
-            rng=[0, 10],
+            rng=[0, 5],
             callback=_set_contour_line_width,
             double=True,
             layout=layout,
@@ -532,7 +533,9 @@ class EvokedField:
             double=True,
             layout=layout,
         )
-        r._dock_finalize()
+
+        if not existing_dock:
+            r._dock_finalize()
 
     def _on_time_change(self, event):
         """Respond to time_change UI event."""


### PR DESCRIPTION
When adding an stc to guide the interactive dipole fitting, add the STC Color Limits controls to the dock. It's easy to add other STC controls as well, but I think this is all we need for now.

<img width="3122" height="1570" alt="image" src="https://github.com/user-attachments/assets/424cb523-8726-42d7-a8dc-ad283863c645" />

