### PR TITLE
Dipole GUI interactivity and visual enhancements (phase 2)

### DIFF
--- a/mne/gui/_dipolefit.py
+++ b/mne/gui/_dipolefit.py
@@ -43,7 +43,7 @@ from ..viz import EvokedField
 from ..viz._3d import _get_3d_option, _plot_head_surface, _plot_sensors_3d
 from ..viz.backends._utils import _qt_app_exec, _qt_safe_window, _splash_message
 from ..viz.ui_events import ChannelsSelect, TimeChange, link, publish, subscribe
-from ..viz.utils import _get_color_list, _is_dark
+from ..viz.utils import _get_color_list
 
 # Message shown in the status bar when the GUI is not busy doing something else.
 _STATUS_IDLE = "Ready"
@@ -893,6 +893,20 @@ class DipoleFitUI:
             r = self._renderer
             hlayout = r._dock_add_layout(vertical=False)
             widgets = []
+            # A small color swatch, so the rows in the dipole list can be matched up
+            # with the traces at a glance.
+            swatch = r._dock_add_label(value="", layout=hlayout)
+            swatch.set_style(
+                {
+                    "background-color": to_hex(dip_color),
+                    "border-radius": "6px",
+                    "min-width": "12px",
+                    "max-width": "12px",
+                    "min-height": "12px",
+                    "max-height": "12px",
+                }
+            )
+            widgets.append(swatch)
             widgets.append(
                 r._dock_add_check_box(
                     name="",
@@ -910,19 +924,6 @@ class DipoleFitUI:
                     layout=hlayout,
                 )
             )
-            # Give the name field the color of the dipole's trace, so the rows in the
-            # dipole list can be matched up with the traces at a glance.
-            widgets[-1].set_style(
-                {
-                    "background-color": to_hex(dip_color),
-                    "color": "white" if _is_dark(dip_color) else "black",
-                }
-            )
-            # Hovering the row emphasizes the traces belonging to this dipole.
-            widgets[-1].set_hover_callbacks(
-                enter=partial(_on_dipole_hover, dip_num=dip_num, hover=True),
-                leave=partial(_on_dipole_hover, dip_num=dip_num, hover=False),
-            )
             widgets.append(
                 r._dock_add_button(
                     name="",
@@ -931,6 +932,13 @@ class DipoleFitUI:
                     layout=hlayout,
                 )
             )
+            # Hovering anywhere in the row emphasizes the traces belonging to this
+            # dipole.
+            for widget in widgets:
+                widget.set_hover_callbacks(
+                    enter=partial(_on_dipole_hover, dip_num=dip_num, hover=True),
+                    leave=partial(_on_dipole_hover, dip_num=dip_num, hover=False),
+                )
             dipole_dict["widgets"] = widgets
             r._layout_add_widget(self._dipole_box, hlayout)
             new_dipoles.append(dipole_dict)
@@ -1089,10 +1097,15 @@ class DipoleFitUI:
         if self._gof_ax is None:
             self._gof_ax = canvas.axes.twinx()
             self._gof_ax.set_ylim(0, 100)
-            self._gof_ax.set_ylabel("GOF (%)", color="gray")
-            self._gof_ax.tick_params(axis="y", colors="gray")
+            # match the tick/label sizing the main axes got from `set_color`
+            self._gof_ax.set_ylabel("GOF (%)", color="gray", fontsize=14)
+            self._gof_ax.tick_params(
+                axis="y", colors="gray", labelsize=13, length=6, width=1.5
+            )
             self._gof_ax.spines["top"].set_visible(False)
             self._gof_ax.spines["right"].set_visible(True)
+            self._gof_ax.spines["right"].set_color("gray")
+            self._gof_ax.spines["right"].set_linewidth(2.0)
             self._gof_ax.spines["bottom"].set_visible(False)
             self._gof_ax.spines["left"].set_visible(False)
             # Twin axes are drawn on top by default. Flip that around (the classic
@@ -1269,7 +1282,7 @@ class DipoleFitUI:
         if dipole["helmet_arrow_actor"] is not None:  # no helmet arrow for EEG
             dipole["helmet_arrow_actor"].visibility = False
         for widget in dipole["widgets"]:
-            widget.hide()
+            widget.remove()
         del self._dipoles[dip_num]
         self._fit_timecourses()
         self._renderer._update()
@@ -1302,8 +1315,8 @@ class DipoleFitUI:
             # `_fit_timecourses`).
             canvas.axes.set_ylabel("Activation (nAm)")
             canvas.axes.set_xlim(self._evoked.times[0], self._evoked.times[-1])
-            canvas.axes.spines["top"].set_visible(False)
-            canvas.axes.spines["right"].set_visible(False)
+            # spines, ticks and grid styled as in the Brain traces plot
+            canvas.set_color(bg_color="white", fg_color="black")
             canvas.axes.axhline(0, linewidth=1, color="gray", zorder=0)
         if self._time_line is None:
             canvas = self._renderer._mplcanvas

