### PR TITLE
FIX: don't mutate cached ICA sources in plot_sources properties

### DIFF
--- a/doc/changes/dev/14303.bugfix.rst
+++ b/doc/changes/dev/14303.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where right-clicking a second component in :meth:`mne.preprocessing.ICA.plot_sources` raised an ``IndexError``, by `Johannes Herforth`_.

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -596,7 +596,7 @@ def _fast_plot_ica_properties(
             inst, ica, reject_by_annotation, reject
         )
     del reject, inst
-    epochs_src_picked = epochs_src.pick(picks)
+    epochs_src_picked = epochs_src.copy().pick(picks)
     del epochs_src
     good_indices = np.setdiff1d(np.arange(len(epochs_src_picked)), bad_indices)
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -405,6 +405,11 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     # close child fig directly (workaround for mpl issue #18609)
     fig._fake_keypress("escape", fig=fig.mne.child_figs[0])
     assert browser_backend._get_n_figs() == 1
+    # a second click must work too
+    fig._click_ch_name(ch_index=1, button=3)
+    assert browser_backend._get_n_figs() == 2
+    fig._fake_keypress("escape", fig=fig.mne.child_figs[-1])
+    assert browser_backend._get_n_figs() == 1
     fig._fake_keypress(fig.mne.close_key)
     assert browser_backend._get_n_figs() == 0
     del long_raw


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
and the [detailed contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

If you used AI to help prepare this pull request, please pay special attention to
our **Policy on AI Assistance in Contributions** in
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md).
Here are some examples of what we expect for "tool, manner, and scope" disclosure:

- "I implemented the code changes myself, and Claude Sonnet 4.6 wrote the test."
- "I prompted Gemini 3.1 Pro to get a first draft implementation, then refined it
  manually until I was satisfied."
- "I wrote the code and asked Kimi K2.5 to write the docstring for me."
- "I fed GPT 5.4 the paper where the algorithm is described, and asked it to implement
  it for me. Then I had it write an example script using the `sample` dataset, and I
  wrote the narrative text of the tutorial myself."

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->


#### What does this implement/fix?

Found a bug when right clicking the IC number on the left side (opening the ica_properties) when in `plot_sources`. There seems to have been a regression from the previous versions where on the first right click it works fine, but on the second it crashes with an index error:

```
IndexError: All picks must be < n_channels (1), got array([42]
```

It turns out that using the picks command was mutating the browser cached data in place and therefore only worked the first time. Regression test was also added. The fix was just adding a copy before doing the picks.

Let me know if you have any other questions.
