### PR TITLE
DOC: Add osl-dynamics to related software list

### DIFF
--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -37,6 +37,7 @@ PYPI_PACKAGES = {
     "cross-domain-saliency-maps",
     "meggie",
     "niseq",
+    "osl-dynamics",
     "sesameeg",
     "zuna",
 }

--- a/doc/sphinxext/related_software_nodeps.txt
+++ b/doc/sphinxext/related_software_nodeps.txt
@@ -11,4 +11,5 @@ cross-domain-saliency-maps  # tensorflow # categories: stats
 fsleyes  # wxPython # categories: modalities, visu
 mne-kit-gui # mayavi # categories: preproc
 mne-videobrowser # opencv # categories: visu
+osl-dynamics # tensorflow # categories: connectivity, stats, oscillations
 zuna # requires pytorch # categories: stats


### PR DESCRIPTION
Adds [osl-dynamics](https://github.com/OHBA-analysis/osl-dynamics) to the related software list, under connectivity / stats / oscillations. This is a package that can be use for modelling dynamics in M/EEG data, including Hidden Markov Modelling.

Added to `PYPI_PACKAGES` (osl-dynamics in only available via `pip`). Placed in `related_software_nodeps.txt` because it requires TensorFlow at runtime.

(No changelog entry, following other similar PRs: #13849 and #13812).