--- a/mne/gui/tests/test_dipolefit.py
+++ b/mne/gui/tests/test_dipolefit.py
@@ -208,11 +208,10 @@ def test_dipolefit_gui_basic(
     assert dip1_dict["color"] == _get_color_list()[0]
     assert dip2_dict["color"] == _get_color_list()[1]
 
-    # The name field of each dipole is styled with the color of its trace.
+    # Each dipole's row has a color swatch matching the color of its trace.
     for dip_dict in (dip1_dict, dip2_dict):
-        style = dip_dict["widgets"][1].widget.styleSheet()
+        style = dip_dict["widgets"][0].widget.styleSheet()
         assert to_hex(dip_dict["color"]) in style
-        assert "color:black;" in style  # both colors are light enough for black text
 
     # Timecourses are stored in Am, but displayed in nAm, with the goodness-of-fit of
     # the combined model shown on a twin axis.
@@ -303,7 +302,7 @@ def test_dipolefit_gui_dipole_controls(
         g._set_camera_preset("Sideways")
 
     # Test toggling dipoles off and on. This is done through the GUI widgets, which are
-    # ordered: [active, name, delete].
+    # ordered: [swatch, active, name, delete].
     dip = mne.read_dipole(fname_dip)[[12, 15]]  # 80ms and 90ms
     g.add_dipole(dip, name=["rh", "lh"])
     dip1, dip2 = g._dipoles.values()
@@ -326,45 +325,50 @@ def test_dipolefit_gui_dipole_controls(
     from qtpy.QtWidgets import QApplication
 
     lw, ms = dip1["line_artist"].get_linewidth(), dip1["dot_artist"].get_markersize()
-    # Hover the actual Qt widget (the dipole's name field), so that the enter/leave
-    # event filter is exercised as well.
-    name_widget = dip1["widgets"][1]._widget
-    QApplication.sendEvent(name_widget, QEvent(QEvent.Type.Enter))
-    assert dip1["line_artist"].get_linewidth() > lw
-    assert dip1["dot_artist"].get_markersize() > ms
-    QApplication.sendEvent(name_widget, QEvent(QEvent.Type.Leave))
-    assert dip1["line_artist"].get_linewidth() == lw
-    assert dip1["dot_artist"].get_markersize() == ms
+    # Hover any of the actual Qt widgets in the row (not just the name field), so that
+    # the enter/leave event filter is exercised for the whole row.
+    for widget_idx in (0, 1, 2, 3):  # swatch, active, name, delete
+        widget = dip1["widgets"][widget_idx]._widget
+        QApplication.sendEvent(widget, QEvent(QEvent.Type.Enter))
+        assert dip1["line_artist"].get_linewidth() > lw
+        assert dip1["dot_artist"].get_markersize() > ms
+        QApplication.sendEvent(widget, QEvent(QEvent.Type.Leave))
+        assert dip1["line_artist"].get_linewidth() == lw
+        assert dip1["dot_artist"].get_markersize() == ms
     g._on_dipole_hover(99, True)  # deleted dipole: no-op rather than an error
     old_timecourses = np.vstack((dip1["timecourse"], dip2["timecourse"]))
-    dip2["widgets"][0].set_value(False)
+    dip2["widgets"][1].set_value(False)
     assert not dip2["active"]
     new_timecourses = np.vstack((dip1["timecourse"], dip2["timecourse"]))
     assert not np.allclose(old_timecourses, new_timecourses, atol=1e-9)
 
     # With all dipoles disabled, there is nothing to fit and no arrows to update.
-    dip1["widgets"][0].set_value(False)
+    dip1["widgets"][1].set_value(False)
     assert g.dipoles == []
     g.set_time(0.05)
     assert g._current_time == 0.05
 
-    dip1["widgets"][0].set_value(True)
-    dip2["widgets"][0].set_value(True)
+    dip1["widgets"][1].set_value(True)
+    dip2["widgets"][1].set_value(True)
     assert dip1["active"] and dip2["active"]
     new_timecourses = np.vstack((dip1["timecourse"], dip2["timecourse"]))
     assert np.allclose(old_timecourses, new_timecourses, atol=0)
 
     # Change the names of the dipoles.
-    dip1["widgets"][1].set_value("dipole1")
+    dip1["widgets"][2].set_value("dipole1")
     g._on_dipole_set_name("dipole2", dip2["num"])
     assert dip1["dip"].name == "dipole1"
     assert dip2["dip"].name == "dipole2"
 
     # Remove a dipole (through the "delete" button).
     line, dot = dip1["line_artist"], dip1["dot_artist"]
-    dip1["widgets"][2].set_value(None)
+    dip1_widgets = list(dip1["widgets"])
+    dip1["widgets"][3].set_value(None)
     assert line not in g._renderer._mplcanvas.axes.lines
     assert dot not in g._renderer._mplcanvas.axes.lines
+    # The row's widgets are actually detached, not just hidden, on delete.
+    for widget in dip1_widgets:
+        assert widget._widget.parent() is None
     assert len(g.dipoles) == 1
     assert 1 in g._dipoles  # dipole number should not change
     assert list(g._dipoles.keys())[0] == 1

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -1359,6 +1359,11 @@ class _AbstractWdgt(ABC):
         pass
 
     @abstractmethod
+    def remove(self):
+        """Detach and free this widget; unlike hide(), it is gone for good."""
+        pass
+
+    @abstractmethod
     def set_enabled(self, state):
         pass
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -1501,6 +1501,9 @@ class _IpyWidget(_AbstractWdgt):
     def hide(self):
         self._widget.layout.visibility = "hidden"
 
+    def remove(self):
+        self._widget.close()
+
     def set_enabled(self, state):
         self._widget.disabled = not state
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -1985,6 +1985,10 @@ class _QtWidget(_AbstractWdgt):
     def hide(self):
         self._widget.hide()
 
+    def remove(self):
+        self._widget.setParent(None)
+        self._widget.deleteLater()
+
     def set_enabled(self, state):
         self._widget.setEnabled(state)
 


### PR DESCRIPTION
#### Reference issue (if any)

following the discussion in #14228

#### What does this implement/fix?

- hover anywhere in the row bolds that dipole's trace
- row widgets are now detached instead of hidden with a new `remove()` on the abstract 
- now calls the  _`AbstractMplCanvas.set_color`, as `Brain`, so spines/ticks/... match the `Brain`

Opus 5 wrote the tests and I iterated over it. Happy to hear suggestions for the next phases!
