### PR TITLE
Brain GUI modernization (Phase 7)

### DIFF
--- a/doc/changes/dev/14270.newfeature.rst
+++ b/doc/changes/dev/14270.newfeature.rst
@@ -1,0 +1,1 @@
+The :class:`mne.viz.Brain` GUI now gives label-mode traces the same as vertex traces, and autoscales the traces plot's y-axis whenever a new trace is picked, by `Payam Sadeghi-Shabestari`_.

--- a/doc/changes/dev/14270.newfeature.rst
+++ b/doc/changes/dev/14270.newfeature.rst
@@ -1,1 +1,1 @@
-The :class:`mne.viz.Brain` GUI now gives label-mode traces the same as vertex traces, and autoscales the traces plot's y-axis whenever a new trace is picked, by `Payam Sadeghi-Shabestari`_.
+The :class:`mne.viz.Brain` trace list now shows picked labels with a short name, their number of source vertices, and the extraction mode, and the traces plot now rescales its y-axis whenever a new trace is picked, by `Payam Sadeghi-Shabestari`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -583,6 +583,7 @@ class Brain:
         self._peak_vertices = {}
         self._auto_peak_points = set()
         self._trace_meta = {}
+        self._label_trace_meta = {}
         self._mouse_no_mvt = -1
         self._show_hover_info = False
         self._hover_caption = None
@@ -1055,7 +1056,7 @@ class Brain:
             self._configure_vertex_time_course()
             return
 
-        layout = self._renderer._dock_add_group_box(name, collapse=True)
+        layout = self._renderer._dock_add_group_box(name, collapse=False)
 
         # setup candidate annots
         @safe_event
@@ -1659,6 +1660,7 @@ class Brain:
         # subsequent removal (and clear_glyphs at annotation changes) fail too
         self._picked_patches[hemi].remove(label_id)
         line, label._line = label._line, None
+        self._label_trace_meta.pop(line, None)
         if line is not None:
             try:
                 line.remove()
