### PR TITLE
Fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ _check_skip: &check_skip
       circleci-agent step halt;
     fi
 
+# Runs that download every dataset and build every example, and so are the only
+# ones whose caches are worth writing; see the data save_cache comment below
+_full_build: &full_build
+  matches:
+    pattern: "^(main|maint/.*)$"
+    value: << pipeline.git.branch >>
+
 # gen3 resource classes are only valid with the `current` tag, not a pinned
 # dated tag -- a pinned tag is rejected with "is not a valid resource class"
 _machine_image: &machine_image
@@ -105,12 +112,20 @@ jobs:
           command: ./tools/circleci_bash_env.sh
 
       # Writes testing_version.txt and misc_version.txt, used in the cache keys of
-      # the two datasets whose versions actually change on a regular basis. Caches
-      # are immutable on CircleCI, so a dataset with a fixed key would be pinned to
-      # whatever was first cached and re-downloaded in full on every later run.
+      # the two datasets whose versions actually change on a regular basis, so
+      # that a version bump misses the cache outright rather than restoring the
+      # stale copy and then re-downloading it.
       - run:
           name: Get dataset versions
           command: ./tools/get_testing_version.sh
+
+      # Works out which examples run and therefore which datasets are needed,
+      # writing cache_keys/<cache>.txt = real|noop for the restores below. Has to
+      # come before them: most PRs touch no example at all and so need no dataset,
+      # and restoring every cache unconditionally would pull ~35 G to no purpose.
+      - run:
+          name: Triage examples and datasets
+          command: ./tools/circleci_triage.sh
 
       - run:
           name: Install fonts needed for diagrams
@@ -161,7 +176,7 @@ jobs:
       # Load tiny cache so that ~/.mne does not need to be created below
       - restore_cache:
           keys:
-            - data-cache-tiny-0-{{ checksum "misc_version.txt" }}
+            - data-cache-tiny-v1-{{ checksum "misc_version.txt" }}-{{ checksum "cache_keys/tiny.txt" }}
 
       # Look at what we have and fail early if there is some library conflict
       - run:
@@ -179,72 +194,82 @@ jobs:
           name: List packages
           command: python -m pip list
 
-      # Figure out if we should run a full build or specify a pattern
+      # A cache whose marker says noop hashes to a key nothing ever saved, so
+      # the restore misses and costs nothing
       - restore_cache:
           keys:
-            - data-cache-tiny-1
+            - data-cache-ssvep-v1-{{ checksum "cache_keys/ssvep.txt" }}
       - restore_cache:
           keys:
-            - data-cache-multimodal
+            - data-cache-epilepsy-ecog-v1-{{ checksum "cache_keys/epilepsy-ecog.txt" }}
       - restore_cache:
           keys:
-            - data-cache-limo
+            - data-cache-erp-core-v1-{{ checksum "cache_keys/erp-core.txt" }}
       - restore_cache:
           keys:
