### PR TITLE
Avoid copying all epochs data in GetEpochsMixin._getitem

### DIFF
--- a/doc/changes/dev/14262.bugfix.rst
+++ b/doc/changes/dev/14262.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where selecting epochs (e.g., :meth:`epochs[0] <mne.Epochs.__getitem__>`) copied the entire data array, by `Eric Larson`_.

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1963,6 +1963,7 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
         """Make a deepcopy."""
         result = Info.__new__(Info)
         result._unlocked = True
+        memodict[id(self)] = result  # e.g. info["temp"] = info
         for k, v in self.items():
             # chs is roughly half the time but most are immutable
             if k == "chs":

--- a/mne/_fiff/tests/test_meas_info.py
+++ b/mne/_fiff/tests/test_meas_info.py
@@ -281,6 +281,12 @@ def test_info():
     info2 = Info(info_dict)
     assert info == info2
 
+    # a self-referencing entry must terminate and remap to the copy (gh-14260)
+    with info._unlock():
+        info["temp"] = info
+    info2 = info.copy()
+    assert info2["temp"] is info2
+
 
 def test_read_write_info(tmp_path):
     """Test IO of info."""

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -1148,6 +1148,22 @@ def brain_gc(request):
 
 
 _files = list()
+# Per-nodeid total duration (setup + call + teardown) and whether any phase was an
+# unexpected skip. Accumulated in pytest_runtest_logreport because under pytest-xdist
+# the tests run in worker processes, and xdist replays every TestReport through
+# pytest_runtest_logreport on the controller
+_durations: dict[str, float] = defaultdict(float)
+_bad_skips: set[str] = set()
+
+
+def pytest_runtest_logreport(report: pytest.TestReport):
+    """Accumulate per-test durations and unexpected skips."""
+    _durations[report.nodeid] += report.duration
+    if (
+        report.outcome in ("error", "failed")
+        and "UNEXPECTED SKIP" in report.longreprtext
+    ):
+        _bad_skips.add(report.nodeid)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
@@ -1158,13 +1174,8 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     print("\n")
     # get the number to print
     files = defaultdict(lambda: 0.0)
-    bad_skip = False
-    for item in session.items:
-        if _phase_report_key not in item.stash:
-            continue
-        report = item.stash[_phase_report_key]
-        dur = sum(x.duration for x in report.values())
-        parts = Path(item.nodeid.split(":")[0]).parts
+    for nodeid, dur in _durations.items():
+        parts = Path(nodeid.split(":")[0]).parts
         # split mne/tests/test_whatever.py into separate categories since these
         # are essentially submodule-level tests. Keeping just [:3] works,
         # except for mne/viz where we want level-4 granulatity
@@ -1174,18 +1185,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
             parts = parts + ("",)
         file_key = "/".join(parts)
         files[file_key] += dur
-        # detect if there were any bad skips
-        for _phase, result in report.items():
-            if (
-                result.outcome in ("error", "failed")
-                and "UNEXPECTED SKIP" in result.longreprtext
-            ):
-                bad_skip = True
     files = sorted(list(files.items()), key=lambda x: x[1])[::-1]
     # print
     _files[:] = files[:n]
     # Now handle exit status modification
