### PR TITLE
Fix bug with SciPy 1.18.0 EEGLAB reading

### DIFF
--- a/doc/changes/dev/14293.bugfix.rst
+++ b/doc/changes/dev/14293.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reading EEGLAB ``.set`` files containing MATLAB objects (e.g., ``string`` or ``datetime``) with SciPy 1.18+ when pymatreader is not installed, by `Eric Larson`_.

--- a/environment.yml
+++ b/environment.yml
@@ -62,7 +62,7 @@ dependencies:
   - threadpoolctl
   - tqdm >=4.66
   - traitlets
-  - trame
+  - trame <4
   - trame-pyvista
   - trame-vtk
   - trame-vuetify !=3.2.3

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -57,8 +57,10 @@ def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
             data[key] = _check_for_scipy_mat_struct(data[key])
 
     if isinstance(data, MatlabOpaque):
+        # TODO VERSION: scipy < 1.18 has the class name in field 2 (scipy/scipy#23481)
+        idx = 1 if data.dtype.names[0] == "_TypeSystem" else 2
         try:
-            if data[0][2] == b"string":
+            if data[0][idx] in ("string", b"string"):
                 return None
         except IndexError:
             pass

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -4,6 +4,7 @@
 
 import os
 import shutil
+import sys
 from copy import deepcopy
 from unittest.mock import Mock
 
@@ -16,6 +17,7 @@ from numpy.testing import (
     assert_equal,
 )
 from scipy import io
+from scipy.io.matlab import MatlabOpaque
 
 import mne
 from mne import read_epochs_eeglab, write_events
@@ -23,7 +25,7 @@ from mne.annotations import events_from_annotations, read_annotations
 from mne.channels import read_custom_montage
 from mne.datasets import testing
 from mne.io import read_raw_eeglab
-from mne.io.eeglab._eeglab import _readmat
+from mne.io.eeglab._eeglab import _check_for_scipy_mat_struct, _readmat
 from mne.io.eeglab.eeglab import _dol_to_lod, _get_montage_information
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import Bunch, _check_pymatreader_installed, _record_warnings
@@ -45,6 +47,16 @@ epochs_h5_fnames = [epochs_fname_h5, epochs_fname_onefile_h5]
 montage_path = base_dir / "test_chans.locs"
 
 
+@pytest.fixture(params=["pymatreader", "scipy"])
+def mat_reader(request, monkeypatch):
+    """Read .mat files with pymatreader or with the scipy fallback."""
+    if request.param == "scipy":
+        monkeypatch.setitem(sys.modules, "pymatreader", None)
+    elif not _check_pymatreader_installed(strict=False):
+        pytest.skip("pymatreader not installed")
+    return request.param
+
+
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     "fname",
@@ -63,8 +75,10 @@ montage_path = base_dir / "test_chans.locs"
     ],
     ids=os.path.basename,
 )
-def test_io_set_raw(fname):
+def test_io_set_raw(fname, mat_reader):
     """Test importing EEGLAB .set files."""
+    if "_h5" in fname.name and mat_reader == "scipy":
+        pytest.skip("scipy cannot read v7.3 (HDF5) .mat files")
     montage = read_custom_montage(montage_path)
     montage.ch_names = [f"EEG {ii:03d}" for ii in range(len(montage.ch_names))]
 
@@ -367,8 +381,10 @@ def test_io_set_raw_more(tmp_path):
         ),
     ],
 )
-def test_io_set_epochs(fnames):
+def test_io_set_epochs(fnames, mat_reader):
     """Test importing EEGLAB .set epochs files."""
+    if "_h5" in fnames[0].name and mat_reader == "scipy":
+        pytest.skip("scipy cannot read v7.3 (HDF5) .mat files")
     epochs_fname, epochs_fname_onefile = fnames
     with _record_warnings(), pytest.warns(RuntimeWarning, match="multiple events"):
         epochs = read_epochs_eeglab(epochs_fname)
@@ -707,6 +723,22 @@ def test_io_set_raw_2021():
         reader=read_raw_eeglab,
         input_fname=raw_fname_2021,
     )
