### PR TITLE
FIX: Warn when bridged interpolation uses bad channels

### DIFF
--- a/doc/changes/dev/14287.bugfix.rst
+++ b/doc/changes/dev/14287.bugfix.rst
@@ -1,0 +1,1 @@
+Warn when :func:`mne.preprocessing.interpolate_bridged_electrodes` ignores bad channels during interpolation, by `Deepesh Sonar`_.

--- a/mne/preprocessing/interpolate.py
+++ b/mne/preprocessing/interpolate.py
@@ -13,7 +13,7 @@ from ..epochs import BaseEpochs, EpochsArray
 from ..evoked import Evoked, EvokedArray
 from ..io import BaseRaw, RawArray
 from ..transforms import _cart_to_sph, _sph_to_cart
-from ..utils import _ensure_int, _validate_type
+from ..utils import _ensure_int, _validate_type, warn
 
 
 def equalize_bads(insts, interp_thresh=1.0, copy=True):
@@ -84,6 +84,9 @@ def interpolate_bridged_electrodes(inst, bridged_idx, bad_limit=4):
     that to aid in interpolation rather than completely discarding the
     data from the two channels.
 
+    Channels listed in ``inst.info["bads"]`` are ignored for exclusion and
+    may influence the interpolation result.
+
     Parameters
     ----------
     inst : instance of Epochs, Evoked, or Raw
@@ -126,6 +129,12 @@ def interpolate_bridged_electrodes(inst, bridged_idx, bad_limit=4):
         )
     # store bads orig to put back at the end
     bads_orig = inst.info["bads"]
+    if bads_orig:
+        warn(
+            f"The channels {', '.join(bads_orig)} are marked as bad but will not "
+            "be excluded from bridged-electrode interpolation and may influence "
+            "the result."
+        )
     inst.info["bads"] = list()
 
     # look for group of bad channels

--- a/mne/preprocessing/tests/test_interpolate.py
+++ b/mne/preprocessing/tests/test_interpolate.py
@@ -83,16 +83,19 @@ def test_interpolate_bridged_electrodes():
         idx0 = inst.ch_names.index("EEG 001")
         idx1 = inst.ch_names.index("EEG 002")
         ch_names_orig = inst.ch_names.copy()
+        inst.info["bads"] = ["EEG 003"]
         bads_orig = inst.info["bads"].copy()
         inst2 = inst.copy()
         inst2.info["bads"] = ["EEG 001", "EEG 002"]
         inst2.interpolate_bads()
         data_interp_reg = inst2.get_data(picks=["EEG 001", "EEG 002"])
-        inst = interpolate_bridged_electrodes(inst, [(idx0, idx1)])
+        with pytest.warns(RuntimeWarning, match="EEG 003.*not.*excluded"):
+            inst = interpolate_bridged_electrodes(inst, [(idx0, idx1)])
         data_interp = inst.get_data(picks=["EEG 001", "EEG 002"])
         assert not any(["virtual" in ch for ch in inst.ch_names])
         assert inst.ch_names == ch_names_orig
         assert inst.info["bads"] == bads_orig
+        inst.info["bads"] = []
         # check closer to regular interpolation than original data
         assert 1e-6 < np.mean(np.abs(data_interp - data_interp_reg)) < 5.4e-5
 


### PR DESCRIPTION
## Summary

`interpolate_bridged_electrodes` temporarily clears `inst.info["bads"]` while building the interpolation. This can allow channels already marked bad to influence the result without notifying the caller.

This patch keeps the existing interpolation behavior and public API unchanged, but emits a warning naming the affected channels and documents the behavior.

## Changes

- Warn when `inst.info["bads"]` is non-empty.
- Document the behavior in the public docstring.
- Extend the existing regression test to check the warning and restoration of the original bad-channel list.
- Add a bugfix changelog fragment.

## Testing

- `.venv/bin/python -m pytest -p no:pytest-qt mne/preprocessing/tests/test_interpolate.py::test_interpolate_bridged_electrodes --verbose` — 1 passed
- `.venv/bin/python -m pytest -p no:pytest-qt mne/preprocessing/tests/test_interpolate.py --verbose` — 11 passed
- `.venv/bin/python -m pytest -p no:pytest-qt mne/tests/test_docstring_parameters.py --verbose` — 17 passed, 2 skipped
- Ruff check and format check passed
- Codespell passed
- `git diff --check` passed

Closes #14263.