-    if exitstatus == pytest.ExitCode.OK and bad_skip:
+    if exitstatus == pytest.ExitCode.OK and _bad_skips:
         session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2305,6 +2305,7 @@ class BaseEpochs(
         """Make a deepcopy."""
         cls = self.__class__
         result = cls.__new__(cls)
+        memodict[id(self)] = result  # so self-referencing attributes terminate
         for k, v in self.__dict__.items():
             # drop_log is immutable and _raw is private (and problematic to
             # deepcopy)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -819,6 +819,8 @@ def test_own_data():
     assert len(epochs) == epochs._data.shape[0] == len(epochs.events)
     assert len(epochs) == n_epochs
     assert not epochs._data.flags["OWNDATA"]
+    # in-place selection must own its data too, so it stays resizable (gh-14260)
+    assert epochs.copy()._getitem(slice(2), copy=False)._data.flags["OWNDATA"]
 
     # data ownership value error
     epochs.drop_bad(flat=dict(eeg=8e-6))
@@ -2350,7 +2352,7 @@ def test_preload_epochs():
     assert_array_almost_equal(epochs_preload.average().data, epochs.average().data, 18)
 
 
-def test_indexing_slicing():
+def test_indexing_slicing(monkeypatch):
     """Test of indexing and slicing operations."""
     raw, events, picks = _get_data()
     epochs = Epochs(
@@ -2388,6 +2390,14 @@ def test_indexing_slicing():
 
         data_epochs2_sliced = epochs2_sliced.get_data()
         assert_array_equal(data_epochs2_sliced, data_normal[start_index:end_index])
+
+        if preload:  # gh-14260
+            assert not np.shares_memory(epochs2_sliced._data, epochs2._data)
+            with monkeypatch.context() as m:
+                m.setattr(BaseEpochs, "copy", None)  # make copy() fail mid-getitem
+                with pytest.raises(TypeError, match="not callable"):
+                    epochs2[0]
+            assert_array_equal(epochs2._data, data_normal)  # placeholder not left
 
         # using indexing
         pos = 0
@@ -2748,6 +2758,10 @@ def test_epochs_copy():
     )
     copied = epochs.copy()
     assert_array_equal(epochs._data, copied._data)
+    # a self-referencing attribute must terminate and remap to the copy (gh-14260)
+    epochs.circular = epochs
+    copied = epochs.copy()
+    assert copied.circular is copied
 
     epochs = Epochs(
         raw,

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -333,6 +333,10 @@ def test_spectrum_getitem_epochs(epochs_spectrum):
     want = epochs_spectrum.get_data()
     got = epochs_spectrum["1"].get_data()
     assert_array_equal(want, got)
+    # gh-14260: a slice selection owns its data rather than aliasing the parent
+    sliced = epochs_spectrum[:1]
+    assert sliced._data.flags["OWNDATA"]
+    assert not np.shares_memory(sliced._data, epochs_spectrum._data)
 
 
 @pytest.mark.parametrize("method", ("mean", partial(np.std, axis=0)))

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1334,6 +1334,14 @@ def test_epochstfr_getitem(epochs_full, n_drop, as_tfr_array):
     subset_ints = tfr[[0, 1, 2]]
     subset_slice = tfr[:3]
     assert subset_ints == subset_slice
+    # gh-14260: selections own C-ordered data, they don't alias or inherit the
+    # (non-contiguous) layout of the parent
+    assert not tfr._data.flags["C_CONTIGUOUS"]
+    for sub in (subset_ints, subset_slice):
+        assert all(sub._data.flags[f] for f in ("C_CONTIGUOUS", "OWNDATA", "WRITEABLE"))
+        assert sub._data.dtype == tfr._data.dtype
+        assert not np.shares_memory(sub._data, tfr._data)
+    assert tfr[[]].shape == (0,) + tfr.shape[1:]
     # test iteration
     for ix, epo in enumerate(tfr):
         assert_array_equal(tfr[ix].data, epo.data.obj[np.newaxis])

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -220,12 +220,23 @@ class GetEpochsMixin:
             subset of epochs (and optionally array with kept epoch indices)
         """
         self._sanity_check_event_id()
-        inst = self.copy() if copy else self
-        if self._data is not None:
-            np.copyto(inst._data, self._data, casting="no")
+        select = self._item_to_select(item)
+        # np.require makes each instance own its data (so it can be resized later)
+        new_data = None
+        if copy and select_data and self.preload and self._data is not None:
+            orig_data = self._data
+            new_data = np.require(orig_data[select], requirements=["O"])
+            # placeholder for the deepcopy, will be replaced for `inst` later
+            self._data = new_data[:0]
+            try:
+                inst = self.copy()
+            finally:
+                self._data = orig_data
+            del orig_data
+        else:
+            inst = self.copy() if copy else self
         del self
 
-        select = inst._item_to_select(item)
         has_selection = hasattr(inst, "selection")
         if has_selection:
             key_selection = inst.selection[select]
@@ -257,9 +268,9 @@ class GetEpochsMixin:
             # will reset the index for us
             GetEpochsMixin.metadata.fset(inst, metadata, verbose=False)
         if inst.preload and select_data:
-            # ensure that each Epochs instance owns its own data so we can
-            # resize later if necessary
-            inst._data = np.require(inst._data[select], requirements=["O"])
+            if new_data is None:
+                new_data = np.require(inst._data[select], requirements=["O"])
+            inst._data = new_data
         if drop_event_id:
             # update event id to reflect new content of inst
             inst.event_id = {


### PR DESCRIPTION
Fixes a slowdown introduced in #11282 where `epochs[...]` required a deepcopy of the entire `._data` object (it got rid of a `self._data = None` trick to make checker happy) -- fix it a different way that still satisfies the checks and doesn't end up requiring a copy of the data. On `main`, `[epochs[ii] for ii in len(epochs]` copies the entire data array `len(epochs)` times. On this PR, it only copies what is actually taken/used. It makes the checks happy by setting `self._data = data[:0]` which copies instantly and makes the checks happy, replaces it on `self` in a `finally`, and then replaces it on `inst` later before returning `inst`.

Also tacks on a tiny fix with deepcopy where we didn't add `self` to the `memodict` so infinite recursion was possible in some corner cases (e.g., via `info["temp"] = info`). Probably not likely people will actually hit this, but setting `memodict` properly is best practice so might as well.

Changes investigated and drafted by Claude Fable 5 and reviewed / iterated by me (while looking at MNE-BIDS-Pipeline bottlenecks).