-            - data-cache-fsaverage
+            - data-cache-eyelink-v1-{{ checksum "cache_keys/eyelink.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-raw
+            - data-cache-multimodal-v1-{{ checksum "cache_keys/multimodal.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-phantom-ctf
+            - data-cache-limo-v1-{{ checksum "cache_keys/limo.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-phantom-elekta
+            - data-cache-fsaverage-v1-{{ checksum "cache_keys/fsaverage.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-phantom-kernel
+            - data-cache-bst-raw-v1-{{ checksum "cache_keys/bst-raw.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-auditory
+            - data-cache-bst-phantom-ctf-v1-{{ checksum "cache_keys/bst-phantom-ctf.txt" }}
       - restore_cache:
           keys:
-            - data-cache-bst-resting
+            - data-cache-bst-phantom-elekta-v1-{{ checksum "cache_keys/bst-phantom-elekta.txt" }}
       - restore_cache:
           keys:
-            - data-cache-fieldtrip
+            - data-cache-bst-phantom-kernel-v1-{{ checksum "cache_keys/bst-phantom-kernel.txt" }}
       - restore_cache:
           keys:
-            - data-cache-somato
+            - data-cache-bst-auditory-v1-{{ checksum "cache_keys/bst-auditory.txt" }}
       - restore_cache:
           keys:
-            - data-cache-hf-sef
+            - data-cache-bst-resting-v1-{{ checksum "cache_keys/bst-resting.txt" }}
       - restore_cache:
           keys:
-            - data-cache-opm
+            - data-cache-fieldtrip-v1-{{ checksum "cache_keys/fieldtrip.txt" }}
       - restore_cache:
           keys:
-            - data-cache-sample
+            - data-cache-somato-v1-{{ checksum "cache_keys/somato.txt" }}
       - restore_cache:
           keys:
-            - data-cache-spm-face
+            - data-cache-hf-sef-v1-{{ checksum "cache_keys/hf-sef.txt" }}
       - restore_cache:
           keys:
-            - data-cache-testing-{{ checksum "testing_version.txt" }}
+            - data-cache-opm-v1-{{ checksum "cache_keys/opm.txt" }}
       - restore_cache:
           keys:
-            - data-cache-visual-1
+            - data-cache-sample-v1-{{ checksum "cache_keys/sample.txt" }}
       - restore_cache:
           keys:
-            - data-cache-ucl-opm-auditory
+            - data-cache-spm-face-v1-{{ checksum "cache_keys/spm-face.txt" }}
       - restore_cache:
           keys:
-            - data-cache-phantom-kit
+            - data-cache-testing-v1-{{ checksum "testing_version.txt" }}-{{ checksum "cache_keys/testing.txt" }}
       - restore_cache:
           keys:
-            - data-cache-ds004388
+            - data-cache-visual-v1-{{ checksum "cache_keys/visual.txt" }}
+      - restore_cache:
+          keys:
+            - data-cache-ucl-opm-auditory-v1-{{ checksum "cache_keys/ucl-opm-auditory.txt" }}
+      - restore_cache:
+          keys:
+            - data-cache-phantom-kit-v1-{{ checksum "cache_keys/phantom-kit.txt" }}
+      - restore_cache:
+          keys:
+            - data-cache-ds004388-v1-{{ checksum "cache_keys/ds004388.txt" }}
       - run:
-          name: Get data and triage examples to run
+          name: Get the datasets the triage step marked as needed
           # This limit could be increased, but this is helpful for finding slow ones
           # (even ~2GB datasets should be downloadable in this time from good
           # providers)
@@ -262,101 +287,126 @@ jobs:
       # finished downloading, and a failure in the (long, flaky) doc build below
       # should not throw the downloads away. Kept as separate caches, maybe
       # better in terms of size limitations (?)
-      - save_cache:
-          key: data-cache-tiny-0-{{ checksum "misc_version.txt" }}  # < 100 M, might as well combine
-          paths:
-            - ~/.mne
-            - ~/mne_data/MNE-kiloword-data  # (28 M)
-            - ~/mne_data/MNE-eegbci-data  # (35 M)
-            - ~/mne_data/MNE-misc-data  # (39 M)
-            - ~/mne_data/mTRF_1.5  # (56 M)
-            - ~/mne_data/MNE-phantom-4DBTi  # (77 M)
-      - save_cache:
-          key: data-cache-tiny-1  # more to combine
-          paths:
-            - ~/mne_data/MNE-fNIRS-motor-data  # (71 M)
-            - ~/mne_data/MNE-refmeg-noise-data  # (93 M)
-            - ~/mne_data/physionet-sleep-data  # (95 M)
-      - save_cache:
-          key: data-cache-multimodal
-          paths:
-            - ~/mne_data/MNE-multimodal-data  # (240 M)
-      - save_cache:
-          key: data-cache-limo
-          paths:
-            - ~/mne_data/MNE-limo-data  # (244 M)
-      - save_cache:
-          key: data-cache-fsaverage
-          paths:
-            - ~/mne_data/MNE-fsaverage-data  # (762 M)
-      - save_cache:
-          key: data-cache-bst-raw
-          paths:
-            - ~/mne_data/MNE-brainstorm-data/bst_raw  # (830 M)
-      - save_cache:
-          key: data-cache-bst-phantom-ctf
-          paths:
-            - ~/mne_data/MNE-brainstorm-data/bst_phantom_ctf  # (177 M)
-      - save_cache:
-          key: data-cache-bst-phantom-elekta
-          paths:
-            - ~/mne_data/MNE-brainstorm-data/bst_phantom_elekta  # (1.4 G)
-      - save_cache:
-          key: data-cache-bst-phantom-kernel
-          paths:
-            - ~/mne_data/MNE-phantom-kernel-data  # (362 M)
-      - save_cache:
-          key: data-cache-bst-auditory
-          paths:
-            - ~/mne_data/MNE-brainstorm-data/bst_auditory  # (2.9 G)
-      - save_cache:
-          key: data-cache-bst-resting
-          paths:
-            - ~/mne_data/MNE-brainstorm-data/bst_resting  # (4.5 G)
-      - save_cache:
-          key: data-cache-fieldtrip
-          paths:
-            - ~/mne_data/MNE-fieldtrip_cmc-data  # (699 M)
-      - save_cache:
-          key: data-cache-somato
-          paths:
-            - ~/mne_data/MNE-somato-data  # (750 M)
-      - save_cache:
-          key: data-cache-hf-sef
-          paths:
-            - ~/mne_data/HF_SEF  # (1.3 G)
-      - save_cache:
-          key: data-cache-opm
-          paths:
-            - ~/mne_data/MNE-OPM-data  # (1.9 G)
-      - save_cache:
-          key: data-cache-sample
-          paths:
-            - ~/mne_data/MNE-sample-data  # (3.2 G)
-      - save_cache:
-          key: data-cache-spm-face
-          paths:
-            - ~/mne_data/MNE-spm-face  # (1.5 G)
-      - save_cache:
-          key: data-cache-testing-{{ checksum "testing_version.txt" }}
-          paths:
-            - ~/mne_data/MNE-testing-data  # (2.5 G)
-      - save_cache:
-          key: data-cache-visual-1
-          paths:
-            - ~/mne_data/MNE-visual_92_categories-data  # (6 G)
-      - save_cache:
-          key: data-cache-ucl-opm-auditory
-          paths:
-            - ~/mne_data/auditory_OPM_stationary  # (4 G)
-      - save_cache:
-          key: data-cache-phantom-kit
-          paths:
-            - ~/mne_data/MNE-phantom-KIT-data  # (1 G)
-      - save_cache:
-          key: data-cache-ds004388
-          paths:
-            - ~/mne_data/ds004388  # (1.8 G)
+      #
+      # Only saved on main and maint/*, which is exactly the set of runs that
+      # download every dataset: getting this far on those branches means either
+      # the scheduled build or [circle deploy], and both take the full branch of
+      # circleci_triage.sh -- any other push to them halts in the triage step
+      # above. A PR fetches only what its changed examples need, and save_cache
+      # writes an empty 16 B archive for the paths that do not exist. Caches are
+      # immutable and the first write to a key wins, so those empty archives
+      # would pin the key forever and no later build could replace them.
+      - when:
+          condition: *full_build
+          steps:
+            - save_cache:
+                key: data-cache-tiny-v1-{{ checksum "misc_version.txt" }}-{{ checksum "cache_keys/tiny.txt" }}  # the small ones, combined
+                paths:
+                  - ~/.mne
+                  - ~/mne_data/MNE-kiloword-data  # (28 M)
+                  - ~/mne_data/MNE-eegbci-data  # (35 M)
+                  - ~/mne_data/MNE-misc-data  # (39 M)
+                  - ~/mne_data/mTRF_1.5  # (56 M)
+                  - ~/mne_data/MNE-phantom-4DBTi  # (77 M)
+                  - ~/mne_data/MNE-fNIRS-motor-data  # (71 M)
+                  - ~/mne_data/MNE-refmeg-noise-data  # (93 M)
+                  - ~/mne_data/physionet-sleep-data  # (95 M)
+            - save_cache:
+                key: data-cache-ssvep-v1-{{ checksum "cache_keys/ssvep.txt" }}
+                paths:
+                  - ~/mne_data/ssvep-example-data  # (57 M)
+            - save_cache:
+                key: data-cache-epilepsy-ecog-v1-{{ checksum "cache_keys/epilepsy-ecog.txt" }}
+                paths:
+                  - ~/mne_data/MNE-epilepsy-ecog-data  # (101 M)
+            - save_cache:
+                key: data-cache-erp-core-v1-{{ checksum "cache_keys/erp-core.txt" }}
+                paths:
+                  - ~/mne_data/MNE-ERP-CORE-data  # (118 M)
+            - save_cache:
+                key: data-cache-eyelink-v1-{{ checksum "cache_keys/eyelink.txt" }}
+                paths:
+                  - ~/mne_data/MNE-eyelink-data  # (154 M)
+            - save_cache:
+                key: data-cache-multimodal-v1-{{ checksum "cache_keys/multimodal.txt" }}
+                paths:
+                  - ~/mne_data/MNE-multimodal-data  # (240 M)
+            - save_cache:
+                key: data-cache-limo-v1-{{ checksum "cache_keys/limo.txt" }}
+                paths:
+                  - ~/mne_data/MNE-limo-data  # (244 M)
+            - save_cache:
+                key: data-cache-fsaverage-v1-{{ checksum "cache_keys/fsaverage.txt" }}
+                paths:
+                  - ~/mne_data/MNE-fsaverage-data  # (762 M)
+            - save_cache:
+                key: data-cache-bst-raw-v1-{{ checksum "cache_keys/bst-raw.txt" }}
+                paths:
+                  - ~/mne_data/MNE-brainstorm-data/bst_raw  # (830 M)
+            - save_cache:
+                key: data-cache-bst-phantom-ctf-v1-{{ checksum "cache_keys/bst-phantom-ctf.txt" }}
+                paths:
+                  - ~/mne_data/MNE-brainstorm-data/bst_phantom_ctf  # (177 M)
+            - save_cache:
+                key: data-cache-bst-phantom-elekta-v1-{{ checksum "cache_keys/bst-phantom-elekta.txt" }}
+                paths:
+                  - ~/mne_data/MNE-brainstorm-data/bst_phantom_elekta  # (1.4 G)
+            - save_cache:
+                key: data-cache-bst-phantom-kernel-v1-{{ checksum "cache_keys/bst-phantom-kernel.txt" }}
+                paths:
+                  - ~/mne_data/MNE-phantom-kernel-data  # (362 M)
+            - save_cache:
+                key: data-cache-bst-auditory-v1-{{ checksum "cache_keys/bst-auditory.txt" }}
+                paths:
+                  - ~/mne_data/MNE-brainstorm-data/bst_auditory  # (2.9 G)
+            - save_cache:
+                key: data-cache-bst-resting-v1-{{ checksum "cache_keys/bst-resting.txt" }}
+                paths:
+                  - ~/mne_data/MNE-brainstorm-data/bst_resting  # (4.5 G)
+            - save_cache:
+                key: data-cache-fieldtrip-v1-{{ checksum "cache_keys/fieldtrip.txt" }}
+                paths:
+                  - ~/mne_data/MNE-fieldtrip_cmc-data  # (699 M)
+            - save_cache:
+                key: data-cache-somato-v1-{{ checksum "cache_keys/somato.txt" }}
+                paths:
+                  - ~/mne_data/MNE-somato-data  # (750 M)
+            - save_cache:
+                key: data-cache-hf-sef-v1-{{ checksum "cache_keys/hf-sef.txt" }}
+                paths:
+                  - ~/mne_data/HF_SEF  # (1.3 G)
+            - save_cache:
+                key: data-cache-opm-v1-{{ checksum "cache_keys/opm.txt" }}
+                paths:
+                  - ~/mne_data/MNE-OPM-data  # (1.9 G)
+            - save_cache:
+                key: data-cache-sample-v1-{{ checksum "cache_keys/sample.txt" }}
+                paths:
+                  - ~/mne_data/MNE-sample-data  # (3.2 G)
+            - save_cache:
+                key: data-cache-spm-face-v1-{{ checksum "cache_keys/spm-face.txt" }}
+                paths:
+                  - ~/mne_data/MNE-spm-face  # (1.5 G)
+            - save_cache:
+                key: data-cache-testing-v1-{{ checksum "testing_version.txt" }}-{{ checksum "cache_keys/testing.txt" }}
+                paths:
+                  - ~/mne_data/MNE-testing-data  # (2.5 G)
+            - save_cache:
+                key: data-cache-visual-v1-{{ checksum "cache_keys/visual.txt" }}
+                paths:
+                  - ~/mne_data/MNE-visual_92_categories-data  # (6 G)
+            - save_cache:
+                key: data-cache-ucl-opm-auditory-v1-{{ checksum "cache_keys/ucl-opm-auditory.txt" }}
+                paths:
+                  - ~/mne_data/auditory_OPM_stationary  # (4 G)
+            - save_cache:
+                key: data-cache-phantom-kit-v1-{{ checksum "cache_keys/phantom-kit.txt" }}
+                paths:
+                  - ~/mne_data/MNE-phantom-KIT-data  # (1 G)
+            - save_cache:
+                key: data-cache-ds004388-v1-{{ checksum "cache_keys/ds004388.txt" }}
+                paths:
+                  - ~/mne_data/ds004388  # (1.8 G)
 
       # Run doctest (if it's full or front) before building the docs
       - run:
@@ -374,12 +424,17 @@ jobs:
           command: |  # we have -o pipefail in #BASH_ENV so we should be okay
             set -x
             PATTERN=$(cat pattern.txt) make -C doc $(cat build.txt) 2>&1 | tee sphinx_log.txt
-      # Only on success: a failed build compiles an arbitrary subset of the
-      # kernels, and there is no point saving that.
-      - save_cache:
-          key: mne-numba-1-{{ checksum "numba_key.txt" }}-{{ epoch }}
-          paths:
-            - ~/.cache/mne-numba
+      # Only on success, and only on a full build: anything else compiles an
+      # arbitrary subset of the kernels and there is no point saving that. The
+      # restore above stays unconditional -- it is small, and a PR is happy with
+      # whatever the last full build compiled.
+      - when:
+          condition: *full_build
+          steps:
+            - save_cache:
+                key: mne-numba-1-{{ checksum "numba_key.txt" }}-{{ epoch }}
+                paths:
+                  - ~/.cache/mne-numba
       - run:
           name: Check sphinx log for warnings (which are treated as errors)
           when: always

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ uv.lock
 
 # written into the repo root by the CI helper scripts in tools/
 /build.txt
+/cache_keys/
+/datasets.txt
 /gitlog.txt
 /merge.txt
 /misc_version.txt

--- a/tools/circleci_download.sh
+++ b/tools/circleci_download.sh
@@ -1,139 +1,46 @@
 #!/bin/bash -e
 
 set -o pipefail
-export MNE_TQDM=off
-echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
-echo "export MNE_DOC_BUILD_N_JOBS=1" >> $BASH_ENV
 
-if { [[ "$CIRCLE_BRANCH" == "main" ]] || [[ $(cat gitlog.txt) == *"[circle full]"* ]] || [[ "$CIRCLE_BRANCH" == "maint/"* ]] ; } && [[ "$CIRCLE_PROJECT_USERNAME" == "mne-tools" ]]; then
-    echo "Doing a full build";
-    echo html-memory > build.txt;
-    echo "export OPENBLAS_NUM_THREADS=1" >> $BASH_ENV
-    echo "export MNE_DOC_BUILD_N_JOBS=4" >> $BASH_ENV
+# Fetches the datasets circleci_triage.sh listed in datasets.txt, which is only
+# the ones this build's examples actually use; everything else was either
+# restored from a cache or is not needed at all. Most datasets just want their
+# data_path, so only the ones that need something else are spelled out here.
+
+export MNE_TQDM=off
+
+if grep -qxF all datasets.txt; then
     python -c "import mne; mne.datasets._download_all_example_data()";
-else
-    echo "Doing a partial build";
-    FNAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/main) $CIRCLE_BRANCH);
-    if [[ $(cat gitlog.txt) == *"[circle front]"* ]]; then
-        FNAMES="tutorials/inverse/30_mne_dspm_loreta.py tutorials/machine-learning/30_strf.py tutorials/machine-learning/50_decoding.py tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py tutorials/evoked/20_visualize_evoked.py "${FNAMES};
-        python -c "import mne; print(mne.datasets.testing.data_path(update_path=True))";
-    fi;
-    echo FNAMES="$FNAMES";
-    for FNAME in $FNAMES; do
-        if [[ $(echo "$FNAME" | grep -P '^(tutorials|examples)(/.*)?/((?!sgskip).)*\.py$') ]] ; then
-            echo "Checking example $FNAME ...";
-            PATTERN=$(basename $FNAME)"\\|"$PATTERN;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*sample.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.sample.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*fetch_fsaverage.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.fetch_fsaverage(verbose=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*spm_face.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.spm_face.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*somato.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.somato.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*eegbci.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.eegbci.load_data(1, [3, 6, 10, 14], update_path=True))";
-                python -c "import mne; print(mne.datasets.eegbci.load_data(2, [3], update_path=True))";
-                python -c "import mne; print(mne.datasets.eegbci.load_data(3, [3], update_path=True))";
-                python -c "import mne; print(mne.datasets.eegbci.load_data(4, [3], update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*sleep_physionet.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.sleep_physionet.age.fetch_data([0, 1], recording=[1]))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*hf_sef.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.hf_sef.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_auditory.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.brainstorm.bst_auditory.data_path(update_path=True, accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_resting.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.brainstorm.bst_resting.data_path(update_path=True, accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_raw.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.brainstorm.bst_raw.data_path(update_path=True, accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_phantom_ctf.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.brainstorm.bst_phantom_ctf.data_path(update_path=True, accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_phantom_elekta.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.brainstorm.bst_phantom_elekta.data_path(update_path=True, accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*phantom_kernel.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.phantom_kernel.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*hcp_mmp_parcellation.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.sample.data_path(update_path=True))";
-                python -c "import mne; print(mne.datasets.fetch_hcp_mmp_parcellation(subjects_dir=mne.datasets.sample.data_path() / 'subjects', accept=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*misc.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.misc.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*testing.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.testing.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*kiloword.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.kiloword.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*mtrf.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.mtrf.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*fieldtrip_cmc.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.fieldtrip_cmc.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*multimodal.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.multimodal.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*fnirs_motor.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.fnirs_motor.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets[^_]*opm.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.opm.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*phantom_4dbti.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.phantom_4dbti.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*limo.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.limo.data_path(subject=1, update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*refmeg_noise.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.refmeg_noise.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*ssvep.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.ssvep.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*epilepsy_ecog.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.epilepsy_ecog.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*erp_core.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.erp_core.data_path(update_path=True))";
-                python -c "import mne; print(mne.datasets.erp_core.fetch_file('sub-001/eeg/sub-001_task-N170_eeg.fdt'))";
-                python -c "import mne; print(mne.datasets.erp_core.fetch_file('sub-001/eeg/sub-001_task-N170_eeg.set'))";
-                python -c "import mne; print(mne.datasets.erp_core.fetch_file('sub-001/eeg/sub-001_task-N170_events.tsv'))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*eyelink.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.eyelink.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*ucl_opm_auditory.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.ucl_opm_auditory.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*phantom_kit.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.phantom_kit.data_path(update_path=True))";
-            fi;
-            if [[ $(cat $FNAME | grep -x ".*datasets.*visual_92_categories.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.visual_92_categories.data_path(update_path=True))";
-            fi;
-        fi;
-    done;
-    echo PATTERN="$PATTERN";
-    echo html-pattern-memory > build.txt;
-    if [[ $PATTERN ]]; then
-        PATTERN="\(${PATTERN::-2}\)";
-    else
-        PATTERN="run_no_examples_or_tutorials"
-    fi;
-fi;
-echo "$PATTERN" > pattern.txt;
+    exit 0
+fi
+
+while read -r NAME; do
+    echo "Getting $NAME ...";
+    case $NAME in
+        fsaverage)
+            python -c "import mne; print(mne.datasets.fetch_fsaverage())";;
+        hcp_mmp_parcellation)
+            python -c "import mne; print(mne.datasets.fetch_hcp_mmp_parcellation(subjects_dir=mne.datasets.sample.data_path() / 'subjects', accept=True))";;
+        eegbci)
+            python -c "import mne; print([mne.datasets.eegbci.load_data(subject, runs, update_path=True) for subject, runs in [(1, [3, 6, 10, 14]), (2, [3]), (3, [3]), (4, [3])]])";;
+        sleep_physionet)
+            python -c "import mne; print(mne.datasets.sleep_physionet.age.fetch_data([0, 1], recording=[1]))";;
+        bst_*)
+            python -c "import mne; print(mne.datasets.brainstorm.$NAME.data_path(update_path=True, accept=True))";;
+        limo)
+            python -c "import mne; print(mne.datasets.limo.data_path(subject=1, update_path=True))";;
+        erp_core)
+            python -c "import mne; print(mne.datasets.erp_core.data_path(update_path=True))";
+            python -c "import mne; print([mne.datasets.erp_core.fetch_file(f'sub-001/eeg/sub-001_task-N170_{suffix}') for suffix in ['eeg.fdt', 'eeg.set', 'events.tsv']])";;
+        ds004388)
+            python -c "
+import glob, mne, openneuro
+target_dir = mne.datasets.default_path() / 'ds004388'
+if not glob.glob(str(target_dir / 'sub-001/eeg/*median_run-03_eeg*.set')):
+    target_dir.mkdir(exist_ok=True)
+    openneuro.download(dataset='ds004388', target_dir=target_dir, include='sub-001/eeg/*median_run-03_eeg*')
+";;
+        *)
+            python -c "import mne; print(mne.datasets.$NAME.data_path(update_path=True))";;
+    esac
+done < datasets.txt

--- a/tools/circleci_triage.sh
+++ b/tools/circleci_triage.sh
@@ -1,0 +1,106 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+# Works out what this build needs, before anything is restored or downloaded:
+# build.txt and pattern.txt for the doc build, datasets.txt for
+# circleci_download.sh, and cache_keys/<cache>.txt for the cache keys in
+# .circleci/config.yml. A cache marked noop hashes to a key nothing has ever
+# saved, so its restore misses and costs nothing -- which is what most PRs want,
+# since they touch no example and so need no dataset at all.
+
+# dataset | cache holding it | an example needs the dataset if this matches one
+# of its lines in full
+DATASETS="
+sample|sample|.*datasets.*sample.*
+hcp_mmp_parcellation|sample|.*datasets.*hcp_mmp_parcellation.*
+fsaverage|fsaverage|.*datasets.*fetch_fsaverage.*
+spm_face|spm-face|.*datasets.*spm_face.*
+somato|somato|.*datasets.*somato.*
+eegbci|tiny|.*datasets.*eegbci.*
+misc|tiny|.*datasets.*misc.*
+kiloword|tiny|.*datasets.*kiloword.*
+mtrf|tiny|.*datasets.*mtrf.*
+phantom_4dbti|tiny|.*datasets.*phantom_4dbti.*
+sleep_physionet|tiny|.*datasets.*sleep_physionet.*
+fnirs_motor|tiny|.*datasets.*fnirs_motor.*
+refmeg_noise|tiny|.*datasets.*refmeg_noise.*
+hf_sef|hf-sef|.*datasets.*hf_sef.*
+bst_auditory|bst-auditory|.*brainstorm.*bst_auditory.*
+bst_resting|bst-resting|.*brainstorm.*bst_resting.*
+bst_raw|bst-raw|.*brainstorm.*bst_raw.*
+bst_phantom_ctf|bst-phantom-ctf|.*brainstorm.*bst_phantom_ctf.*
+bst_phantom_elekta|bst-phantom-elekta|.*brainstorm.*bst_phantom_elekta.*
+phantom_kernel|bst-phantom-kernel|.*datasets.*phantom_kernel.*
+testing|testing|.*datasets.*testing.*
+fieldtrip_cmc|fieldtrip|.*datasets.*fieldtrip_cmc.*
+multimodal|multimodal|.*datasets.*multimodal.*
+opm|opm|.*datasets[^_]*opm.*
+limo|limo|.*datasets.*limo.*
+ucl_opm_auditory|ucl-opm-auditory|.*datasets.*ucl_opm_auditory.*
+phantom_kit|phantom-kit|.*datasets.*phantom_kit.*
+visual_92_categories|visual|.*datasets.*visual_92_categories.*
+ds004388|ds004388|.*ds004388.*
+ssvep|ssvep|.*datasets.*ssvep.*
+epilepsy_ecog|epilepsy-ecog|.*datasets.*epilepsy_ecog.*
+erp_core|erp-core|.*datasets.*erp_core.*
+eyelink|eyelink|.*datasets.*eyelink.*
+"
+
+want() {
+    grep -qxF "$1" datasets.txt || echo "$1" >> datasets.txt
+}
+
+: > datasets.txt
+echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
+echo "export MNE_DOC_BUILD_N_JOBS=1" >> $BASH_ENV
+
+if { [[ "$CIRCLE_BRANCH" == "main" ]] || [[ $(cat gitlog.txt) == *"[circle full]"* ]] || [[ "$CIRCLE_BRANCH" == "maint/"* ]] ; } && [[ "$CIRCLE_PROJECT_USERNAME" == "mne-tools" ]]; then
+    echo "Doing a full build";
+    echo html-memory > build.txt;
+    echo "export OPENBLAS_NUM_THREADS=1" >> $BASH_ENV
+    echo "export MNE_DOC_BUILD_N_JOBS=4" >> $BASH_ENV
+    # the full build downloads more than DATASETS covers (infant_template, the
+    # phantom and parcellation fetchers, ...), so it is all or nothing
+    want all
+else
+    echo "Doing a partial build";
+    FNAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/main) $CIRCLE_BRANCH);
+    if [[ $(cat gitlog.txt) == *"[circle front]"* ]]; then
+        FNAMES="tutorials/inverse/30_mne_dspm_loreta.py tutorials/machine-learning/30_strf.py tutorials/machine-learning/50_decoding.py tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py tutorials/evoked/20_visualize_evoked.py "${FNAMES};
+        want testing
+    fi;
+    echo FNAMES="$FNAMES";
+    for FNAME in $FNAMES; do
+        if [[ $(echo "$FNAME" | grep -P '^(tutorials|examples)(/.*)?/((?!sgskip).)*\.py$') ]] ; then
+            echo "Checking example $FNAME ...";
+            PATTERN=$(basename $FNAME)"\\|"$PATTERN;
+            while IFS='|' read -r NAME CACHE MATCH; do
+                if [[ -n "$NAME" ]] && grep -qx "$MATCH" $FNAME; then
+                    want $NAME
+                fi
+            done <<< "$DATASETS"
+        fi;
+    done;
+    echo PATTERN="$PATTERN";
+    echo html-pattern-memory > build.txt;
+    if [[ $PATTERN ]]; then
+        PATTERN="\(${PATTERN::-2}\)";
+    else
+        PATTERN="run_no_examples_or_tutorials"
+    fi;
+fi;
+echo "$PATTERN" > pattern.txt;
+
+mkdir -p cache_keys
+for CACHE in $(echo "$DATASETS" | cut -d '|' -f 2 | sort -u); do
+    echo noop > cache_keys/$CACHE.txt
+done
+while IFS='|' read -r NAME CACHE MATCH; do
+    if [[ -n "$NAME" ]] && grep -qxF -e "$NAME" -e all datasets.txt; then
+        echo real > cache_keys/$CACHE.txt
+    fi
+done <<< "$DATASETS"
+
+echo "Datasets wanted: $(tr '\n' ' ' < datasets.txt)"
+grep -H . cache_keys/*.txt


### PR DESCRIPTION
I noticed some of our CircleCI caches were being read as 16B. That's because they came from some run (probably a PR) where the dataset wasn't actually downloaded. This run saved the cache anyway as empty, and caches are immutable, so this empty cache persisted even once a `main` run downloaded the actual data (it couldn't overwrite the existing cache).

This fixes it by making it so that dataset caches are only saved when on a full run, and only restored on PRs for the data that will be used. This requires using a "trick" where we write a file saying "noop" or "real" based on whether or not the cache restoration should be a noop or real (has to be a file because CircleCI can only set cache keys using hashes of files, not env vars). Only the real caches get saved, the `noop`s will be misses (and that's fine).

I'll merge this with `[circle deploy]` and then we can see if it works properly on PRs and other scheduled runs! Changes drafted by Claude Opus 5 but reviewed and iterated a lot by me.