@@ -1789,16 +1791,42 @@ class Brain:
         The vertex auto-picked at peak activation for each hemisphere gets a
         "Peak (LH) 1000"-style name; other picked vertices get a compact
         "LH 1000"-style name instead of the full MNI-coordinate string (still
-        available as the row's tooltip). RMS curves are returned unchanged.
+        available as the row's tooltip). A picked parcellation label gets its
+        display name (e.g. "Superiortemporal (LH)") instead of the raw
+        internal name (still available as the tooltip). RMS curves are
+        returned unchanged.
         """
         meta = self._trace_meta.get(line)
-        if meta is None:
-            return line.get_label()
-        hemi, vertex_id, _ = meta
-        hemi_names = {"lh": "LH", "rh": "RH", "vol": "Vol"}
-        if self._peak_vertices.get(hemi) == vertex_id:
-            return f"Peak ({hemi_names[hemi]}) {vertex_id}"
-        return f"{hemi_names[hemi]} {vertex_id}"
+        if meta is not None:
+            hemi, vertex_id, _ = meta
+            hemi_names = {"lh": "LH", "rh": "RH", "vol": "Vol"}
+            if self._peak_vertices.get(hemi) == vertex_id:
+                return f"Peak ({hemi_names[hemi]}) {vertex_id}"
+            return f"{hemi_names[hemi]} {vertex_id}"
+        label_meta = self._label_trace_meta.get(line)
+        if label_meta is not None:
+            hemi, label_name, _, _ = label_meta
+            hemi_names = {"lh": "LH", "rh": "RH"}
+            display_name = label_name
+            for suffix in ("-lh", "-rh", "_lh", "_rh"):
+                if display_name.endswith(suffix):
+                    display_name = display_name[: -len(suffix)]
+                    break
+            display_name = display_name.replace("_", " ").replace("-", " ").title()
+            return f"{display_name} ({hemi_names.get(hemi, hemi)})"
+        return line.get_label()
+
+    def _trace_display_subtitle(self, line):
+        """Return an optional small subtitle line for a trace-list row."""
+        meta = self._trace_meta.get(line)
+        if meta is not None:
+            mni_str = meta[2]
+            return f"MNI: {mni_str}" if mni_str else None
+        label_meta = self._label_trace_meta.get(line)
+        if label_meta is not None:
+            _, _, mode, n_vertices = label_meta
+            return f"{n_vertices} vertices, mode: {mode}"
+        return None
 
     def clear_glyphs(self):
         """Clear the picking glyphs."""
@@ -1879,6 +1907,8 @@ class Brain:
         )
         self._trace_meta[line] = (hemi, vertex_id, mni_str)
         if update:
+            self.mpl_canvas.axes.relim()
+            self.mpl_canvas.axes.autoscale_view()
             self.mpl_canvas.update_plot()
         return line
 
@@ -2671,8 +2701,17 @@ class Brain:
                 tc = np.linalg.norm(tc, axis=0)
             color = next(self.color_cycle)
             line = self.mpl_canvas.plot(
-                self._data["time"], tc, label=label_name, color=color
+                self._data["time"], tc, label=label_name, color=color, update=False
             )
+            self._label_trace_meta[line] = (
+                hemi,
+                label_name,
+                self.label_extract_mode,
+                len(label.vertices),
+            )
+            self.mpl_canvas.axes.relim()
+            self.mpl_canvas.axes.autoscale_view()
+            self.mpl_canvas.update_plot()
         else:
             line = None
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1056,7 +1056,7 @@ class Brain:
             self._configure_vertex_time_course()
             return
 
-        layout = self._renderer._dock_add_group_box(name, collapse=False)
+        layout = self._renderer._dock_add_group_box(name, collapse=True)
 
         # setup candidate annots
         @safe_event

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1791,10 +1791,9 @@ class Brain:
         The vertex auto-picked at peak activation for each hemisphere gets a
         "Peak (LH) 1000"-style name; other picked vertices get a compact
         "LH 1000"-style name instead of the full MNI-coordinate string (still
-        available as the row's tooltip). A picked parcellation label gets its
-        display name (e.g. "Superiortemporal (LH)") instead of the raw
-        internal name (still available as the tooltip). RMS curves are
-        returned unchanged.
+        available as the row's tooltip). A picked label gets a
+        "superiortemporal (LH)"-style name, moving its name's hemisphere
+        suffix into the parentheses. RMS curves are returned unchanged.
         """
         meta = self._trace_meta.get(line)
         if meta is not None:
@@ -1806,14 +1805,7 @@ class Brain:
         label_meta = self._label_trace_meta.get(line)
         if label_meta is not None:
             hemi, label_name, _, _ = label_meta
-            hemi_names = {"lh": "LH", "rh": "RH"}
-            display_name = label_name
-            for suffix in ("-lh", "-rh", "_lh", "_rh"):
-                if display_name.endswith(suffix):
-                    display_name = display_name[: -len(suffix)]
-                    break
-            display_name = display_name.replace("_", " ").replace("-", " ").title()
-            return f"{display_name} ({hemi_names.get(hemi, hemi)})"
+            return f"{label_name.removesuffix(f'-{hemi}')} ({hemi.upper()})"
         return line.get_label()
 
     def _trace_display_subtitle(self, line):
@@ -2703,11 +2695,13 @@ class Brain:
             line = self.mpl_canvas.plot(
                 self._data["time"], tc, label=label_name, color=color, update=False
             )
+            # count the source vertices the extraction uses, not surface ones
+            stc_vertices = stc.vertices[0 if hemi == "lh" else 1]
             self._label_trace_meta[line] = (
                 hemi,
                 label_name,
                 self.label_extract_mode,
-                len(label.vertices),
+                np.intersect1d(label.vertices, stc_vertices).size,
             )
             self.mpl_canvas.axes.relim()
             self.mpl_canvas.axes.autoscale_view()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -1540,6 +1540,12 @@ def test_brain_native_trace_list(renderer_interactive_pyvistaqt, brain_gc):
     assert str(vertex_id) in line.get_label()
     assert row_text(row) == f"LH {vertex_id}"
 
+    # the y-axis must autoscale to fit a newly-picked trace, not leave it
+    # clipped outside whatever range the previous traces happened to set
+    ymin, ymax = canvas.axes.get_ylim()
+    y = line.get_ydata()
+    assert y.min() >= ymin and y.max() <= ymax
+
     # toggling a row hides the trace and its 3D glyph together, without
     # rebuilding the row list (sync() must skip unchanged trace sets --
     # the whole point of the native list was to stop rebuilding on every
@@ -1840,9 +1846,29 @@ def test_brain_click_picking_label(renderer_interactive_pyvistaqt, brain_gc, qtb
     assert len(brain._picked_patches["lh"]) == 0
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, point)
     assert len(brain._picked_patches["lh"]) == 1
+
+    # the picked label's trace-list row gets a friendly display name/subtitle
+    # instead of the raw internal label name (still available as the tooltip)
+    label_id = brain._picked_patches["lh"][0]
+    label = brain._annotation_labels["lh"][label_id]
+    line = label._line
+    assert line in brain._label_trace_meta
+    display_label = brain._trace_display_label(line)
+    assert display_label != line.get_label()
+    assert display_label.endswith("(LH)")
+    subtitle = brain._trace_display_subtitle(line)
+    assert str(brain.label_extract_mode) in subtitle
+    assert str(len(label.vertices)) in subtitle
+
+    # the y-axis must autoscale to fit the newly-picked label's trace
+    ymin, ymax = brain.mpl_canvas.axes.get_ylim()
+    y = line.get_ydata()
+    assert y.min() >= ymin and y.max() <= ymax
+
     # clicking the same label again removes it
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, point)
     assert len(brain._picked_patches["lh"]) == 0
