### PR TITLE
Persist the numba JIT cache, sysmon coverage, refleak freeze

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,16 @@ jobs:
           paths:
             - ~/.cache/uv
 
+      # Load numba's JIT cache
+      - run:
+          name: Get numba cache key
+          command: |
+            { ./tools/get_numba_version.sh; find mne -name "*numba*.py" | sort | xargs cat; } | sha256sum > numba_key.txt
+            cat numba_key.txt
+      - restore_cache:
+          keys:
+            - mne-numba-1-{{ checksum "numba_key.txt" }}-
+
       - run:
           name: Check Qt
           command: |
@@ -360,6 +370,12 @@ jobs:
           command: |  # we have -o pipefail in #BASH_ENV so we should be okay
             set -x
             PATTERN=$(cat pattern.txt) make -C doc $(cat build.txt) 2>&1 | tee sphinx_log.txt
+      # Only on success: a failed build compiles an arbitrary subset of the
+      # kernels, and there is no point saving that.
+      - save_cache:
+          key: mne-numba-1-{{ checksum "numba_key.txt" }}-{{ epoch }}
+          paths:
+            - ~/.cache/mne-numba
       - run:
           name: Check sphinx log for warnings (which are treated as errors)
           when: always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,11 +155,25 @@ jobs:
         run: MNE_SKIP_TESTING_DATASET_TESTS=true pytest -m "not (ultraslowtest or pgtest)" -n "$PYTEST_XDIST_N" --dist loadscope --timeout=120 --timeout-method=thread -o faulthandler_timeout=110 $COV_ARGS --tb=short -vv -rfE mne/
         if: matrix.kind == 'minimal'
       - run: ./tools/get_testing_version.sh
-      - uses: actions/cache@v6.1.0
+        if: matrix.kind != 'minimal'
+      # The "minimal" kind never fetches the datasets, so don't try to cache them
+      # (or it could lead to an empty cache!)
+      - name: Cache testing data
+        uses: actions/cache@v6.1.0
         with:
-          key: mne_data-testing-${{ env.TESTING_VERSION }}-misc-${{ env.MISC_VERSION }}
+          key: mne_data-testing-${{ env.TESTING_VERSION }}-misc-${{ env.MISC_VERSION }}-1
           path: ~/mne_data
+        if: matrix.kind != 'minimal'
       - run: bash ./tools/github_actions_download.sh
+        if: matrix.kind != 'minimal'
+      - run: ./tools/get_numba_version.sh
+      - name: Cache numba
+        uses: actions/cache@v6.1.0
+        with:
+          key: mne_numba-${{ matrix.os }}-${{ matrix.python }}-${{ env.NUMBA_VERSION }}-${{ hashFiles('mne/**/*numba*.py') }}
+          path: ${{ env.NUMBA_CACHE_DIR }}
+        # nothing to cache, and an empty directory would just poison the key
+        if: env.NUMBA_VERSION != 'none'
       - run: bash ./tools/github_actions_test.sh  # for some reason on macOS we need to run "bash X" in order for a failed test run to show up
       - uses: codecov/codecov-action@v7.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ uv.lock
 /gitlog.txt
 /merge.txt
 /misc_version.txt
+/numba_key.txt
 /pattern.txt
 /testing_version.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,12 @@ stages:
           PYTEST_XDIST_N: '2'  # Microsoft-hosted agents have 2 cores
           MNE_TEST_ALLOW_SKIP: '^$'  # nothing
           MNE_BROWSER_PRECOMPUTE: 'false'
+          # See tools/github_actions_env_vars.sh for why these are set (this job
+          # is on Python 3.14, so sys.monitoring can measure branches)
+          COVERAGE_CORE: 'sysmon'
+          NUMBA_CACHE_DIR: '/home/vsts/.cache/mne-numba'
+          NUMBA_CPU_NAME: 'generic'
+          NUMBA_CPU_FEATURES: ''
         steps:
           - bash: |
               set -xeo pipefail
@@ -87,6 +93,13 @@ stages:
             displayName: Cache testing data
           - bash: ./tools/github_actions_download.sh
             displayName: Download testing data
