### PR TITLE
Avoid deprecated `prek auto-update` alias for `scheduled_updates` workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,14 +9,14 @@ jobs:
   autobot:
     runs-on: ubuntu-latest
     # Only auto-merge bot PRs that should not need human judgment: dependabot
-    # updates and the weekly `prek auto-update`. Others are left alone, e.g. the
+    # updates and the weekly `prek update`. Others are left alone, e.g. the
     # spec_zero PR, which usually needs `mne/fixes.py` shim adjustments.
     if: >-
       github.repository == 'mne-tools/mne-python' && (
         github.event.pull_request.user.login == 'dependabot[bot]' ||
         (
           github.event.pull_request.user.login == 'mne-bot' &&
-          github.event.pull_request.head.ref == 'prek_auto_update'
+          github.event.pull_request.head.ref == 'prek_update'
         )
       )
     steps:

--- a/.github/workflows/scheduled_updates.yml
+++ b/.github/workflows/scheduled_updates.yml
@@ -3,7 +3,6 @@ name: Scheduled updates
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * 1'  # At 00:00 every Monday
-  pull_request:
   workflow_dispatch:
     inputs:
       ssh:
@@ -105,4 +104,4 @@ jobs:
           fi
           PR_NUM=$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body-file "$RUNNER_TEMP/pr_body.md" "${LABEL_ARGS[@]}")
           echo "Opened https://github.com/mne-tools/mne-python/pull/${PR_NUM}" >> $GITHUB_STEP_SUMMARY
-        if: false
+        if: steps.status.outputs.dirty == 'true' && (success() || failure())

--- a/.github/workflows/scheduled_updates.yml
+++ b/.github/workflows/scheduled_updates.yml
@@ -3,6 +3,7 @@ name: Scheduled updates
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * 1'  # At 00:00 every Monday
+  pull_request:
   workflow_dispatch:
     inputs:
       ssh:
@@ -104,4 +105,4 @@ jobs:
           fi
           PR_NUM=$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body-file "$RUNNER_TEMP/pr_body.md" "${LABEL_ARGS[@]}")
           echo "Opened https://github.com/mne-tools/mne-python/pull/${PR_NUM}" >> $GITHUB_STEP_SUMMARY
-        if: steps.status.outputs.dirty == 'true' && (success() || failure())
+        if: false

--- a/.github/workflows/scheduled_updates.yml
+++ b/.github/workflows/scheduled_updates.yml
@@ -27,10 +27,10 @@ jobs:
             title: 'MAINT: Update dependency specifiers'
             body: '*Adjustments may need to be made to shims in `mne/fixes.py` and elsewhere in this or another PR. `make -C tools/dev dep` is a good starting point for finding potential updates.*'
             label: ''  # this one writes doc/changes/dev/dependency.rst itself
-          - id: prek_auto_update
+          - id: prek_update
             name: Update pre-commit hooks
             title: 'MAINT: Update pre-commit hook versions'
-            body: '*Created by `prek auto-update`. The updated hooks were then run over the whole repo, so any reformatting they now do is included here.*'
+            body: '*Created by `prek update`. The updated hooks were then run over the whole repo, so any reformatting they now do is included here.*'
             label: 'no-changelog-entry-needed'
     env:
       GH_TOKEN: ${{ secrets.MNE_BOT_TOKEN }}
@@ -68,8 +68,8 @@ jobs:
         if: matrix.id == 'spec_zero'
         run: python ./tools/dev/spec_zero_update_versions.py
       - name: Update pre-commit hook versions
-        if: matrix.id == 'prek_auto_update'
-        run: prek auto-update
+        if: matrix.id == 'prek_update'
+        run: prek update
       - name: check if files changed
         run: |
           git diff && git status --porcelain


### PR DESCRIPTION
Recent `scheduled_update` runs are failing (e.g., https://github.com/mne-tools/mne-python/actions/runs/34081832811/job/101618439991) due to `prek auto-update` being removed as an alias for `update` in v0.5: https://prek.j178.dev/0.5.2/changelog/#050

Switches it to use `update` directly.