+    assert line not in brain._label_trace_meta
     # the clear-glyphs shortcut clears a picked label
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, point)
     assert len(brain._picked_patches["lh"]) == 1

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -1533,18 +1533,16 @@ def test_brain_native_trace_list(renderer_interactive_pyvistaqt, brain_gc):
     picked = set(brain.get_picked_points()["lh"])
     n_verts = len(brain.geo["lh"].coords)
     vertex_id = next(v for v in range(n_verts) if v not in picked)
+    # a removed trace's data limits linger until relim(), so picking must
+    # rescale the y-axis to only the traces that are still there
+    canvas.axes.plot([0], [1e6])[0].remove()
     ui_events.publish(brain, ui_events.VertexSelect(hemi="lh", vertex_id=vertex_id))
+    assert canvas.axes.get_ylim()[1] < 1e6
     assert rows.count() == len(row_lines) + 1
     row = rows.itemAt(rows.count() - 1).widget()
     line = row._line
     assert str(vertex_id) in line.get_label()
     assert row_text(row) == f"LH {vertex_id}"
-
-    # the y-axis must autoscale to fit a newly-picked trace, not leave it
-    # clipped outside whatever range the previous traces happened to set
-    ymin, ymax = canvas.axes.get_ylim()
-    y = line.get_ydata()
-    assert y.min() >= ymin and y.max() <= ymax
 
     # toggling a row hides the trace and its 3D glyph together, without
     # rebuilding the row list (sync() must skip unchanged trace sets --
@@ -1844,26 +1842,23 @@ def test_brain_click_picking_label(renderer_interactive_pyvistaqt, brain_gc, qtb
     for dx in range(-40, 41, 10):
         _send_mouse_move(widget, point + QPoint(dx, 0))
     assert len(brain._picked_patches["lh"]) == 0
+    brain.mpl_canvas.axes.plot([0], [1e6])[0].remove()  # stale limits, see above
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, point)
     assert len(brain._picked_patches["lh"]) == 1
+    assert brain.mpl_canvas.axes.get_ylim()[1] < 1e6
 
     # the picked label's trace-list row gets a friendly display name/subtitle
     # instead of the raw internal label name (still available as the tooltip)
     label_id = brain._picked_patches["lh"][0]
     label = brain._annotation_labels["lh"][label_id]
     line = label._line
