### PR TITLE
Fix for NumPy eig change

### DIFF
--- a/doc/changes/dev/14300.bugfix.rst
+++ b/doc/changes/dev/14300.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.beamformer.make_lcmv` would create complex rather than real filters when using NumPy 2.5, by `Eric Larson`_.

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -339,7 +339,9 @@ def _compute_beamformer(
         # sort eigenvectors by eigenvalues for picking:
         order = np.argsort(np.abs(eig_vals), axis=-1)
         # eig_vals = np.take_along_axis(eig_vals, order, axis=-1)
-        max_power_ori = eig_vecs[np.arange(len(eig_vecs)), :, order[:, -1]]
+        # eigenvalues are real (product of PSD matrices) but NumPy >= 2.5 always
+        # returns complex eigenvectors, so take the real part
+        max_power_ori = eig_vecs[np.arange(len(eig_vecs)), :, order[:, -1]].real
         assert max_power_ori.shape == (n_sources, n_orient)
 
         # set the (otherwise arbitrary) sign to match the normal

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -1028,6 +1028,7 @@ def test_orientation_max_power(
     loc = apply_lcmv(evoked, filters).data
     ori = filters["max_power_ori"]
     assert ori.shape == (246, 3)
+    assert loc.dtype == ori.dtype == np.float64
     loc = np.abs(loc)
     # Compute the percentage of sources for which there is no loc bias:
     max_idx = np.argmax(loc, axis=0)

--- a/tutorials/inverse/50_beamformer_lcmv.py
+++ b/tutorials/inverse/50_beamformer_lcmv.py
@@ -28,11 +28,10 @@ from mne.datasets import fetch_fsaverage, sample
 # points independently. A set of weights is constructed for each defined source location
 # which defines the contribution of each sensor to this source.
 #
-# Beamformers are often used for their focal reconstructions and their ability
-# to reconstruct deeper sources. They can also suppress external noise sources.
-# The beamforming method applied in this tutorial is the linearly constrained
-# minimum variance (LCMV) beamformer :footcite:`VanVeenEtAl1997` operates on
-# time series.
+# Beamformers are often used for their focal reconstructions and their ability to
+# reconstruct deeper sources. They can also suppress external noise sources. The
+# beamforming method applied in this tutorial is the linearly constrained minimum
+# variance (LCMV) beamformer :footcite:`VanVeenEtAl1997` operates on time series.
 #
 # Frequency-resolved data can be reconstructed with the dynamic imaging of
 # coherent sources (DICS) beamforming method :footcite:`GrossEtAl2001`.

--- a/tutorials/stats-sensor-space/10_background_stats.py
+++ b/tutorials/stats-sensor-space/10_background_stats.py
@@ -245,7 +245,7 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # Here we have to do a bit of gymnastics to get our function to do
 # a permutation test without correcting for multiple comparisons:
 
-X.shape = (n_subjects, n_src)  # flatten the array for simplicity
+X = X.reshape(n_subjects, n_src)  # flatten the array for simplicity
 titles.append("Permutation")
 ts.append(np.zeros(width * width))
 ps.append(np.zeros(width * width))
@@ -497,7 +497,7 @@ for adj_name, adj_description in builtin_ch_adj:
 titles.append("Clustering")
 
 # Reshape data to what is equivalent to (n_samples, n_space, n_time)
-X.shape = (n_subjects, width, width)
+X = X.reshape(n_subjects, width, width)
 
 # Compute threshold from t distribution (this is also the default)
 # Here we use a two-tailed test, hence we need to divide alpha by 2.


### PR DESCRIPTION
`np.eig` always returns complex values now, even for real positive semidefinite matrices. Fix our behavior accordingly. This one is trivial and fixes a real CircleCI error in main so I'll self-mark for merge-when-green