+          - bash: ./tools/get_numba_version.sh
+            displayName: Get numba version
+          - task: Cache@2
+            inputs:
+              key: 'mne_numba | "$(Agent.OS)" | "3.14" | "$(numba_version)" | mne/**/*numba*.py'
+              path: /home/vsts/.cache/mne-numba
+            displayName: Cache numba
           - script: pytest -m "ultraslowtest or pgtest" -n $(PYTEST_XDIST_N) --dist loadscope --tb=short --cov=mne --cov-report=xml -vv mne
             displayName: slow and mne-qt-browser tests
           - bash: bash <(curl -s https://codecov.io/bash)
@@ -105,6 +118,8 @@ stages:
           PYTEST_XDIST_N: '2'  # Microsoft-hosted agents have 2 cores
           TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -vv mne/gui mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/report"
           MNE_TEST_ALLOW_SKIP: '^$'  # nothing (can be overridden below)
+          # See tools/github_actions_env_vars.sh; this job is on Python 3.14
+          COVERAGE_CORE: 'sysmon'
         steps:
           - bash: |
               set -xeo pipefail
@@ -172,6 +187,12 @@ stages:
           PYTEST_XDIST_N: '2'  # Microsoft-hosted agents have 2 cores
           OMP_DYNAMIC: 'false'
           PYTHONUNBUFFERED: 1
+          # See tools/github_actions_env_vars.sh; both matrix legs are Python 3.14
+          COVERAGE_CORE: 'sysmon'
+          # See tools/github_actions_env_vars.sh for why these three are set
+          NUMBA_CACHE_DIR: 'C:\Users\VssAdministrator\.cache\mne-numba'
+          NUMBA_CPU_NAME: 'generic'
+          NUMBA_CPU_FEATURES: ''
           AZURE_CI_WINDOWS: 'true'
           MNE_CI_KIND: $(TEST_MODE)
           MNE_TEST_ALLOW_SKIP: $(MNE_TEST_ALLOW_SKIP)
@@ -233,6 +254,13 @@ stages:
             displayName: Cache testing data
           - bash: ./tools/github_actions_download.sh
             displayName: Download testing data
+          - bash: ./tools/get_numba_version.sh
+            displayName: Get numba version
+          - task: Cache@2
+            inputs:
+              key: 'mne_numba | "$(Agent.OS)" | "$(PYTHON_VERSION)" | "$(numba_version)" | mne/**/*numba*.py'
+              path: C:\Users\VssAdministrator\.cache\mne-numba
+            displayName: Cache numba
           # Windows does not define HOME, and MNE-C dereferences it unconditionally:
           # mne_forward_solution crashes with 0xC0000005 without it. Set after the
           # steps above so that Git Bash keeps deriving its own MSYS-style HOME.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,6 +251,9 @@ stages:
               key: 'mne_numba | "$(Agent.OS)" | "$(PYTHON_VERSION)" | "$(numba_version)" | mne/**/*numba*.py'
               path: C:\Users\VssAdministrator\.cache\mne-numba
             displayName: Cache numba
+            # pip-pre has no numba when nightly wheels are missing; without it
+            # nothing creates the cache dir and the post-job save fails on tar
+            condition: ne(variables['numba_version'], 'none')
           # Windows does not define HOME, and MNE-C dereferences it unconditionally:
           # mne_forward_solution crashes with 0xC0000005 without it. Set after the
           # steps above so that Git Bash keeps deriving its own MSYS-style HOME.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,9 +50,6 @@ stages:
           # See tools/github_actions_env_vars.sh for why these are set (this job
           # is on Python 3.14, so sys.monitoring can measure branches)
           COVERAGE_CORE: 'sysmon'
-          NUMBA_CACHE_DIR: '/home/vsts/.cache/mne-numba'
-          NUMBA_CPU_NAME: 'generic'
-          NUMBA_CPU_FEATURES: ''
         steps:
           - bash: |
               set -xeo pipefail
@@ -93,13 +90,6 @@ stages:
             displayName: Cache testing data
           - bash: ./tools/github_actions_download.sh
             displayName: Download testing data
-          - bash: ./tools/get_numba_version.sh
-            displayName: Get numba version
-          - task: Cache@2
-            inputs:
-              key: 'mne_numba | "$(Agent.OS)" | "3.14" | "$(numba_version)" | mne/**/*numba*.py'
-              path: /home/vsts/.cache/mne-numba
-            displayName: Cache numba
           - script: pytest -m "ultraslowtest or pgtest" -n $(PYTEST_XDIST_N) --dist loadscope --tb=short --cov=mne --cov-report=xml -vv mne
             displayName: slow and mne-qt-browser tests
           - bash: bash <(curl -s https://codecov.io/bash)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -697,18 +697,22 @@ def pg_backend(request, garbage_collect):
         # and hence its browser alive. Requiring *zero* browsers would then
         # blame the next test that uses this fixture for a browser it never
         # created, turning one real failure into a cascade of errors. Only
-        # report browsers this test itself leaked. Snapshot stores only ids,
-        # so it pins nothing alive.
-        snap = Snapshot(MNEQtBrowser, collect=False)
-        yield backend
-        backend._close_all()
-        # This shouldn't be necessary, but let's make sure nothing is stale
-        import mne_qt_browser
+        # report browsers this test itself leaked. Snapshot pins nothing alive.
+        # freeze=True: see brain_gc for why, and for the thaw() discipline it
+        # obliges us to.
+        snap = Snapshot(MNEQtBrowser, freeze=True)
+        try:
+            yield backend
+            backend._close_all()
+            # This shouldn't be necessary, but let's make sure nothing is stale
+            import mne_qt_browser
 
-        mne_qt_browser._browser_instances.clear()
-        if not _test_passed(request):
-            return
-        snap.assert_no_new(f"Closure of {request.node.name}", request=request)
+            mne_qt_browser._browser_instances.clear()
+            if not _test_passed(request):
+                return
+            snap.assert_no_new(f"Closure of {request.node.name}", request=request)
+        finally:
+            snap.thaw()  # no-op once assert_no_new() has thawed
 
 
 @pytest.fixture(
@@ -1111,40 +1115,43 @@ def brain_gc(request):
         return
     from mne.viz import Brain
 
-    # Snapshot stores only ids (pins nothing alive) so VTK objects that
-    # pre-date the test (e.g. held by module-level state) are never reported.
-    # collect=False: a gc.collect() here would cost as much as the one that
-    # actually matters at teardown, and we only care about objects going *up*
-    # (new ones surviving), not down. Skipping it just means some snapshotted
-    # objects are already garbage and vanish by teardown, which is fine; the
-    # only cost is a slightly wider id-reuse window (a missed leak at worst,
-    # never a false report).
-    snap = Snapshot(_is_vtk, label="VTK", collect=False)
-    yield
-    close_func()
-    # pyvistaqt >= 0.11.3 schedules the plotter's window for deferred deletion
-    # (deleteLater) on close; until Qt processes it, the C++ window object
-    # keeps its Python wrapper (and thereby the whole plotter graph) alive.
-    from qtpy.QtCore import QEvent
-    from qtpy.QtWidgets import QApplication
+    # Snapshot pins nothing alive, so VTK objects that pre-date the test (e.g.
+    # held by module-level state) are never reported. freeze=True moves the live
+    # heap into the permanent generation instead of recording ids
+    snap = Snapshot(_is_vtk, label="VTK", freeze=True)
+    try:
+        yield
+        close_func()
+        # pyvistaqt >= 0.11.3 schedules the plotter's window for deferred deletion
+        # (deleteLater) on close; until Qt processes it, the C++ window object
+        # keeps its Python wrapper (and thereby the whole plotter graph) alive.
+        from qtpy.QtCore import QEvent
+        from qtpy.QtWidgets import QApplication
 
-    app = QApplication.instance()
-    if app is not None:
-        for _ in range(2):
-            app.processEvents()
-            app.sendPostedEvents(None, QEvent.DeferredDelete)
-    if not _test_passed(request):
-        return
-    # The collect must happen *before* list(Brain._instances) is evaluated:
-    # a Brain in a dead reference cycle is still in the WeakSet until
-    # collected, and the list would pin it alive and falsely report it.
-    gc_collect_once(request)
-    # Brain._instances is a WeakSet populated only when MNE_3D_BACKEND_TESTING
-    # is set (see Brain.__init__), so use it instead of a slow gc.get_objects()
-    # scan of the whole process to check for lingering Brain instances.
-    assert_no_instances(Brain, "after", request=request, objs=list(Brain._instances))
-    # VTK objects aren't individually tracked, so this one is a full heap scan.
-    snap.assert_no_new("after", request=request)
+        app = QApplication.instance()
+        if app is not None:
+            for _ in range(2):
+                app.processEvents()
+                app.sendPostedEvents(None, QEvent.DeferredDelete)
+        if not _test_passed(request):
+            return
+        # The collect must happen *before* list(Brain._instances) is evaluated:
+        # a Brain in a dead reference cycle is still in the WeakSet until
+        # collected, and the list would pin it alive and falsely report it.
+        gc_collect_once(request)
+        # VTK objects aren't individually tracked, so this is the check the
+        # freeze exists for. It has to run before the Brain check, because it is
+        # what thaws: a referrer chain built on a frozen heap cannot see any of
+        # the containers that pre-date the freeze.
+        snap.assert_no_new("after", request=request)
+        # Brain._instances is a WeakSet populated only when MNE_3D_BACKEND_TESTING
+        # is set (see Brain.__init__), so use it instead of a slow gc.get_objects()
+        # scan of the whole process to check for lingering Brain instances.
+        assert_no_instances(
+            Brain, "after", request=request, objs=list(Brain._instances)
+        )
+    finally:
+        snap.thaw()  # no-op once assert_no_new() has thawed
 
 
 _files = list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ doc = [
   "pyvistaqt >= 0.11",  # released 2023-06-30, will become 0.12 on 2028-07-01
   "pyxdf",
   "pyzmq != 24.0.0",
-  "refleak >= 0.2.1",  # released 2024-05-21, will become 1.6 on 2026-12-09
+  "refleak >= 0.2.2",  # released 2024-05-21, will become 1.6 on 2026-12-09
   "scikit-learn >= 1.5",  # released 2024-05-21, will become 1.6 on 2026-12-09
   "seaborn >= 0.5, != 0.11.2",
   "selenium >= 4.27.1",
@@ -61,7 +61,7 @@ test = [
   "pytest-rerunfailures",
   "pytest-timeout >= 2.2",
   "pytest-xdist >= 3.6.1",
-  "refleak >= 0.2.1",
+  "refleak >= 0.2.2",
   "ruff >= 0.1",
   "threadpoolctl",
   "twine",

--- a/tools/circleci_bash_env.sh
+++ b/tools/circleci_bash_env.sh
@@ -29,6 +29,11 @@ echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
 echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
 echo "export MNE_ADD_CONTRIBUTOR_IMAGE=true" >> $BASH_ENV
 echo "export MNE_REQUIRE_RELATED_SOFTWARE_INSTALLED=true" >> $BASH_ENV
+# Persist numba's on-disk JIT cache across runs, with generic CPU to make the
+# cached objects portable
+echo "export NUMBA_CACHE_DIR=$HOME/.cache/mne-numba" >> $BASH_ENV
+echo "export NUMBA_CPU_NAME=generic" >> $BASH_ENV
+echo "export NUMBA_CPU_FEATURES=" >> $BASH_ENV
 echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
 echo "export DISPLAY=:99" >> $BASH_ENV
 echo "source ~/python_env/bin/activate" >> $BASH_ENV
@@ -37,4 +42,6 @@ ln -s ~/python_env/bin/python ~/.local/bin/python
 echo "BASH_ENV:"
 cat $BASH_ENV
 mkdir -p ~/mne_data
+# Must exist before save_cache runs, even if nothing ever compiles into it
+mkdir -p ~/.cache/mne-numba
 touch pattern.txt

--- a/tools/get_numba_version.sh
+++ b/tools/get_numba_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+# Numba's on-disk JIT cache (NUMBA_CACHE_DIR) is invalidated whenever numba or
+# llvmlite is upgraded, so CI cache keys have to include their versions in a form
+# usable in a cache key. Prints "none" when numba is not installed, which just
+# means the cache never gets populated for that job.
+NUMBA_VERSION=`python -c "
+try:
+    import llvmlite, numba
+except Exception:
+    print('none')
+else:
+    print(f'{numba.__version__}-{llvmlite.__version__}')
+"`
+if [ ! -z $GITHUB_ENV ]; then
+	echo "NUMBA_VERSION="$NUMBA_VERSION | tee -a $GITHUB_ENV
+elif [ ! -z $AZURE_CI ]; then
+	echo "##vso[task.setvariable variable=numba_version]$NUMBA_VERSION"
+else
+	echo $NUMBA_VERSION
+fi

--- a/tools/github_actions_env_vars.sh
+++ b/tools/github_actions_env_vars.sh
@@ -19,6 +19,34 @@ case "$MNE_CI_KIND" in
 esac
 echo "COV_ARGS=$COV_ARGS" | tee -a $GITHUB_ENV
 
+# Where we do measure coverage, use the sys.monitoring core rather than the C
+# tracer: it produces identical line and branch results for a fraction of the
+# overhead. It needs Python >= 3.14 to measure branches (we always pass
+# --cov-branch, see the pytest addopts), and coverage's free-threading support is
+# still settling, so those jobs stay on the C tracer. When sysmon is unusable
+# coverage falls back on its own, but only after a CoverageWarning that our
+# warning filters would turn into an error, so don't ask for it there.
+if [[ -n "$COV_ARGS" ]]; then
+    case "$PYTHON_VERSION" in
+        3.11 | 3.12 | 3.13 | *t) ;;
+        *) echo "COVERAGE_CORE=sysmon" | tee -a $GITHUB_ENV ;;
+    esac
+fi
+
+# Persist numba's on-disk JIT cache between runs (see the "Cache numba" step).
+# Without it every xdist worker recompiles all ~30 jitted kernels from scratch:
+# e.g. test_fit_chpi_quat_weighted takes 12 s cold and 0.3 s warm. The whole
+# cache is only ~1 MB.
+#
+# numba keys its cache index on the host CPU model, so on CI -- where the runner
+# pool hands out several different models -- a restored cache would usually miss.
+# Compiling for a generic CPU makes the cached objects portable between them; the
+# kernels are small enough that losing model-specific vectorization is nothing
+# next to the compile time it saves.
+echo "NUMBA_CACHE_DIR=$HOME/.cache/mne-numba" | tee -a $GITHUB_ENV
+echo "NUMBA_CPU_NAME=generic" | tee -a $GITHUB_ENV
+echo "NUMBA_CPU_FEATURES=" | tee -a $GITHUB_ENV
+
 # Number of pytest-xdist workers -- explicit ints (in the spirit of SciPy's CI)
 # rather than "auto". macOS has  fewer cores and less RAM
 if [[ "$CI_OS_NAME" == "macos"* ]]; then

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -70,7 +70,7 @@ python -m pip install $STD_ARGS \
 	git+https://github.com/the-siesta-group/edfio \
 	trame trame-vtk "trame-vuetify!=3.2.3" trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
 	openmeeg imageio-ffmpeg xlrd mffpy traitlets pybv eeglabio defusedxml antio curryreader \
-	filelock
+	jamica filelock
 echo "::endgroup::"
 
 echo "::group::Make sure we're on a NumPy 2.0 variant"

--- a/tools/pylock.ci-old.toml
+++ b/tools/pylock.ci-old.toml
@@ -318,9 +318,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7
 
 [[packages]]
 name = "refleak"
-version = "0.2.1"
-sdist = { url = "https://files.pythonhosted.org/packages/8a/70/b586bac19d443491b0b1bf18e017c98dfdb190503022e58afeb6240ee64f/refleak-0.2.1.tar.gz", upload-time = 2026-07-10T12:59:14Z, size = 28367, hashes = { sha256 = "8dd9585634375b0c0e1e9be12f6cf699b97f140c9a615c5c75b4fdb2305e0849" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/2c/e9/0818313965cdfd38f8639e6ac51d50c1bab20c42dfb8e1de571cf4553105/refleak-0.2.1-py3-none-any.whl", upload-time = 2026-07-10T12:59:13Z, size = 20801, hashes = { sha256 = "e48a7c54523273ec99adff87a83a88fddb52f21778a0479190425fcc456ab5a3" } }]
+version = "0.2.2"
+sdist = { url = "https://files.pythonhosted.org/packages/aa/b1/67b11c3f6ed3ed43aaf3498b22da7e65d835d795016f0072e5f497c68274/refleak-0.2.2.tar.gz", upload-time = 2026-08-17T17:38:02Z, size = 37021, hashes = { sha256 = "c9cfd5054e1703edf4489fb0418aee930cb6f0eeb4f64fb81a6a64772d1841c2" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/43/5d968309f1749045aa4ef9dc044f456ed1c8882e269d16e0b2df168b969c/refleak-0.2.2-py3-none-any.whl", upload-time = 2026-08-17T17:38:01Z, size = 26996, hashes = { sha256 = "395675d59b07bf3fd8730bacb5c947c30d3474a6aff1efabdd4f7d2d8689d37b" } }]
 
 [[packages]]
 name = "requests"

--- a/tutorials/forward/30_forward.py
+++ b/tutorials/forward/30_forward.py
@@ -130,7 +130,7 @@ mne.viz.plot_alignment(
 # definition and spacing parameter.
 #
 # .. warning::
-#     ``'oct4'`` is used here just for speed, for real analyses the recommended
+#     ``'oct4'`` is used here just for speed; for real analyses the recommended
 #     spacing is ``'oct6'``.
 
 src = mne.setup_source_space(
@@ -147,7 +147,7 @@ mne.viz.plot_bem(src=src, **plot_bem_kwargs)
 
 # %%
 # To compute a volume based source space defined with a grid of candidate
-# dipoles inside a sphere of radius 90mm centered at (0.0, 0.0, 40.0) mm
+# dipoles inside a sphere of radius 90 mm centered at (0.0, 0.0, 40.0) mm
 # you can use the following code.
 # Obviously here, the sphere is not perfect. It is not restricted to the
 # brain and it can miss some parts of the cortex.

--- a/tutorials/preprocessing/59_head_positions.py
+++ b/tutorials/preprocessing/59_head_positions.py
@@ -41,8 +41,8 @@ raw.compute_psd().plot(picks="data", exclude="bads", amplitude=False)
 
 # %%
 # We can use `mne.chpi.get_chpi_info` to retrieve the coil frequencies,
-# the index of the channel indicating when which coil was switched on, and the
-# respective "event codes" associated with each coil's activity.
+# the index of the ``STIM`` channel indicating when each coil was switched on,
+# and the respective "event codes" associated with each coil's activity.
 
 chpi_freqs, ch_idx, chpi_codes = mne.chpi.get_chpi_info(info=raw.info)
 print(f"cHPI coil frequencies extracted from raw: {chpi_freqs} Hz")

--- a/tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py
+++ b/tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py
@@ -216,7 +216,7 @@ T_obs, clusters, cluster_p_values, H0 = clu = spatio_temporal_cluster_1samp_test
 # %%
 # Selecting "significant" clusters
 # --------------------------------
-# After performing the cluster-based permutationt test, you may wish to
+# After performing the cluster-based permutation test, you may wish to
 # select the observed clusters that can be considered statistically
 # significant under the permutation distribution. This can easily be
 # done using the code snippet below.


### PR DESCRIPTION
A few easy CI speedups:

1. Fix bug where `minimal` (which doesn't use data) could poison the testing data cache
2. Use `sysmon` coverage where available
3. Use `freeze` in refleak like PyVista
4. Cache numba jit generation (should only need to update when numba updates or our code changes, which is rare)

Changes drafted by Claude Fable 5 and edited / reviewed by me