-    assert line in brain._label_trace_meta
-    display_label = brain._trace_display_label(line)
-    assert display_label != line.get_label()
-    assert display_label.endswith("(LH)")
-    subtitle = brain._trace_display_subtitle(line)
-    assert str(brain.label_extract_mode) in subtitle
-    assert str(len(label.vertices)) in subtitle
-
-    # the y-axis must autoscale to fit the newly-picked label's trace
-    ymin, ymax = brain.mpl_canvas.axes.get_ylim()
-    y = line.get_ydata()
-    assert y.min() >= ymin and y.max() <= ymax
+    assert brain._trace_display_label(line) == f"{label.name[:-3]} (LH)"
+    # only the (decimated) source vertices within the label count
+    n_vertices = np.intersect1d(label.vertices, brain._data["stc"].vertices[0]).size
+    assert 0 < n_vertices < len(label.vertices)
+    assert brain._trace_display_subtitle(line) == (
+        f"{n_vertices} vertices, mode: {brain.label_extract_mode}"
+    )
 
     # clicking the same label again removes it
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, point)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -1501,10 +1501,9 @@ class _QtTraceRow(QWidget):
         text.setWordWrap(True)
         text_col.addWidget(text)
 
-        meta = brain._trace_meta.get(line) if brain else None
-        coords = meta[2] if meta is not None else None
-        if coords:
-            coord_label = QLabel(f"MNI: {coords}")
+        subtitle = brain._trace_display_subtitle(line) if brain else None
+        if subtitle:
+            coord_label = QLabel(subtitle)
             coord_label.setStyleSheet(
                 "color: palette(placeholder-text); font-size: 8pt;"
             )

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -1591,7 +1591,8 @@ class _QtTraceList(QWidget):
                 widget.deleteLater()
         if not lines:
             placeholder = QLabel(
-                "Set Annotation to None to see\nvertex and RMS traces here."
+                "Click a label to see its trace here,\n"
+                "or set Annotation to None to see\nvertex and RMS traces."
             )
             placeholder.setStyleSheet(
                 "color: palette(placeholder-text); font-style: italic; font-size: 9pt;"


### PR DESCRIPTION
#### Reference issue (if any)

Phase 7 of https://github.com/mne-tools/mne-python/issues/14042 and following https://github.com/mne-tools/mne-python/pull/14222

#### What does this implement/fix?

Adds possibility to see brain activations in brain `labels` with different possible `modes` (e.g. mean-flip)

#### Additional information

following script is helpful for testing:

```
import numpy as np
import mne
from mne.datasets import sample

data_path = sample.data_path()
subjects_dir = data_path / "subjects"

# without src, only mean/max are valid
src = mne.setup_source_space(
    "sample", spacing="oct6", subjects_dir=subjects_dir, add_dist=False
)
src_vertices = src[0]["vertno"]

brain = mne.viz.Brain(
    "sample", subjects_dir=subjects_dir, hemi="lh", background="black", show=False
)
coords = brain.geo["lh"].coords


def gaussian_patch(coords, center, sigma=15.0):
    d = np.linalg.norm(coords - center, axis=1)
    return np.exp(-(d**2) / (2 * sigma**2))


times = np.linspace(0, 1, 20)
temporal = gaussian_patch(coords, center=np.array([-52.0, -18.0, -8.0]))[src_vertices]
temporal_t = temporal[:, np.newaxis] * np.exp(3 * times)[np.newaxis, :]
brain.add_data(
    temporal_t,
    hemi="lh",
    vertices=src_vertices,
    src=src,
    fmin=0.1,
    fmax=1.0,
    colormap="hot",
    key="temporal",
    smoothing_steps=5,
    time=times,
    transparent=True,
)

frontal = gaussian_patch(coords, center=np.array([-38.0, 28.0, 46.0]))[src_vertices]
frontal_t = frontal[:, np.newaxis] * (1 - np.exp(-3 * times))[np.newaxis, :]
brain.add_data(
    frontal_t,
    hemi="lh",
    vertices=src_vertices,
    src=src,
    fmin=0.1,
    fmax=0.6,
    colormap="Blues",
    alpha=0.5,
    key="frontal",
    remove_existing=False,
    smoothing_steps=5,
    time=times,
    transparent=True,
)
brain.setup_time_viewer(show_traces=True)
brain.show()


```