+
+
+@pytest.mark.parametrize("cls", ("string", "datetime"))
+@pytest.mark.parametrize("scipy_118", (False, True))
+def test_scipy_mcos(cls, scipy_118):
+    """Test MATLAB MCOS objects (e.g., string, datetime) with the scipy reader."""
+    # We don't have any test files with these objects, but users do
+    # (e.g. gh-14292), so let's construct a synthetic case to catch it
+    meta = np.array((1, 2), dtype=[("a", "O"), ("b", "O")])
+    if scipy_118:  # scipy/scipy#23481
+        row = dict(_TypeSystem="MCOS", _Class=cls, _ObjectMetadata=meta)
+    else:
+        row = dict(s0="x", s1=b"MCOS", s2=cls.encode(), arr=meta)
+    data = MatlabOpaque(np.array([tuple(row.values())], [(k, "O") for k in row]))
+    out = _check_for_scipy_mat_struct(dict(x=data))["x"]
+    assert (out is None) == (cls == "string")
 
 
 @testing.requires_testing_data

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -78,7 +78,9 @@ def mat_reader(request, monkeypatch):
 def test_io_set_raw(fname, mat_reader):
     """Test importing EEGLAB .set files."""
     if "_h5" in fname.name and mat_reader == "scipy":
-        pytest.skip("scipy cannot read v7.3 (HDF5) .mat files")
+        with pytest.raises(NotImplementedError, match="HDF reader"):
+            read_raw_eeglab(fname)
+        return
     montage = read_custom_montage(montage_path)
     montage.ch_names = [f"EEG {ii:03d}" for ii in range(len(montage.ch_names))]
 
@@ -384,7 +386,9 @@ def test_io_set_raw_more(tmp_path):
 def test_io_set_epochs(fnames, mat_reader):
     """Test importing EEGLAB .set epochs files."""
     if "_h5" in fnames[0].name and mat_reader == "scipy":
-        pytest.skip("scipy cannot read v7.3 (HDF5) .mat files")
+        with pytest.raises(NotImplementedError, match="HDF reader"):
+            read_epochs_eeglab(fnames[0])
+        return
     epochs_fname, epochs_fname_onefile = fnames
     with _record_warnings(), pytest.warns(RuntimeWarning, match="multiple events"):
         epochs = read_epochs_eeglab(epochs_fname)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ full-no-qt = [
   "statsmodels >= 0.6",
   "threadpoolctl",
   "traitlets",
-  "trame",
+  "trame < 4",  # trame-vtk and trame-pyvista do not support trame 4 yet
   "trame-pyvista",
   "trame-vtk",
   "trame-vuetify != 3.2.3",

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -56,9 +56,8 @@ python -c "import vtk"
 echo "::endgroup::"
 
 echo "::group::Everything else"
-# TODO: Pin pyvista until regression fixed 2026/09/09
 uv pip install $STD_ARGS \
-	"pyvista @ https://github.com/pyvista/pyvista/archive/b2d3a65bffc881a85673b911b02d90f1047bc7cf.zip" \
+	"pyvista @ https://github.com/pyvista/pyvista/archive/refs/heads/main.zip" \
 	"pyvistaqt @ https://github.com/pyvista/pyvistaqt/archive/refs/heads/main.zip" \
 	"nilearn @ https://github.com/nilearn/nilearn/archive/refs/heads/main.zip" \
 	"edfio @ https://github.com/the-siesta-group/edfio/archive/refs/heads/main.zip" \

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -71,7 +71,7 @@ uv pip install $STD_ARGS \
 	"joblib @ https://github.com/joblib/joblib/archive/refs/heads/main.zip" \
 	"h5io @ https://github.com/h5io/h5io/archive/refs/heads/main.zip" \
 	"snirf @ https://github.com/BUNPC/pysnirf2/archive/refs/heads/main.zip" \
-	trame trame-vtk "trame-vuetify!=3.2.3" trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
+	"trame<4" trame-vtk "trame-vuetify!=3.2.3" trame-pyvista nest-asyncio2 jupyter ipyevents ipympl \
 	openmeeg imageio-ffmpeg xlrd mffpy traitlets pybv eeglabio defusedxml antio curryreader \
 	jamica filelock
 echo "::endgroup::"


### PR DESCRIPTION
Closes #14292. Drafted with Claude Opus 5 and reviewed / iterated by me. Use a little fixture to cause files to be read by pymatreader and scipy in some tests, then use it to check the bug.

This one is pretty straightforward so self-marking for merge-when-green and marking for backport.